### PR TITLE
Release 2.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 -------
 
+2.2.0 (2026-07-03)
+^^^^^^^^^^^^^^^^^^
+* Fixed graphical output when a filename is supplied (#164)
+* Fixed PROV-XML deserialization when prov is the default namespace (#155)
+* New ``plot`` extra: ``pip install prov[plot]`` for matplotlib support (#166)
+* Marked as Production/Stable; added Python 3.14 to the test matrix
+* Tooling: ruff (lint+format), pytest runner, uv-based CI, automated PyPI
+  releases via Trusted Publishing. No public API changes.
+
 2.1.1 (2025-06-24)
 ^^^^^^^^^^^^^^^^^^
 * No change - fixing the previous botched release

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 __all__ = ["Error", "model", "read"]
 


### PR DESCRIPTION
Roadmap Phase 0-1 release (plan Task 16): changelog for 2.2.0 and version bump. Release will be created by the maintainer after merge; publishing runs via the Trusted Publishing workflow.