### PR TITLE
docs: pin sphinx <9 to fix ReadTheDocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx>=8.1.3,<9
 sphinx_rtd_theme


### PR DESCRIPTION
## Summary

Pins Sphinx to <9 to prevent ReadTheDocs build failures.

## Root Cause

Sphinx 9's autodoc calls `repr()` on class bases while documenting `prov.serializers.provrdf`. rdflib's `DefinedNamespaceMeta.__repr__` raises `AttributeError` on its abstract base class, crashing the build.

Verified: Sphinx 8.1.3 and 8.2.3 build fine, 9.0.4 and 9.1.0 crash.

## Verification

Local sphinx-build with Sphinx 8.2.3 (within the pinned range) exits 0 with no errors related to autodoc or rdflib repr.