### PR TITLE
Graphical output does not work when filename supplied in version 2.1.1

### DIFF
--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -2429,7 +2429,7 @@ class ProvBundle(object):
         from prov import dot
 
         if filename:
-            format = str(os.path.splitext(filename))[-1].lower().strip(os.path.extsep)
+            format = str(os.path.splitext(filename)[-1]).lower().strip(os.path.extsep)
         else:
             format = "png"
         format = format.lower()


### PR DESCRIPTION
I implemented the fix that was suggested in issue #164 