### PR TITLE
Write out boolean type in PROV-N

### DIFF
--- a/prov/model.py
+++ b/prov/model.py
@@ -101,9 +101,9 @@ def encoding_provn_value(value):
     elif isinstance(value, datetime.datetime):
         return value.isoformat()
     elif isinstance(value, float):
-        return u'"%f" %%%% xsd:float' % value
+        return u'"%g" %%%% xsd:float' % value
     elif isinstance(value, bool):
-        return u'"%s" %%%% xsd:boolean' % value
+        return u'"%i" %%%% xsd:boolean' % value        
     else:
         # TODO: QName export
         return unicode(value)


### PR DESCRIPTION
Hello,

This is a proposal to explicitly include a `%%xsd:boolean` typing whenever a boolean value is written as part of a PROV-N serialisation.

This example script:

<pre>
from prov.model import ProvBundle, Namespace, ProvDocument

ex = Namespace('ex', 'http://example.org/')
provDocument = ProvDocument()
provDocument.add_namespace(ex)
provDocument.entity('ex:e1', (('ex:bool', True)))
print provDocument.get_provn(4)
</pre>


Would then return:

<pre>
document
          prefix ex <http://example.org/>
          
          entity(ex:e1, [ex:bool="True" %% xsd:boolean])
endDocument
</pre>


instead of (current version):

<pre>
document
          prefix ex <http://example.org/>
          
          entity(ex:e1, [ex:bool=True])
 endDocument
</pre>


The current PROV-N serialisation does not seem correct (as from [PROV-N literal](http://www.w3.org/TR/2013/REC-prov-n-20130430/#prod-literal), a value without type is a string, an integer or a qualified name). Or, am I missing something? I would be glad to get your input.
