### PR TITLE
Convenience plot

### DIFF
--- a/prov/model.py
+++ b/prov/model.py
@@ -84,7 +84,7 @@ def encoding_provn_value(value):
     elif isinstance(value, float):
         return u'"%g" %%%% xsd:float' % value
     elif isinstance(value, bool):
-        return u'"%i" %%%% xsd:boolean' % value        
+        return u'"%i" %%%% xsd:boolean' % value
     else:
         # TODO: QName export
         return unicode(value)
@@ -1067,14 +1067,12 @@ class ProvBundle(object):
     def plot(self, filename=None, show_nary=True, use_labels=False,
              show_element_attributes=True, show_relation_attributes=True):
         """
-        Convenienve function to plot a prov document.
+        Convenience function to plot a prov document.
 
         :type filename: string, optional
         :param filename: The filename to save to. If not given, it will open
             an interactive matplotlib plot. The filetype is determined from
             the filename ending.
-        :param bundle: The provenance bundle/document to be converted.
-        :type name: :class:`ProvBundle`
         :param show_nary: shows all elements in n-ary relations.
         :type show_nary: bool
         :param use_labels: uses the prov:label property of an element as its name (instead of its identifier).


### PR DESCRIPTION
One can just do a `ProvDocument.plot()` call and it will plot is using the `prov.dot` submodule.

Most arguments are just passed to the `prov.dot.prov_to_dot()` function.

The `filename` parameter specifies where to write the file to. The fileformat will be determined from the filename and passed to pydot. This therefore automatically supports all output formats pydot supports.

If `filename` is not given, a preview will be shown by outputting a `png` image in memory and displaying it with matplotlib. I chose matplotlib and not the `show()` function from PIL as matplotlib plays nice with the notebook enabling things like this:

http://nbviewer.ipython.org/gist/krischer/39489ed6e487688c94e9

All imports are lazy to not affect the dependencies of the rest of the project.
