### PR TITLE
keep the timezone when parsing datetime from JSON

### DIFF
--- a/prov/model/__init__.py
+++ b/prov/model/__init__.py
@@ -14,6 +14,7 @@ import logging
 import datetime
 import json
 import re
+import dateutil.parser
 import collections
 from collections import defaultdict
 from copy import deepcopy, copy
@@ -169,30 +170,9 @@ _normalise_attributes = lambda attr: (unicode(attr[0]), unicode(attr[1]))
 
 
 #  Datatypes
-_r_xsd_dateTime = re.compile(""" ^
-    (?P<year>-?[0-9]{4}) - (?P<month>[0-9]{2}) - (?P<day>[0-9]{2})
-    T (?P<hour>[0-9]{2}) : (?P<minute>[0-9]{2}) : (?P<second>[0-9]{2})
-    (?P<microsecond>\.[0-9]{1,6})?
-    (?P<tz>
-      Z | (?P<tz_hr>[-+][0-9]{2}) : (?P<tz_min>[0-9]{2})
-    )?
-    $ """, re.X)
-
 
 def _parse_xsd_dateTime(s):
-    """Returns datetime or None."""
-    m = _r_xsd_dateTime.match(s)
-    if m is not None:
-        values = m.groupdict()
-        if values["microsecond"] is None:
-            values["microsecond"] = 0
-        else:
-            values["microsecond"] = values["microsecond"][1:]
-            values["microsecond"] += "0" * (6 - len(values["microsecond"]))
-        values = dict((k, int(v)) for k, v in values.iteritems() if not k.startswith("tz"))
-        return datetime.datetime(**values)
-    else:
-        return None
+    return dateutil.parser.parse(s)
 
 
 def _ensure_datetime(time):

--- a/prov/model/test/testModel.py
+++ b/prov/model/test/testModel.py
@@ -158,6 +158,27 @@ class TestFlattening(unittest.TestCase):
         self.assertIsNotNone(a1.get_endTime(), "a1 was not merged correctly, expecting startTime set.")
         self.assertEqual(len(a1.get_attribute('prov:label')), 1, "a1 was not merged correctly, expecting one prov:label attribute")
 
+    def test_datetime_with_tz(self):
+        """ test that timezone is taken in to account while parsing json"""
+        test_json = """
+        {
+            "activity": {
+                "a1": [
+                    {"prov:label": "An activity with timezone"},
+                    {"prov:startTime": "2011-11-16T16:05:00.123456+03:00"},
+                    {"prov:endTime": "2011-11-16T16:06:00.654321"}
+                ]
+            }
+        }"""
+        g = ProvBundle.from_provjson(test_json)
+        a1 = g.get_record("a1")
+        self.assertEqual(a1.get_startTime().isoformat(),
+                         "2011-11-16T16:05:00.123456+03:00",
+                         "timezone is not set correctly")
+        self.assertEqual(a1.get_endTime().isoformat(),
+                         "2011-11-16T16:06:00.654321",
+                         "timezone is not set correctly")
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'persistence': ['Django'],
         'py26-support': ['ordereddict'],
     },
+    install_requires=['python-dateutil'], 
     provides=['prov'],
     keywords=['provenance', 'graph', 'model', 'persistence', 'tracking', 'PROV', 'PROV-DM', 'PROV-JSON', 'JSON', 'Django'],
     classifiers=[
@@ -38,5 +39,5 @@ setup(
           'Topic :: Scientific/Engineering :: Information Analysis',
           'Topic :: Security',
           'Topic :: System :: Logging',
-          ],
+          ]
 )


### PR DESCRIPTION
I noticed that timezone are removed while parsing JSON and therefore are not stored in the Django database.
