### PR TITLE
Add langtag getter to Literal

### DIFF
--- a/prov/model/__init__.py
+++ b/prov/model/__init__.py
@@ -240,6 +240,9 @@ class Literal(object):
     def get_datatype(self):
         return self._datatype
     
+    def get_langtag(self):
+        return self._langtag
+    
     def provn_representation(self):
         if self._langtag:
             # a langtag can only goes with string


### PR DESCRIPTION
There is an attribute self._langtag but no getter for it, contrary to self._datatype and self._value.
