### PR TITLE
fix: association with agent

### DIFF
--- a/prov/graph.py
+++ b/prov/graph.py
@@ -79,10 +79,10 @@ def graph_to_prov(g):
     :param g: The graph instance to convert.
     """
     prov_doc = ProvDocument()
-    for n in g.nodes_iter():
+    for n in g.nodes():
         if isinstance(n, ProvRecord) and n.bundle is not None:
             prov_doc.add_record(n)
-    for _, _, edge_data in g.edges_iter(data=True):
+    for _, _, edge_data in g.edges(data=True):
         try:
             relation = edge_data['relation']
             if isinstance(relation, ProvRecord):

--- a/prov/serializers/provrdf.py
+++ b/prov/serializers/provrdf.py
@@ -23,7 +23,7 @@ from prov.constants import (
     PROV_ALTERNATE, PROV_MENTION, PROV_DELEGATION, PROV_ACTIVITY, PROV_ATTR_STARTTIME,
     PROV_ATTR_ENDTIME, PROV_LOCATION, PROV_ATTR_TIME, PROV_ROLE, PROV_COMMUNICATION,
     PROV_ATTR_INFORMANT, PROV_ATTR_RESPONSIBLE, PROV_ATTR_TRIGGER, PROV_ATTR_ENDER,
-    PROV_ATTR_STARTER, PROV_ATTR_USED_ENTITY)
+    PROV_ATTR_STARTER, PROV_ATTR_USED_ENTITY, PROV_ASSOCIATION)
 from prov.serializers import Serializer, Error
 
 
@@ -252,13 +252,15 @@ class ProvRDFSerializer(Serializer):
                                     # TODO: Why is obj_attr above not used anywhere?
                                 except IndexError:
                                     obj_val = None
-                                if obj_val and (rec_type not in {PROV_END,
-                                                                PROV_START,
-                                                                PROV_USAGE,
-                                                                PROV_GENERATION,
-                                                                PROV_DERIVATION,
-                                                                PROV_INVALIDATION} or
-                                                (valid_formal_indices == {0, 1} and
+                                if obj_val and (rec_type not in
+                                                    {PROV_END,
+                                                     PROV_START,
+                                                     PROV_USAGE,
+                                                     PROV_GENERATION,
+                                                     PROV_DERIVATION,
+                                                     PROV_ASSOCIATION,
+                                                     PROV_INVALIDATION} or
+                                            (valid_formal_indices == {0, 1} and
                                                  len(record.extra_attributes) == 0)):
                                     used_objects.append(record.formal_attributes[1][0])
                                     obj_val = self.encode_rdf_representation(obj_val)
@@ -317,10 +319,13 @@ class ProvRDFSerializer(Serializer):
                                 pred = URIRef(PROV['activity'].uri)
                             if PROV['responsible'].uri in pred:
                                 pred = URIRef(PROV['agent'].uri)
-                            if rec_type == PROV_DELEGATION and PROV['activity'].uri in pred:
+                            if rec_type == PROV_DELEGATION and \
+                                            PROV['activity'].uri in pred:
                                 pred = URIRef(PROV['hadActivity'].uri)
-                            if (rec_type in [PROV_END, PROV_START] and PROV['trigger'].uri in pred) or\
-                                (rec_type in [PROV_USAGE] and PROV['used'].uri in pred):
+                            if (rec_type in [PROV_END, PROV_START] and
+                                            PROV['trigger'].uri in pred) or\
+                                (rec_type in [PROV_USAGE] and
+                                         PROV['used'].uri in pred):
                                 pred = URIRef(PROV['entity'].uri)
                             if rec_type in [PROV_GENERATION, PROV_END,
                                             PROV_START, PROV_USAGE,

--- a/prov/tests/statements.py
+++ b/prov/tests/statements.py
@@ -889,6 +889,22 @@ class TestStatementsBase(object):
         self.add_further_attributes(assoc)
         self.do_tests(document)
 
+    def test_association_10(self):
+        document = self.new_document()
+        assoc1 = document.association(EX_NS['a1'],
+                                      agent=EX_NS['ag1'],
+                                      identifier=EX_NS['assoc10a'])
+        assoc1.add_attributes([
+            (PROV_ROLE, "figroll"),
+        ])
+        assoc2 = document.association(EX_NS['a1'],
+                                      agent=EX_NS['ag2'],
+                                      identifier=EX_NS['assoc10b'])
+        assoc2.add_attributes([
+            (PROV_ROLE, "sausageroll"),
+        ])
+        self.do_tests(document)
+
     # ATTRIBUTIONS
     def test_attribution_1(self):
         document = self.new_document()


### PR DESCRIPTION
fixes association with agent for the following scenario

@dbkeator - this PR should fix the issue you saw.

```python
import prov.model as pm                                                                      
doc = pm.ProvDocument()                                                                      
doc.add_namespace('foo', 'http://example.org/')                                              
doc.activity('foo:a1')                                                                       
doc.agent('foo:ag1')                                                                         
doc.agent('foo:ag2')                                                                         
doc.association('foo:a1', 'foo:ag1', other_attributes={pm.PROV_ROLE: 'foo:r1'})              
doc.association('foo:a1', 'foo:ag2', other_attributes={pm.PROV_ROLE: 'foo:r2'})              
print(doc.get_provn())                                                                       
print(doc.serialize(format='rdf'))
```

now generates:

```
@prefix foo: <http://example.org/> .
@prefix prov: <http://www.w3.org/ns/prov#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xml: <http://www.w3.org/XML/1998/namespace> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

{
    foo:a1 a prov:Activity ;
        prov:qualifiedAssociation [ a prov:Association ;
                prov:agent foo:ag2 ;
                prov:hadRole "foo:r2"^^xsd:string ],
            [ a prov:Association ;
                prov:agent foo:ag1 ;
                prov:hadRole "foo:r1"^^xsd:string ] .

    foo:ag1 a prov:Agent .

    foo:ag2 a prov:Agent .
}
```