### PR TITLE
Update test_dot.py to fix encoding error with Python2.7

### DIFF
--- a/prov/tests/test_dot.py
+++ b/prov/tests/test_dot.py
@@ -25,7 +25,7 @@ if find_loader("pydot") is not None:
 
         def do_tests(self, prov_doc, msg=None):
             dot = prov_to_dot(prov_doc)
-            svg_content = dot.create(format="svg")
+            svg_content = dot.create(format="svg",encoding="utf-8")
             # Very naive check of the returned SVG content as we have no way to check the graphical content
             self.assertGreater(
                 len(svg_content), self.MIN_SVG_SIZE,


### PR DESCRIPTION
test_unifying (prov.tests.test_model.TestUnification) ... ok

======================================================================
ERROR: test_all_examples (prov.tests.test_dot.SVGDotOutputTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/prov/tests/test_model.py", line 39, in test_all_examples
    self.do_tests(g)
  File "/<<PKGBUILDDIR>>/prov/tests/test_dot.py", line 28, in do_tests
    svg_content = dot.create(format="svg")
  File "/usr/lib/python2.7/dist-packages/pydot.py", line 1836, in create
    self.write(tmp_name, encoding=encoding)
  File "/usr/lib/python2.7/dist-packages/pydot.py", line 1754, in write
    f.write(s)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u1ef3' in position 1489: ordinal not in range(128)