### PR TITLE
Fix XML deserialization with prov as default namespace

### DIFF
--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -360,12 +360,12 @@ def _extract_attributes(
     attributes = []  # type: list[tuple[prov.model.QualifiedName, Any]]
     for subel in element:
         sqname = etree.QName(subel)
-        _t = xml_qname_to_QualifiedName(
-            subel,
+        qname_str = (
             "%s:%s" % (subel.prefix, sqname.localname)
             if subel.prefix
-            else sqname.localname,
+            else sqname.localname
         )
+        _t = xml_qname_to_QualifiedName(subel, qname_str)
 
         for key, value in subel.attrib.items():
             value_str = value.decode("utf-8") if isinstance(value, bytes) else value
@@ -419,6 +419,10 @@ def xml_qname_to_QualifiedName(
         if ns_uri == XML_XSD_URI:
             ns = XSD  # use the standard xsd namespace (i.e. with #)
         else:
+            # Deliberately not mapping PROV.uri to the canonical PROV namespace
+            # here (unlike the prefixed branch above): doing so would change the
+            # serialized output for previously-accepted documents, breaking the
+            # 2.x output-compatibility promise.
             ns = Namespace("", ns_uri)
         return ns[qname_str]
     # no default namespace

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -418,8 +418,6 @@ def xml_qname_to_QualifiedName(
         ns_uri = element.nsmap[None]
         if ns_uri == XML_XSD_URI:
             ns = XSD  # use the standard xsd namespace (i.e. with #)
-        elif ns_uri == PROV.uri:
-            ns = PROV
         else:
             ns = Namespace("", ns_uri)
         return ns[qname_str]

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -361,7 +361,10 @@ def _extract_attributes(
     for subel in element:
         sqname = etree.QName(subel)
         _t = xml_qname_to_QualifiedName(
-            subel, "%s:%s" % (subel.prefix, sqname.localname)
+            subel,
+            "%s:%s" % (subel.prefix, sqname.localname)
+            if subel.prefix
+            else sqname.localname,
         )
 
         for key, value in subel.attrib.items():
@@ -413,7 +416,12 @@ def xml_qname_to_QualifiedName(
     # case 2: unknown prefix
     if None in element.nsmap:
         ns_uri = element.nsmap[None]
-        ns = Namespace("", ns_uri)
+        if ns_uri == XML_XSD_URI:
+            ns = XSD  # use the standard xsd namespace (i.e. with #)
+        elif ns_uri == PROV.uri:
+            ns = PROV
+        else:
+            ns = Namespace("", ns_uri)
         return ns[qname_str]
     # no default namespace
     raise ProvXMLException(

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -369,9 +369,29 @@ class ProvXMLTestCase(unittest.TestCase):
         # the <value> element is in the default (PROV) namespace:
         # it must parse as prov:value, not "None:value"
         values = list(entity.get_attribute(PROV["value"]))
-        self.assertEqual(len(values), 1)
-        # and the document must serialize back to XML without error
-        self.assertTrue(document.serialize(format="xml"))
+        self.assertEqual(values, [1])
+        # and the document must round-trip through XML unchanged
+        round_tripped = prov.ProvDocument.deserialize(
+            content=document.serialize(format="xml"), format="xml"
+        )
+        self.assertEqual(round_tripped, document)
+
+    def test_deserialization_with_xsd_as_default_namespace(self):
+        # An unprefixed xsi:type resolved against an XSD default namespace must
+        # map to the canonical xsd namespace (with #); previously it produced a
+        # corrupt datatype URI (http://www.w3.org/2001/XMLSchemaint).
+        xml_string = """<prov:document xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:prov="http://www.w3.org/ns/prov#"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:ex="https://example.org/">
+          <prov:entity prov:id="ex:e">
+            <prov:value xsi:type="int">1</prov:value>
+          </prov:entity>
+        </prov:document>"""
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+        entity = list(document.get_records(prov.ProvEntity))[0]
+        values = list(entity.get_attribute(PROV["value"]))
+        self.assertEqual(values, [1])
 
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -353,6 +353,26 @@ class ProvXMLTestCase(unittest.TestCase):
         self.assertNotEqual(new_ns, ns)
         self.assertEqual(new_ns.uri, "http://example.com/ns/new_ex#")
 
+    def test_deserialization_with_prov_as_default_namespace(self):
+        # https://github.com/trungdong/prov/issues/155
+        xml_string = """<document xmlns="http://www.w3.org/ns/prov#"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:prov="http://www.w3.org/ns/prov#"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:ex="https://example.org/">
+          <entity prov:id="ex:e">
+            <value xsi:type="xsd:int">1</value>
+          </entity>
+        </document>"""
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+        entity = list(document.get_records(prov.ProvEntity))[0]
+        # the <value> element is in the default (PROV) namespace:
+        # it must parse as prov:value, not "None:value"
+        values = list(entity.get_attribute(PROV["value"]))
+        self.assertEqual(len(values), 1)
+        # and the document must serialize back to XML without error
+        self.assertTrue(document.serialize(format="xml"))
+
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
     def _perform_round_trip(self, filename, force_types=False):


### PR DESCRIPTION
Fixes #155. Elements without a prefix produced 'None:value' qualified names, breaking round-trips of ProvToolbox output.