### PR TITLE
Pythonic refactoring

### DIFF
--- a/prov/model.py
+++ b/prov/model.py
@@ -200,6 +200,9 @@ class ProvWarning(Warning):
 class ProvExceptionInvalidQualifiedName(ProvException):
     """Exception for an invalid qualified identifier name."""
 
+    qname = None
+    """Intended qualified name."""
+
     def __init__(self, qname):
         """
         Constructor.

--- a/prov/model.py
+++ b/prov/model.py
@@ -225,7 +225,11 @@ class ProvElementIdentifierRequired(ProvException):
 @six.python_2_unicode_compatible
 class ProvRecord(object):
     """Base class for PROV records."""
+
     FORMAL_ATTRIBUTES = ()
+
+    _prov_type = None
+    """PROV type of record."""
 
     def __init__(self, bundle, identifier, attributes=None):
         """
@@ -255,8 +259,8 @@ class ProvRecord(object):
         )
 
     def get_type(self):
-        """Returning the PROV type of the record."""
-        pass
+        """Returns the PROV type of the record."""
+        return self._prov_type
 
     def get_asserted_types(self):
         """Returns the set of all asserted PROV types of this record."""
@@ -583,9 +587,7 @@ class ProvRelation(ProvRecord):
 class ProvEntity(ProvElement):
     """Provenance Entity element"""
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_ENTITY
+    _prov_type = PROV_ENTITY
 
     # Convenient assertions that take the current ProvEntity as the first
     # (formal) argument
@@ -689,9 +691,7 @@ class ProvActivity(ProvElement):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_STARTTIME, PROV_ATTR_ENDTIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_ACTIVITY
+    _prov_type = PROV_ACTIVITY
 
     #  Convenient methods
     def set_time(self, startTime=None, endTime=None):
@@ -818,9 +818,7 @@ class ProvGeneration(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ENTITY, PROV_ATTR_ACTIVITY, PROV_ATTR_TIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_GENERATION
+    _prov_type = PROV_GENERATION
 
 
 class ProvUsage(ProvRelation):
@@ -828,9 +826,7 @@ class ProvUsage(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ACTIVITY, PROV_ATTR_ENTITY, PROV_ATTR_TIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_USAGE
+    _prov_type = PROV_USAGE
 
 
 class ProvCommunication(ProvRelation):
@@ -838,9 +834,7 @@ class ProvCommunication(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_INFORMED, PROV_ATTR_INFORMANT)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_COMMUNICATION
+    _prov_type = PROV_COMMUNICATION
 
 
 class ProvStart(ProvRelation):
@@ -849,9 +843,7 @@ class ProvStart(ProvRelation):
     FORMAL_ATTRIBUTES = (PROV_ATTR_ACTIVITY, PROV_ATTR_TRIGGER,
                          PROV_ATTR_STARTER, PROV_ATTR_TIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_START
+    _prov_type = PROV_START
 
 
 class ProvEnd(ProvRelation):
@@ -860,9 +852,7 @@ class ProvEnd(ProvRelation):
     FORMAL_ATTRIBUTES = (PROV_ATTR_ACTIVITY, PROV_ATTR_TRIGGER,
                          PROV_ATTR_ENDER, PROV_ATTR_TIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_END
+    _prov_type = PROV_END
 
 
 class ProvInvalidation(ProvRelation):
@@ -870,9 +860,7 @@ class ProvInvalidation(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ENTITY, PROV_ATTR_ACTIVITY, PROV_ATTR_TIME)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_INVALIDATION
+    _prov_type = PROV_INVALIDATION
 
 
 # Component 2: Derivations
@@ -883,18 +871,14 @@ class ProvDerivation(ProvRelation):
                          PROV_ATTR_ACTIVITY, PROV_ATTR_GENERATION,
                          PROV_ATTR_USAGE)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_DERIVATION
+    _prov_type = PROV_DERIVATION
 
 
 # Component 3: Agents, Responsibility, and Influence
 class ProvAgent(ProvElement):
     """Provenance Agent element."""
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_AGENT
+    _prov_type = PROV_AGENT
 
     # Convenient assertions that take the current ProvAgent as the first
     # (formal) argument
@@ -919,9 +903,7 @@ class ProvAttribution(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ENTITY, PROV_ATTR_AGENT)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_ATTRIBUTION
+    _prov_type = PROV_ATTRIBUTION
 
 
 class ProvAssociation(ProvRelation):
@@ -929,9 +911,7 @@ class ProvAssociation(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ACTIVITY, PROV_ATTR_AGENT, PROV_ATTR_PLAN)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_ASSOCIATION
+    _prov_type = PROV_ASSOCIATION
 
 
 class ProvDelegation(ProvRelation):
@@ -940,9 +920,7 @@ class ProvDelegation(ProvRelation):
     FORMAL_ATTRIBUTES = (PROV_ATTR_DELEGATE, PROV_ATTR_RESPONSIBLE,
                          PROV_ATTR_ACTIVITY)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_DELEGATION
+    _prov_type = PROV_DELEGATION
 
 
 class ProvInfluence(ProvRelation):
@@ -950,9 +928,7 @@ class ProvInfluence(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_INFLUENCEE, PROV_ATTR_INFLUENCER)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_INFLUENCE
+    _prov_type = PROV_INFLUENCE
 
 
 # Component 5: Alternate Entities
@@ -961,9 +937,7 @@ class ProvSpecialization(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_SPECIFIC_ENTITY, PROV_ATTR_GENERAL_ENTITY)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_SPECIALIZATION
+    _prov_type = PROV_SPECIALIZATION
 
 
 class ProvAlternate(ProvRelation):
@@ -971,9 +945,7 @@ class ProvAlternate(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_ALTERNATE1, PROV_ATTR_ALTERNATE2)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_ALTERNATE
+    _prov_type = PROV_ALTERNATE
 
 
 class ProvMention(ProvSpecialization):
@@ -982,9 +954,7 @@ class ProvMention(ProvSpecialization):
     FORMAL_ATTRIBUTES = (PROV_ATTR_SPECIFIC_ENTITY, PROV_ATTR_GENERAL_ENTITY,
                          PROV_ATTR_BUNDLE)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_MENTION
+    _prov_type = PROV_MENTION
 
 
 # Component 6: Collections
@@ -993,9 +963,7 @@ class ProvMembership(ProvRelation):
 
     FORMAL_ATTRIBUTES = (PROV_ATTR_COLLECTION, PROV_ATTR_ENTITY)
 
-    def get_type(self):
-        """Returning the PROV type of the record."""
-        return PROV_MEMBERSHIP
+    _prov_type = PROV_MEMBERSHIP
 
 
 #  Class mappings from PROV record type

--- a/prov/serializers/__init__.py
+++ b/prov/serializers/__init__.py
@@ -30,11 +30,7 @@ class Serializer(object):
         Abstract method for serializing.
 
         :param stream: Stream object to serialize the document into.
-        """def get_type(self):def get_type(self):
-        """Returning the PROV type of the record."""
-        return
-        """Returning the PROV type of the record."""
-        return
+        """
 
     def deserialize(self, stream, **kwargs):
         """

--- a/prov/serializers/__init__.py
+++ b/prov/serializers/__init__.py
@@ -14,6 +14,9 @@ from prov import Error
 class Serializer(object):
     """Serializer for PROV documents."""
 
+    document = None
+    """PROV document to serialise."""
+
     def __init__(self, document=None):
         """
         Constructor.
@@ -27,7 +30,11 @@ class Serializer(object):
         Abstract method for serializing.
 
         :param stream: Stream object to serialize the document into.
-        """
+        """def get_type(self):def get_type(self):
+        """Returning the PROV type of the record."""
+        return
+        """Returning the PROV type of the record."""
+        return
 
     def deserialize(self, stream, **kwargs):
         """


### PR DESCRIPTION
Some small refactoring to make some class definitions more pythonic:

-  Having public class attributes not just defined within the constructor helps in autospeccing when using mocking frameworks for unit testing (such as `mock`).
- Replacing repeated declarations of the `get_type()` method by a generic class attribute with a super class method only.