### PR TITLE
Add bundle as entity records | Improve unified method  

### DIFF
--- a/prov/model.py
+++ b/prov/model.py
@@ -1612,16 +1612,24 @@ class ProvDocument(ProvBundle):
             raise ProvException('A bundle with that identifier already exists')
 
         #Add prov_type to entry if it is the right type and identifier
-        if identifier in self._id_map:
-            bundle_entities = self._id_map[identifier]
+        if valid_id in self._id_map.keys():
+            bundle_entities = self._id_map[valid_id]
             #For each entry with the bundle identifier
             for bundle_entity in bundle_entities:
                 if not isinstance(bundle_entity,ProvEntity):
                     raise ProvException('A prov record with that identifier already exists')
-                bundle_entity.add_attributes(attributes={PROV_TYPE:PROV_BUNDLE})
+                # get the PROV_TYPE attr and ensure that the PROV_TYPE => PROV_BUNDLE is set as attr. value
+                prov_tpye_set = bundle_entity.get_attribute(PROV_TYPE)
+                found = False
+                # get the PROV_TYPE attr and ensure that the PROV_TYPE => PROV_BUNDLE is set as attr. value
+                prov_tpye_set = bundle_entity.get_attribute(PROV_TYPE)
+                prov_tpye_set.discard(PROV_BUNDLE)
+                prov_tpye_set.discard(str(PROV_BUNDLE))
+                prov_tpye_set.add(PROV_BUNDLE)
+
         else:
             #Create new prov entry
-            bundle_entity = ProvEntity(bundle=self,identifier=identifier,attributes={PROV_TYPE:PROV_BUNDLE})
+            bundle_entity = ProvEntity(bundle=self,identifier=valid_id,attributes={PROV_TYPE:PROV_BUNDLE})
             self.add_record(bundle_entity)
 
         self._bundles[valid_id] = bundle
@@ -1644,16 +1652,22 @@ class ProvDocument(ProvBundle):
         self._bundles[valid_id] = b
 
         # Add prov_type to entry if it is the right type and identifier
-        if identifier in self._id_map:
-            bundle_entities = self._id_map[identifier]
+        if valid_id in self._id_map.keys():
+            bundle_entities = self._id_map[valid_id]
             # For each entry with the bundle identifier
             for bundle_entity in bundle_entities:
                 if not isinstance(bundle_entity, ProvEntity):
                     raise ProvException('A prov record with that identifier already exists')
-                bundle_entity.add_attributes(attributes={PROV_TYPE: PROV_BUNDLE})
+
+                #get the PROV_TYPE attr and ensure that the PROV_TYPE => PROV_BUNDLE is set as attr. value
+                prov_tpye_set = bundle_entity.get_attribute(PROV_TYPE)
+                prov_tpye_set.discard(PROV_BUNDLE)
+                prov_tpye_set.discard(str(PROV_BUNDLE))
+                prov_tpye_set.add(PROV_BUNDLE)
+
         else:
             # Create new prov entry
-            bundle_entity = ProvEntity(bundle=self, identifier=identifier, attributes={PROV_TYPE: PROV_BUNDLE})
+            bundle_entity = ProvEntity(bundle=self, identifier=valid_id, attributes={PROV_TYPE: PROV_BUNDLE})
             self.add_record(bundle_entity)
 
         return b

--- a/prov/model.py
+++ b/prov/model.py
@@ -1105,6 +1105,9 @@ class ProvBundle(object):
                 if merged not in added_merged_records:
                     unified_records.append(merged)
                     added_merged_records.add(merged)
+            elif record in unified_records:
+                #if record is allready there (prevent duplicate records)
+                pass
             else:
                 # add the original record
                 unified_records.append(record)

--- a/prov/model.py
+++ b/prov/model.py
@@ -1611,6 +1611,19 @@ class ProvDocument(ProvBundle):
         if valid_id in self._bundles:
             raise ProvException('A bundle with that identifier already exists')
 
+        #Add prov_type to entry if it is the right type and identifier
+        if identifier in self._id_map:
+            bundle_entities = self._id_map[identifier]
+            #For each entry with the bundle identifier
+            for bundle_entity in bundle_entities:
+                if not isinstance(bundle_entity,ProvEntity):
+                    raise ProvException('A prov record with that identifier already exists')
+                bundle_entity.add_attributes(attributes={PROV_TYPE:PROV_BUNDLE})
+        else:
+            #Create new prov entry
+            bundle_entity = ProvEntity(bundle=self,identifier=identifier,attributes={PROV_TYPE:PROV_BUNDLE})
+            self.add_record(bundle_entity)
+
         self._bundles[valid_id] = bundle
         bundle._document = self
 
@@ -1626,8 +1639,23 @@ class ProvDocument(ProvBundle):
             )
         if valid_id in self._bundles:
             raise ProvException('A bundle with that identifier already exists')
+
         b = ProvBundle(identifier=valid_id, document=self)
         self._bundles[valid_id] = b
+
+        # Add prov_type to entry if it is the right type and identifier
+        if identifier in self._id_map:
+            bundle_entities = self._id_map[identifier]
+            # For each entry with the bundle identifier
+            for bundle_entity in bundle_entities:
+                if not isinstance(bundle_entity, ProvEntity):
+                    raise ProvException('A prov record with that identifier already exists')
+                bundle_entity.add_attributes(attributes={PROV_TYPE: PROV_BUNDLE})
+        else:
+            # Create new prov entry
+            bundle_entity = ProvEntity(bundle=self, identifier=identifier, attributes={PROV_TYPE: PROV_BUNDLE})
+            self.add_record(bundle_entity)
+
         return b
 
     # Serializing and deserializing

--- a/prov/tests/test_model.py
+++ b/prov/tests/test_model.py
@@ -155,9 +155,9 @@ class TestBundleUpdate(unittest.TestCase):
         b2.entity('e')
 
         self.assertRaises(ProvException, lambda: d1.update(1))
-
         d1.update(d2)
-        self.assertEqual(len(d1.get_records()), 2)
+
+        self.assertEqual(len(d1.get_records()), 5) #2 x entity(e) | 2 x entity(b2) | 1x entity(b1)
         self.assertEqual(len(d1.bundles), 2)
 
 


### PR DESCRIPTION
This pull request contains 2 changes: 

# Add bundles as entity
According to the [PROV-O spec](https://www.w3.org/TR/prov-o/#Bundle) the bundle is a subclass of Prov:Entity. Due to this fact I think the prov lib should create a entity like: `Entity("ex:bundleName", attributes={"prov:type": "prov:Bundle"}) ` when a bundle is generated. 
Another possibility is to return the bundle entity dynamic during the `get_records()` call. 

What do you think about this feature? 

# [Prevent unified function to add duplicate records](https://github.com/B-Stefan/prov/commit/94f9746499644d181526e3611ce2acf63fd98396)
I modified the behavior of the `_unified_records()`. The function has added duplicate records to the result. Think this is more like a bug fix. 

All tests passed on my maschine. 
