### PR TITLE
PROV-XML default namespace per Element

### DIFF
--- a/prov/serializers/provxml.py
+++ b/prov/serializers/provxml.py
@@ -223,7 +223,14 @@ class ProvXMLSerializer(prov.serializers.Serializer):
             elif key == "xsd":
                 value = value.rstrip("#") + "#"
             elif key is None:
-                bundle.set_default_namespace(value)
+                if bundle.get_default_namespace() is None:
+                    bundle.set_default_namespace(value)
+                    continue
+                if bundle.get_default_namespace().uri != value:
+                    raise ValueError(
+                        "The XML document changes the default namespace at "
+                        "some point. This cannot be reflected by the PROV "
+                        "data model.")
             else:
                 bundle.add_namespace(key, value)
 

--- a/prov/serializers/provxml.py
+++ b/prov/serializers/provxml.py
@@ -265,6 +265,7 @@ class ProvXMLSerializer(prov.serializers.Serializer):
         r_nsmap = dict((value, key) for (key, value) in xml_doc.nsmap.items())
 
         for element in xml_doc:
+            self._add_xml_namespaces_to_bundle(element, bundle)
             qname = etree.QName(element)
             if qname.namespace != DEFAULT_NAMESPACES["prov"].uri:
                 raise ProvXMLException("Non PROV element discovered in "

--- a/prov/tests/test_xml.py
+++ b/prov/tests/test_xml.py
@@ -301,6 +301,21 @@ class ProvXMLTestCase(unittest.TestCase):
         # This document contains nothing else.
         self.assertEqual(len(doc._records), 0)
 
+    def test_nested_default_namespace(self):
+        """
+        Tests that a default namespace that is defined in a lower level tag is
+        written to a bundle.
+        """
+        filename = os.path.join(DATA_PATH, "nested_default_namespace.xml")
+        doc = prov.ProvDocument.deserialize(source=filename, format="xml")
+
+        ns = Namespace("", "http://example.org/0/")
+
+        self.assertEqual(len(doc._records), 1)
+        self.assertEqual(doc.get_default_namespace(), ns)
+        self.assertEqual(doc._records[0].identifier.namespace, ns)
+        self.assertEqual(doc._records[0].identifier.localpart, "e001")
+
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
     def _perform_round_trip(self, filename, force_types=False):
@@ -320,6 +335,11 @@ for filename in glob.iglob(os.path.join(
         DATA_PATH, "*" + os.path.extsep + "xml")):
     name = os.path.splitext(os.path.basename(filename))[0]
     test_name = "test_roundtrip_from_xml_%s" % name
+
+    # Cannot round trip this one as the namespace in the PROV data model are
+    # always defined per bundle and not per element.
+    if name == "nested_default_namespace":
+        continue
 
     # Python creates closures on function calls...
     def get_fct(f):

--- a/prov/tests/test_xml.py
+++ b/prov/tests/test_xml.py
@@ -326,6 +326,22 @@ class ProvXMLTestCase(unittest.TestCase):
             ValueError, prov.ProvDocument.deserialize,
             source=filename, format="xml")
 
+    def test_redefining_namespaces(self):
+        """
+        Test the behaviour when namespaces are redefined at the element level.
+        """
+        filename = os.path.join(DATA_PATH,
+                                "namespace_redefined_but_does_not_change.xml")
+        # Should not raise.
+        prov.ProvDocument.deserialize(source=filename, format="xml")
+
+        filename = os.path.join(DATA_PATH, "namespace_redefined.xml")
+        # Should raise.
+        self.assertRaises(
+            ValueError, prov.ProvDocument.deserialize,
+            source=filename, format="xml")
+
+
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
     def _perform_round_trip(self, filename, force_types=False):
@@ -349,7 +365,9 @@ for filename in glob.iglob(os.path.join(
     # Cannot round trip this one as the namespace in the PROV data model are
     # always defined per bundle and not per element.
     if name in ("nested_default_namespace",
-                "nested_changing_default_namespace"):
+                "nested_changing_default_namespace",
+                "namespace_redefined_but_does_not_change",
+                "namespace_redefined"):
         continue
 
     # Python creates closures on function calls...

--- a/prov/tests/test_xml.py
+++ b/prov/tests/test_xml.py
@@ -316,6 +316,16 @@ class ProvXMLTestCase(unittest.TestCase):
         self.assertEqual(doc._records[0].identifier.namespace, ns)
         self.assertEqual(doc._records[0].identifier.localpart, "e001")
 
+    def test_changing_default_namespace(self):
+        """
+        If the default namespace changes, an error will be raised.
+        """
+        filename = os.path.join(DATA_PATH,
+                                "nested_changing_default_namespace.xml")
+        self.assertRaises(
+            ValueError, prov.ProvDocument.deserialize,
+            source=filename, format="xml")
+
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
     def _perform_round_trip(self, filename, force_types=False):
@@ -338,7 +348,8 @@ for filename in glob.iglob(os.path.join(
 
     # Cannot round trip this one as the namespace in the PROV data model are
     # always defined per bundle and not per element.
-    if name == "nested_default_namespace":
+    if name in ("nested_default_namespace",
+                "nested_changing_default_namespace"):
         continue
 
     # Python creates closures on function calls...

--- a/prov/tests/xml/namespace_redefined.xml
+++ b/prov/tests/xml/namespace_redefined.xml
@@ -7,7 +7,6 @@
 
   <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/new_ex#">
     <prov:type xsi:type="xsd:QName">ex:Workflow</prov:type>
-    <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
   </prov:entity>
 
 </prov:document>

--- a/prov/tests/xml/namespace_redefined.xml
+++ b/prov/tests/xml/namespace_redefined.xml
@@ -1,0 +1,13 @@
+<prov:document
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:ex="http://example.com/ns/ex#"
+    xmlns:tr="http://example.com/ns/tr#">
+
+  <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/new_ex#">
+    <prov:type xsi:type="xsd:QName">ex:Workflow</prov:type>
+    <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+  </prov:entity>
+
+</prov:document>

--- a/prov/tests/xml/namespace_redefined_but_does_not_change.xml
+++ b/prov/tests/xml/namespace_redefined_but_does_not_change.xml
@@ -5,7 +5,7 @@
     xmlns:ex="http://example.com/ns/ex#"
     xmlns:tr="http://example.com/ns/tr#">
 
-    <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/ex#">
+  <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/ex#">
     <prov:type xsi:type="xsd:QName">ex:Workflow</prov:type>
     <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
   </prov:entity>

--- a/prov/tests/xml/namespace_redefined_but_does_not_change.xml
+++ b/prov/tests/xml/namespace_redefined_but_does_not_change.xml
@@ -1,0 +1,13 @@
+<prov:document
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:ex="http://example.com/ns/ex#"
+    xmlns:tr="http://example.com/ns/tr#">
+
+    <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/ex#">
+    <prov:type xsi:type="xsd:QName">ex:Workflow</prov:type>
+    <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+  </prov:entity>
+
+</prov:document>

--- a/prov/tests/xml/namespace_redefined_but_does_not_change.xml
+++ b/prov/tests/xml/namespace_redefined_but_does_not_change.xml
@@ -7,7 +7,6 @@
 
   <prov:entity prov:id="tr:WD-prov-dm-20111215" xmlns:ex="http://example.com/ns/ex#">
     <prov:type xsi:type="xsd:QName">ex:Workflow</prov:type>
-    <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
   </prov:entity>
 
 </prov:document>

--- a/prov/tests/xml/nested_changing_default_namespace.xml
+++ b/prov/tests/xml/nested_changing_default_namespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns="http://example.org/0/" xmlns:prov="http://www.w3.org/ns/prov#">
+    <prov:entity xmlns="http://example.org/1/" prov:id="e001"/>
+</prov:document>

--- a/prov/tests/xml/nested_default_namespace.xml
+++ b/prov/tests/xml/nested_default_namespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#">
+    <prov:entity xmlns="http://example.org/0/" prov:id="e001"/>
+</prov:document>


### PR DESCRIPTION
This is a first attempt to fix #70.

The tricky thing really is that XML allows to define namespaces at the element level whereas (I think) the PROV data model only has global namespaces. So in XML it is possible to define a new default namespace/redefine any other namespace for each element.

This solution will just raise an error in case it encounters that.