### PR TITLE
fix: use multiline only when input is a string

### DIFF
--- a/prov/model/__init__.py
+++ b/prov/model/__init__.py
@@ -241,7 +241,9 @@ def parse_xsd_types(value, datatype):
 
 
 def _ensure_multiline_string_triple_quoted(s):
-    format_str = u'"""%s"""' if '\n' in s else u'"%s"'
+    format_str = '%s'
+    if isinstance(s, basestring):
+        format_str = u'"""%s"""' if '\n' in s else u'"%s"'
     return format_str % s
 
 


### PR DESCRIPTION
this function gets called at a point where the input could be something other than a string.
