### PR TITLE
Adopt ruff lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ uv run python -m unittest prov.tests.test_model.TestFlattening
 uv run python -m unittest prov.tests.test_model.TestFlattening.test_flattening
 
 # Lint
-uv run flake8 src/ prov
+uv run ruff check src/
 
 # Format
 uv run black src/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
-	@echo "lint - check style with flake8"
+	@echo "lint - check style with ruff"
 	@echo "test - run tests quickly with the default Python"
 	@echo "test-all - run tests on every Python version with tox"
 	@echo "coverage - check code coverage quickly with the default Python"
@@ -25,7 +25,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 src/ prov
+	ruff check src/
 
 test:
 	python setup.py test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dev = [
 [tool.ruff]
 line-length = 88
 target-version = "py39"
-extend-exclude = ["build", "dist", ".eggs"]
+extend-exclude = ["build"]  # dist/.eggs are already in ruff's default excludes
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,48 @@ dev = [
     "black>=24.10.0",
     "bumpversion>=0.6.0",
     "coverage>=7.6.10",
-    "flake8>=7.1.1",
+    "ruff>=0.15.20",
     "setuptools>=75.8.0",
     "sphinx>=8.1.3; python_version >= '3.11'",
     "sphinx-rtd-theme",
     "tox>=4.23.2",
     "wheel>=0.45.1",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+extend-exclude = ["build", "dist", ".eggs"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "W",   # pycodestyle warnings
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade (3.9-safe)
+]
+ignore = [
+    "E203",  # whitespace before ':' (black/ruff-format compatible)
+    "E501",  # line length handled by the formatter
+    # These two pyupgrade rules only offer *unsafe* fixes when targeting py39
+    # (ruff can't prove nothing relies on runtime evaluation of the old
+    # syntax, e.g. via typing.get_type_hints()), so they fire on almost every
+    # annotated/`%`-formatted line in the project without an autofix.
+    # Deferred to a dedicated follow-up rather than mass hand-editing here.
+    "UP045",  # non-pep604-annotation-optional (`Optional[X]` -> `X | None`)
+    "UP031",  # printf-string-formatting (`%` -> `.format()`/f-string)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# These modules intentionally re-export everything from another module with
+# `import *`; pyflakes can't tell which of the resulting names are "used".
+"src/prov/model.py" = ["F403", "F405"]
+"src/prov/serializers/provjson.py" = ["F403", "F405"]
+"src/prov/serializers/provxml.py" = ["F403", "F405"]
+"src/prov/tests/attributes.py" = ["F403", "F405"]
+"src/prov/tests/statements.py" = ["F403", "F405"]
+"src/prov/tests/test_extras.py" = ["F403", "F405"]
 
 [tool.black]
 line-length = 88

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -48,7 +48,7 @@ def read(source: str | bytes | os.PathLike, format: str | None = None) -> ProvDo
     for format in serializers:
         try:
             return ProvDocument.deserialize(source=source, format=format)
-        except (TypeError, ValueError, AttributeError, KeyError) as e:
+        except (TypeError, ValueError, AttributeError, KeyError):
             # Catch specific exceptions that can occur during deserialization
             # This allows for better debugging information
             continue

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -326,7 +326,9 @@ def prov_to_dot(
                 relations.append(rec)
 
         if not bundle.is_bundle():
-            for bundle in bundle.bundles:
+            # `bundle.bundles` is evaluated once before the loop starts, so
+            # reassigning `bundle` as the loop variable here is safe.
+            for bundle in bundle.bundles:  # noqa: B020
                 _add_bundle(bundle)
 
         for rec in relations:

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -5,7 +5,7 @@ __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
 
 
-class Identifier(object):
+class Identifier:
     """Base class for all identifiers and also represents xsd:anyURI."""
 
     # TODO: make Identifier an "abstract" base class and move xsd:anyURI
@@ -62,7 +62,7 @@ class QualifiedName(Identifier):
     hashing, and retrieval of individual components (namespace or local part).
     """
 
-    def __init__(self, namespace: "Namespace", localpart: str):
+    def __init__(self, namespace: Namespace, localpart: str):
         """
         Initializes a new qualified name with the provided namespace and localpart
         values. It combines the namespace URI and localpart to form an identifier and
@@ -81,7 +81,7 @@ class QualifiedName(Identifier):
         )
 
     @property
-    def namespace(self) -> "Namespace":
+    def namespace(self) -> Namespace:
         """Namespace of qualified name."""
         return self._namespace
 
@@ -104,7 +104,7 @@ class QualifiedName(Identifier):
         return "'%s'" % self._str
 
 
-class Namespace(object):
+class Namespace:
     """PROV Namespace."""
 
     def __init__(self, prefix: str, uri: str):

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -21,11 +21,11 @@ from io import IOBase
 from typing import (
     Any,
     Callable,
-    Iterable,
     Optional,
     Union,
 )
-import typing  # to use typing.TypeAlias in comments for compatibility with Python 3.9
+from collections.abc import Iterable
+import typing  # noqa: F401 -- used by `# type: typing.TypeAlias` comments below
 from urllib.parse import urlparse
 
 import dateutil.parser
@@ -135,7 +135,7 @@ def encoding_provn_value(
     if isinstance(value, str):
         return _ensure_multiline_string_triple_quoted(value)
     elif isinstance(value, datetime.datetime):
-        return '"{0}" %% xsd:dateTime'.format(value.isoformat())
+        return f'"{value.isoformat()}" %% xsd:dateTime'
     elif isinstance(value, float):
         return '"%g" %%%% xsd:float' % value
     elif isinstance(value, bool):
@@ -145,7 +145,7 @@ def encoding_provn_value(
         return str(value)
 
 
-class Literal(object):
+class Literal:
     def __init__(
         self,
         value: Any,
@@ -266,7 +266,7 @@ class ProvElementIdentifierRequired(ProvException):
 
 
 #  PROV records
-class ProvRecord(object):
+class ProvRecord:
     """Base class for PROV records."""
 
     FORMAL_ATTRIBUTES = ()  # type: tuple[QualifiedName, ...]
@@ -297,7 +297,7 @@ class ProvRecord(object):
     def __hash__(self) -> int:
         return hash((self.get_type(), self._identifier, frozenset(self.attributes)))
 
-    def copy(self) -> "ProvRecord":
+    def copy(self) -> ProvRecord:
         """
         Return an exact copy of this record.
         """
@@ -630,7 +630,7 @@ class ProvElement(ProvRecord):
             # All types of PROV elements require a valid identifier
             raise ProvElementIdentifierRequired()
 
-        super(ProvElement, self).__init__(bundle, identifier, attributes)
+        super().__init__(bundle, identifier, attributes)
 
     def is_element(self) -> bool:
         """
@@ -1377,7 +1377,7 @@ class NamespaceManager(dict):
                 return new_prefix
 
 
-class ProvBundle(object):
+class ProvBundle:
     """PROV Bundle"""
 
     def __init__(
@@ -1385,7 +1385,7 @@ class ProvBundle(object):
         records: Optional[Iterable[ProvRecord]] = None,
         identifier: Optional[QualifiedName] = None,
         namespaces: Optional[NSCollection] = None,
-        document: Optional["ProvDocument"] = None,
+        document: Optional[ProvDocument] = None,
     ):
         """
         Constructor.
@@ -1658,7 +1658,7 @@ class ProvBundle(object):
         # TODO: Check unification rules in the PROV-CONSTRAINTS document
         # This method simply merges the records having the same name
         merged_records = dict()
-        for identifier, records in self._id_map.items():
+        for _identifier, records in self._id_map.items():
             if len(records) > 1:
                 # more than one record having the same identifier
                 # merge the records
@@ -2531,7 +2531,7 @@ class ProvDocument(ProvBundle):
         if not isinstance(other, ProvDocument):
             return False
         # Comparing the documents' content
-        if not super(ProvDocument, self).__eq__(other):
+        if not super().__eq__(other):
             return False
 
         # Comparing the documents' bundles

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 """
 prov-compare -- Compare two PROV-JSON, PROV-XML, or RDF (PROV-O) files for equivalence
 
@@ -39,7 +38,7 @@ class CLIError(Exception):
     """Generic exception to raise and log different fatal errors."""
 
     def __init__(self, msg: str):
-        super(CLIError, self).__init__(type(self))
+        super().__init__(type(self))
         self.msg = "E: %s" % msg
 
     def __str__(self) -> str:

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 """
 convert -- Convert PROV-JSON to RDF, PROV-N, PROV-XML, or graphical formats (SVG, PDF, PNG)
 
@@ -77,7 +76,7 @@ class CLIError(Exception):
     """Generic exception to raise and log different fatal errors."""
 
     def __init__(self, msg: str):
-        super(CLIError, self).__init__(type(self))
+        super().__init__(type(self))
         self.msg = "E: %s" % msg
 
     def __str__(self) -> str:
@@ -101,7 +100,9 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
         try:
             prov_doc.serialize(outfile, format=output_format)
         except serializers.DoNotExist:
-            raise CLIError('Output format "%s" is not supported.' % output_format)
+            # Not chaining with `from` to preserve the historic CLIError
+            # traceback/behaviour; revisit in a follow-up.
+            raise CLIError('Output format "%s" is not supported.' % output_format)  # noqa: B904
 
 
 def main(argv: Optional[list] = None) -> int:  # IGNORE:C0111

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -86,4 +86,8 @@ def get(format_name: str) -> type[Serializer]:
     try:
         return serializers[format_name]
     except KeyError:
-        raise DoNotExist('No serializer available for the format "%s"' % format_name)
+        # Not chaining with `from` to preserve the historic DoNotExist
+        # traceback/behaviour; revisit in a follow-up.
+        raise DoNotExist(  # noqa: B904
+            'No serializer available for the format "%s"' % format_name
+        )

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -102,12 +102,12 @@ class ProvJSONEncoder(json.JSONEncoder):
         if isinstance(o, ProvDocument):
             return encode_json_document(o)
         else:
-            return super(ProvJSONEncoder, self).encode(o)
+            return super().encode(o)
 
 
 class ProvJSONDecoder(json.JSONDecoder):
     def decode(self, s: str, *args: Any, **kwargs: Any) -> Any:
-        container = super(ProvJSONDecoder, self).decode(s, *args, **kwargs)
+        container = super().decode(s, *args, **kwargs)
         document = ProvDocument()
         decode_json_document(container, document)
         return document

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -321,10 +321,6 @@ class ProvRDFSerializer(Serializer):
                             if identifier is None and subj is not None:
                                 try:
                                     obj_val = record.formal_attributes[1][1]
-                                    # TODO: this URIRef is constructed but never used
-                                    URIRef(
-                                        record.formal_attributes[1][0].uri
-                                    )
                                 except IndexError:
                                     obj_val = None
                                 if obj_val and (

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -5,7 +5,8 @@ import base64
 from collections import OrderedDict
 import datetime
 import io
-from typing import Any, Optional, Generator
+from typing import Any, Optional
+from collections.abc import Generator
 import warnings
 
 import dateutil.parser
@@ -225,7 +226,7 @@ class ProvRDFSerializer(Serializer):
             if datatype == XSD["gYearMonth"]:
                 parsed_info = dateutil.parser.parse(literal)
                 return pm.Literal(
-                    "{0}-{1:02d}".format(parsed_info.year, parsed_info.month),
+                    f"{parsed_info.year}-{parsed_info.month:02d}",
                     datatype=self.valid_identifier(datatype),
                 )
             else:
@@ -274,11 +275,13 @@ class ProvRDFSerializer(Serializer):
             container.bind(namespace.prefix, namespace.uri)
 
         id_generator = AnonymousIDGenerator()
-        real_or_anon_id = lambda record: (
-            record._identifier.uri
-            if record._identifier
-            else id_generator.get_anon_id(record)
-        )
+
+        def real_or_anon_id(record: pm.ProvRecord) -> str:
+            return (
+                record._identifier.uri
+                if record._identifier
+                else id_generator.get_anon_id(record)
+            )
 
         for record in bundle._records:
             rec_type = record.get_type()
@@ -295,7 +298,7 @@ class ProvRDFSerializer(Serializer):
                     record.attributes
                 )
                 formal_qualifiers = False
-                for attrid, (attr, value) in enumerate(list(record.formal_attributes)):
+                for attrid, (_attr, value) in enumerate(list(record.formal_attributes)):
                     if (identifier is not None and value is not None) or (
                         identifier is None and value is not None and attrid > 1
                     ):
@@ -318,10 +321,10 @@ class ProvRDFSerializer(Serializer):
                             if identifier is None and subj is not None:
                                 try:
                                     obj_val = record.formal_attributes[1][1]
-                                    obj_attr = URIRef(
+                                    # TODO: this URIRef is constructed but never used
+                                    URIRef(
                                         record.formal_attributes[1][0].uri
                                     )
-                                    # TODO: Why is obj_attr above not used anywhere?
                                 except IndexError:
                                     obj_val = None
                                 if obj_val and (
@@ -702,7 +705,9 @@ class ProvRDFSerializer(Serializer):
                 del other_attributes[subj]
 
         if other_attributes:
-            warnings.warn(
+            # No explicit stacklevel to preserve historic warning behaviour;
+            # revisit in a follow-up.
+            warnings.warn(  # noqa: B028
                 "The following attributes were not converted: " + str(other_attributes),
                 UserWarning,
             )
@@ -740,8 +745,7 @@ def walk(
         else:
             path[level] = child
         # Recurse into the next level
-        for child_paths in walk(tail, level + 1, path, usename):
-            yield child_paths
+        yield from walk(tail, level + 1, path, usename)
 
 
 def literal_rdf_representation(literal: pm.Literal) -> RDFLiteral:

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -108,7 +108,7 @@ class ProvXMLSerializer(Serializer):
             if namespace not in nsmap:
                 nsmap[namespace.prefix] = namespace.uri
 
-        for key, value in DEFAULT_NAMESPACES.items():
+        for _key, value in DEFAULT_NAMESPACES.items():
             uri = value.uri
             if value.prefix == "xsd":
                 # The XSD namespace for some reason has no hash at the end
@@ -276,7 +276,9 @@ class ProvXMLSerializer(Serializer):
                 )
             # Ignore the <prov:other> element storing non-PROV information.
             if qname.localname == "other":
-                warnings.warn(
+                # No explicit stacklevel to preserve historic warning behaviour;
+                # revisit in a follow-up.
+                warnings.warn(  # noqa: B028
                     "Document contains non-PROV information in "
                     "<prov:other>. It will be ignored in this package.",
                     UserWarning,
@@ -374,7 +376,9 @@ def _extract_attributes(
             elif key == _ns_xml("lang"):
                 _v = prov.model.Literal(subel.text, langtag=value_str)
             else:
-                warnings.warn(
+                # No explicit stacklevel to preserve historic warning behaviour;
+                # revisit in a follow-up.
+                warnings.warn(  # noqa: B028
                     "The element '%s' contains an attribute %s='%s' "
                     "which is not representable in the prov module's "
                     "internal data model and will thus be ignored."

--- a/src/prov/tests/attributes.py
+++ b/src/prov/tests/attributes.py
@@ -5,7 +5,7 @@ EX_NS = Namespace("ex", "http://example.org/")
 EX_OTHER_NS = Namespace("other", "http://example.org/")
 
 
-class TestAttributesBase(object):
+class TestAttributesBase:
     """This is the base class for testing support for various datatypes.
     It is not runnable and needs to be included in a subclass of
     RoundTripTestCase.

--- a/src/prov/tests/examples.py
+++ b/src/prov/tests/examples.py
@@ -154,7 +154,7 @@ def primer_example_alternate():
     blogEntry = g.entity("ex:blogEntry")
 
     compile = g.activity("ex:compile")
-    compile2 = g.activity("ex:compile2")
+    g.activity("ex:compile2")
     compose = g.activity("ex:compose")
     correct = g.activity("ex:correct", "2012-03-31T09:21:00", "2012-04-01T15:21:00")
     illustrate = g.activity("ex:illustrate")

--- a/src/prov/tests/qnames.py
+++ b/src/prov/tests/qnames.py
@@ -12,7 +12,7 @@ def document_with_n_bundles_having_default_namespace(n):
     return prov_doc
 
 
-class TestQualifiedNamesBase(object):
+class TestQualifiedNamesBase:
     """This is the base class for testing support for qualified names and
     namespaces. It is not runnable and needs to be included in a subclass of
     RoundTripTestCase.

--- a/src/prov/tests/statements.py
+++ b/src/prov/tests/statements.py
@@ -4,7 +4,7 @@ EX_NS = Namespace("ex", "http://example.org/")
 EX2_NS = Namespace("ex2", "http://example2.org/")
 
 
-class TestStatementsBase(object):
+class TestStatementsBase:
     """This is the base class for testing different PROV statements.
     It is not runnable and needs to be included in a subclass of
     RoundTripTestCase.

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -15,5 +15,5 @@ class ProvGraphTestCase(unittest.TestCase):
             self.assertEqual(
                 prov_doc,
                 prov_org,
-                "Round trip graph conversion for '{}' failed.".format(name),
+                f"Round trip graph conversion for '{name}' failed.",
             )

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -21,7 +21,7 @@ EX_URI = "http://www.example.org/"
 EX2_URI = "http://www.example2.org/"
 
 
-class TestExamplesBase(object):
+class TestExamplesBase:
     """This is the base class for testing support for all the examples provided
     in prov.tests.examples.
     It is not runnable and needs to be included in a subclass of
@@ -54,7 +54,7 @@ class TestLoadingProvToolboxJSON(unittest.TestCase):
                             g2,
                             "Round-trip JSON encoding/decoding failed:  %s." % filename,
                         )
-                    except:
+                    except:  # noqa: E722 -- intentionally broad to catch any failure
                         self.fails.append(filename)
 
     def test_loading_all_json(self):
@@ -216,13 +216,13 @@ class TestAddBundle(unittest.TestCase):
 
 class TestLiteralRepresentation(unittest.TestCase):
     def test_literal_provn_with_single_quotes(self):
-        l = Literal('{"foo": "bar"}')
-        string_rep = l.provn_representation()
+        literal = Literal('{"foo": "bar"}')
+        string_rep = literal.provn_representation()
         self.assertTrue('{\\"f' in string_rep)
 
     def test_literal_provn_with_triple_quotes(self):
-        l = Literal('"""foo\\nbar"""')
-        string_rep = l.provn_representation()
+        literal = Literal('"""foo\\nbar"""')
+        string_rep = literal.provn_representation()
         self.assertTrue('\\"\\"\\"f' in string_rep)
 
 

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -63,7 +63,7 @@ def find_diff(g_rdf, g0_rdf):
     return graphs_equal, in_both, in_first2, in_second2
 
 
-class TestExamplesBase(object):
+class TestExamplesBase:
     """This is the base class for testing support for all the examples provided
     in prov.tests.examples.
     It is not runnable and needs to be included in a subclass of
@@ -82,7 +82,7 @@ class TestExamplesBase(object):
             self.do_tests(g)
 
 
-class TestJSONExamplesBase(object):
+class TestJSONExamplesBase:
     """This is the base class for testing support for all the examples provided
     in prov.tests.examples.
     It is not runnable and needs to be included in a subclass of
@@ -279,13 +279,13 @@ class TestRDFSerializer(unittest.TestCase):
                 if idx in skip:
                     logger.info("Skipping deserialization: %s" % fname)
                     continue
-                g1 = pm.ProvDocument.deserialize(
+                pm.ProvDocument.deserialize(
                     content=g.serialize(format="rdf", rdf_format=format),
                     format="rdf",
                     rdf_format=format,
                 )
             except Exception as e:
-                raise e;
+                raise e
                 # errors.append((e, idx, fname, in_first, in_second))
         self.assertFalse(errors)
 

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -384,8 +384,10 @@ for filename in glob.iglob(os.path.join(DATA_PATH, "*" + os.path.extsep + "xml")
 
     # Python creates closures on function calls...
     def get_fct(f):
-        # Some test files have a lot of type declarations...
-        if name in ["pc1"]:
+        # `name` is the outer loop variable, but it is only read here,
+        # synchronously, on the same iteration it was set -- not from the
+        # returned `fct` closure below, so late-binding is not an issue.
+        if name in ["pc1"]:  # noqa: B023
             force_types = True
         else:
             force_types = False
@@ -393,7 +395,9 @@ for filename in glob.iglob(os.path.join(DATA_PATH, "*" + os.path.extsep + "xml")
         def fct(self):
             self._perform_round_trip(f, force_types=force_types)
 
-        return fct
+        # `fct` here is this function's own name (defined two lines above),
+        # not the outer loop's `fct` variable assigned below.
+        return fct  # noqa: B023
 
     fct = get_fct(filename)
     fct.__name__ = str(test_name)

--- a/uv.lock
+++ b/uv.lock
@@ -644,20 +644,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -959,15 +945,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,7 +1069,7 @@ dev = [
     { name = "bumpversion" },
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "flake8" },
+    { name = "ruff" },
     { name = "setuptools" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1117,21 +1094,12 @@ dev = [
     { name = "black", specifier = ">=24.10.0" },
     { name = "bumpversion", specifier = ">=0.6.0" },
     { name = "coverage", specifier = ">=7.6.10" },
-    { name = "flake8", specifier = ">=7.1.1" },
+    { name = "ruff", specifier = ">=0.15.20" },
     { name = "setuptools", specifier = ">=75.8.0" },
     { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.1.3" },
     { name = "sphinx-rtd-theme" },
     { name = "tox", specifier = ">=4.23.2" },
     { name = "wheel", specifier = ">=0.45.1" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
 ]
 
 [[package]]
@@ -1144,15 +1112,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -1336,6 +1295,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Roadmap Phase 1 step 8. Replaces flake8 with ruff for linting.
- Rule set: E (pycodestyle errors), F (pyflakes), W (pycodestyle warnings), B (flake8-bugbear), UP (pyupgrade, py39-safe target).
- Mechanical autofixes only: drop redundant `object` base classes and `super(Cls, self)` args, unquote forward references, `%`/`.format()` -> f-strings where safe, drop stray encoding-declaration comments, one `lambda` rewritten as `def`, a few genuinely-unused loop/exception variables renamed/removed.
- No behaviour changes, no public API changes (public-API guard test passes).

## Notable exclusions (see comments in `pyproject.toml` / inline `noqa`)
- `F403`/`F405` per-file-ignored on the modules that intentionally do `from x import *` (`model.py`, `provjson.py`, `provxml.py`, and three test-mixin modules).
- `UP045` (`Optional[X]` -> `X | None`) and `UP031` (`%`-formatting -> `.format()`/f-string) ignored project-wide for now: ruff only offers *unsafe* fixes for these under a py39 target, and they fire on nearly every file. Deferred to a follow-up pass.
- A handful of flake8-bugbear findings are behaviour-sensitive and were left as `noqa`-suppressed with an explanatory comment rather than "fixed": two `raise ... from` exception-chaining sites, three `warnings.warn` missing `stacklevel`, a loop-variable shadowing case in `dot.py`, and two loop-variable-capture cases in a test file. These are candidates for follow-up bug reports/fixes, not lint-tooling-swap scope.

## Test plan
- [x] `uv run ruff check src/` clean
- [x] `uv run python -m unittest discover -s src/` — OK (964 tests, expected failures=17)
- [x] `uv run python -m unittest prov.tests.test_public_api` — OK
- [x] `uv run mypy src` — same 6 pre-existing untyped-stub errors as master (no regressions)
- [x] `uv run black --check src/` — same 16 non-compliant files as master (no new drift; black adoption is a later roadmap step)