### PR TITLE
Add add_bundle() support to persistence

### DIFF
--- a/prov/persistence/models.py
+++ b/prov/persistence/models.py
@@ -79,7 +79,14 @@ class PDBundle(PDRecord):
         return namespace
         
     def add_bundle(self, bundle):
-        pdbundle = PDBundle.create(bundle.get_identifier())
+        uri = bundle.get_identifier().get_uri()
+        
+        prov_record = self.get_prov_bundle()
+        
+        if uri in prov_record._bundles:
+            raise prov.ProvException(u"Non unique bundle identifier")
+        
+        pdbundle = PDBundle.create(uri)
         pdbundle.bundle = self
         pdbundle.save_bundle(bundle)
         pdbundle.save()


### PR DESCRIPTION
This inserts the bundle with a full URI identifier and only does this if that identifier is unique to the parent bundle.
