### PR TITLE
fix #12

### DIFF
--- a/prov/model/__init__.py
+++ b/prov/model/__init__.py
@@ -665,8 +665,8 @@ class ProvRecord(object):
             if my_attrs:
                 #  my attributes set is not empty.
                 return False
-        sattr = sorted(self._extra_attributes, key=lambda attr: str(attr[0]) + str(attr[1])) if self._extra_attributes else None
-        oattr = sorted(other._extra_attributes, key=lambda attr: str(attr[0]) + str(attr[1])) if other._extra_attributes else None
+        sattr = sorted(self._extra_attributes, key=lambda attr: unicode(attr[0]) + unicode(attr[1])) if self._extra_attributes else None
+        oattr = sorted(other._extra_attributes, key=lambda attr: unicode(attr[0]) + unicode(attr[1])) if other._extra_attributes else None
         if sattr != oattr:
             return False
         return True


### PR DESCRIPTION
fixed the unicode issue. 
However the tests are still failing for another reason :
If I apply this fix on the commit 3aaf672086aa20e44cb810acb5cc071baa989c2b ( Jul 01), the tests become fixed.

The new issue occurs now in prov/model/**init**.py in add_extra_attributes at self._extra_attributes.update(attr_list)
the attr_list seems not to be hashable or contains elements that are not hashable.

May be you can provide some hint on that issue

edit:
the first commit with the test failing is 8801c106955a1a4f6c3f50b058a138ee4a836000 . may be because it is the first time there is a round-trip test.
