### PR TITLE
Enh/rdf

### DIFF
--- a/prov/model/__init__.py
+++ b/prov/model/__init__.py
@@ -411,7 +411,7 @@ class Namespace(object):
             self._cache[localpart] = qname
             return qname
 
-XSD = Namespace("xsd", 'http://www.w3.org/2001/XMLSchema-datatypes#')
+XSD = Namespace("xsd", 'http://www.w3.org/2001/XMLSchema#')
 PROV = Namespace("prov", 'http://www.w3.org/ns/prov#')
 
 


### PR DESCRIPTION
@trungdong: this adds support for PROV-O type atLocation behavior when the value for `prov:location` is a `URIRef` or `QName`.

@nicholsn - take a look at this PR
