### PR TITLE
fix: RDF serialisation, prov:atTime attribute

### DIFF
--- a/prov/constants.py
+++ b/prov/constants.py
@@ -139,7 +139,7 @@ PROV_ATTR_INFLUENCER = PROV['influencer']
 PROV_ATTR_COLLECTION = PROV['collection']
 
 #  Literal properties
-PROV_ATTR_TIME = PROV['time']
+PROV_ATTR_TIME = PROV['atTime']
 PROV_ATTR_STARTTIME = PROV['startTime']
 PROV_ATTR_ENDTIME = PROV['endTime']
 


### PR DESCRIPTION
Hi @satra, @trungdong,

This is a small fix to the RDF serialisation (cf. #49). 

I think that the `prov:time` attribute in a Generation should be replaced by a `prov:atTime` attribute (cf. https://www.w3.org/TR/prov-o/#atTime). @satra: do you agree with this?

This issue was identified when testing the prov RDF serialisation as part of https://github.com/incf-nidash/nidmresults-fsl. Apart from this small issue and https://github.com/RDFLib/rdflib/pull/655, everything looks fine to me!