### PR TITLE
Convenience read() method with a lazy format detection.

### DIFF
--- a/prov/__init__.py
+++ b/prov/__init__.py
@@ -23,3 +23,37 @@ class Serializer(object):
         """
         Abstract method for deserializing
         """
+
+
+def read(source, format=None):
+    """
+    Convenience function returning a ProvDocument instance.
+
+    It does a lazy format detection by simply using try/except for all known
+    formats. The deserializers should fail fairly early when data of the
+    wrong type is passed to them thus the try/except is likely cheap. One
+    could of course also do some more advanced format autodetection but I am
+    not sure that is necessary.
+
+    The downside is that no proper error messages will be produced, use the
+    format parameter to get the actual traceback.
+    """
+    # Lazy imports to not globber the namespace.
+    from prov.model import ProvDocument
+
+    from prov.serializers import Registry
+    Registry.load_serializers()
+    serializers = Registry.serializers.keys()
+
+    if format:
+        return ProvDocument.deserialize(source=source, format=format.lower())
+
+    for format in serializers:
+        try:
+            return ProvDocument.deserialize(source=source, format=format)
+        except:
+            pass
+    else:
+        raise TypeError("Could not read from the source. To get a proper "
+                        "error message, specify the format with the 'format' "
+                        "parameter.")


### PR DESCRIPTION
This PR adds a convenience deserialization method to prov with a lazy format autodetection. It enables the following:

``` python
import prov

doc = prov.read("provenance.json")
```

The format autodetection is performed by looping through all known deserializers and trying if they work. This is fairly fast assuming the deserializers fail fast and early which they should. It would of course be possible to perform a more advanced format detection but I frankly don't think its worth the effort or necessary.

A disadvantage of the current approach is that is hides errors. It is also possible to pass the format to the function in which case the format detection is skipped and proper errors will be raised.

One should also add tests once the PROV XML support has been merged. Right now there only is one format.
