### PR TITLE
types: make everything but provrdf pass mypy --strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,10 +179,3 @@ check_untyped_defs = true
 # rather than scatter dozens of individually-justified ignores.
 module = "prov.serializers.provrdf"
 disable_error_code = ["arg-type", "assignment", "operator", "index"]
-
-[[tool.mypy.overrides]]
-# pydot.Dot.create() is annotated to return `str`, but its own docstring
-# says (and it actually does, for binary Graphviz formats) return `bytes`;
-# this is an inaccuracy in pydot's stub, not a bug in this module.
-module = "prov.scripts.convert"
-disable_error_code = ["arg-type"]

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -19,7 +19,7 @@ class Error(Exception):
 
 
 def read(
-    source: str | bytes | os.PathLike, format: str | None = None
+    source: str | bytes | os.PathLike[str], format: str | None = None
 ) -> ProvDocument | None:
     """
     Convenience function returning a ProvDocument instance.

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -50,7 +50,7 @@ from prov.model import (
     ProvRecord,
     ProvElement,
 )
-import pydot  # type: ignore[import]
+import pydot
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import networkx as nx
 from prov.model import (
     ProvDocument,
@@ -56,7 +60,7 @@ INFERRED_ELEMENT_CLASS = {
 }
 
 
-def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph:
+def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
     """
     Convert a :class:`~prov.model.ProvDocument` to a `MultiDiGraph
     <https://networkx.github.io/documentation/stable/reference/classes/multidigraph.html>`_
@@ -64,9 +68,9 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph:
 
     :param prov_document: The :class:`~prov.model.ProvDocument` instance to convert.
     """
-    g = nx.MultiDiGraph()  # type: nx.MultiDiGraph
+    g: nx.MultiDiGraph[Any] = nx.MultiDiGraph()
     unified = prov_document.unified()
-    node_map = dict()
+    node_map: dict[Any, ProvRecord] = dict()
     for element in unified.get_records(ProvElement):
         g.add_node(element)
         node_map[element.identifier] = element
@@ -89,7 +93,7 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph:
     return g
 
 
-def graph_to_prov(g: nx.MultiDiGraph) -> ProvDocument:
+def graph_to_prov(g: nx.MultiDiGraph[Any]) -> ProvDocument:
     """
     Convert a `MultiDiGraph
     <https://networkx.github.io/documentation/stable/reference/classes/multidigraph.html>`_

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import networkx as nx
+from prov.identifier import QualifiedName
 from prov.model import (
     ProvDocument,
     ProvRecord,
@@ -70,7 +71,7 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
     """
     g: nx.MultiDiGraph[Any] = nx.MultiDiGraph()
     unified = prov_document.unified()
-    node_map: dict[Any, ProvRecord] = dict()
+    node_map: dict[QualifiedName | None, ProvRecord] = dict()
     for element in unified.get_records(ProvElement):
         g.add_node(element)
         node_map[element.identifier] = element

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -30,7 +30,11 @@ from urllib.parse import urlparse
 import dateutil.parser
 from prov import Error, serializers
 from prov.constants import *
-from prov.identifier import Identifier, QualifiedName, Namespace
+from prov.identifier import (
+    Identifier as Identifier,
+    QualifiedName as QualifiedName,
+    Namespace as Namespace,
+)
 
 
 __author__ = "Trung Dong Huynh"
@@ -54,7 +58,7 @@ RecordAttributesArg = (
 NameValuePair = tuple[QualifiedName, Any]  # type: typing.TypeAlias
 DatetimeOrStr = datetime.datetime | str  # type: typing.TypeAlias
 NSCollection = dict[str, str] | Iterable[Namespace]  # type: typing.TypeAlias
-PathLike = str | bytes | os.PathLike  # type: typing.TypeAlias
+PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
 
 
 # Data Types
@@ -284,7 +288,7 @@ class ProvRecord:
         """
         self._bundle = bundle
         self._identifier = identifier
-        self._attributes: dict[QualifiedName, set] = defaultdict(set)
+        self._attributes: dict[QualifiedName, set[Any]] = defaultdict(set)
         if attributes:
             self.add_attributes(attributes)
 
@@ -319,7 +323,7 @@ class ProvRecord:
         """
         self._attributes[PROV_TYPE].add(type_identifier)
 
-    def get_attribute(self, attr_name: QualifiedNameCandidate) -> set:
+    def get_attribute(self, attr_name: QualifiedNameCandidate) -> set[Any]:
         """
         Returns the attribute values (if any) for the specified attribute name.
 
@@ -350,7 +354,7 @@ class ProvRecord:
         ]
 
     @property
-    def args(self) -> tuple:
+    def args(self) -> tuple[Any, ...]:
         """
         All values of the record's formal attributes.
 
@@ -1127,7 +1131,7 @@ DEFAULT_NAMESPACES = {"prov": PROV, "xsd": XSD, "xsi": XSI}
 
 
 #  Bundle
-class NamespaceManager(dict):
+class NamespaceManager(dict[str, Namespace]):
     """Manages namespaces for PROV documents and bundles."""
 
     parent = None  # type: Optional[NamespaceManager]
@@ -1646,9 +1650,9 @@ class ProvBundle:
     def __ne__(self, other: Any) -> bool:
         return not (self == other)
 
-    __hash__ = None  # type: ignore
+    __hash__ = None  # type: ignore[assignment]
 
-    # type: ignore # type: ignore # Transformations
+    # Transformations
     def _unified_records(self) -> list[ProvRecord]:
         """Returns a list of unified records."""
         # TODO: Check unification rules in the PROV-CONSTRAINTS document
@@ -2304,7 +2308,7 @@ class ProvBundle:
             other_attributes,
         )
         record.add_asserted_type(PROV["PrimarySource"])
-        return record  # type: ignore
+        return record
 
     def specialization(
         self, specificEntity: EntityRef, generalEntity: EntityRef

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -24,7 +24,7 @@ from prov.model import ProvDocument
 
 logger = logging.getLogger(__name__)
 
-__all__ = []  # type: ignore
+__all__: list[str] = []
 __version__ = 0.1
 __date__ = "2015-06-16"
 __updated__ = "2025-06-07"
@@ -45,7 +45,7 @@ class CLIError(Exception):
         return self.msg
 
 
-def main(argv: Optional[list] = None) -> int:  # IGNORE:C0111
+def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
     """Command line options."""
 
     if argv is None:

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -18,7 +18,7 @@ import os
 import sys
 import logging
 import traceback
-from typing import Optional
+from typing import Optional, cast
 
 from prov.model import ProvDocument
 from prov import serializers
@@ -26,7 +26,7 @@ from prov import serializers
 
 logger = logging.getLogger(__name__)
 
-__all__ = []  # type: ignore
+__all__: list[str] = []
 __version__ = 0.1
 __date__ = "2014-03-14"
 __updated__ = "2025-06-07"
@@ -93,7 +93,10 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
         from prov.dot import prov_to_dot
 
         dot = prov_to_dot(prov_doc)
-        content = dot.create(format=output_format)
+        # pydot's stub says create() returns `str`, but its own docstring
+        # says (and it actually does, for binary Graphviz formats) return
+        # `bytes`; this is an inaccuracy in pydot's stub, not a bug here.
+        content = cast(bytes, dot.create(format=output_format))
         outfile.write(content)
     else:
         # Try supported serializers:
@@ -105,7 +108,7 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
             raise CLIError('Output format "%s" is not supported.' % output_format)  # noqa: B904
 
 
-def main(argv: Optional[list] = None) -> int:  # IGNORE:C0111
+def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
     """Command line options."""
 
     if argv is None:

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -3,16 +3,14 @@ from collections import defaultdict
 import datetime
 import io
 import json
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from prov import Error
+from prov.identifier import Identifier, QualifiedName, Namespace
 from prov.serializers import Serializer
 from prov.constants import *
 from prov.model import (
     Literal,
-    Identifier,
-    QualifiedName,
-    Namespace,
     ProvDocument,
     ProvBundle,
     first,
@@ -94,7 +92,7 @@ class ProvJSONSerializer(Serializer):
         if not isinstance(stream, io.TextIOBase):
             buf = io.StringIO(stream.read().decode("utf-8"))
             stream = buf
-        return json.load(stream, cls=ProvJSONDecoder, **args)
+        return cast(ProvDocument, json.load(stream, cls=ProvJSONDecoder, **args))
 
 
 class ProvJSONEncoder(json.JSONEncoder):
@@ -133,7 +131,7 @@ def encode_json_document(document: ProvDocument) -> ProvJSONDict:
 
 
 def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
-    container = defaultdict(dict)  # type: dict[str, dict]
+    container = defaultdict(dict)  # type: dict[str, dict[str, Any]]
     prefixes = {}  # type: dict[str, str]
     for namespace in bundle._namespaces.get_registered_namespaces():
         prefixes[namespace.prefix] = namespace.uri
@@ -210,7 +208,7 @@ def decode_json_container(jc: ProvJSONDict, bundle: ProvBundle) -> None:
         prefixes = jc["prefix"]
         for prefix, uri in prefixes.items():
             if prefix != "default":
-                bundle.add_namespace(Namespace(prefix, uri))  # type: ignore
+                bundle.add_namespace(Namespace(prefix, uri))
             else:
                 bundle.set_default_namespace(uri)
         del jc["prefix"]

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -158,7 +158,7 @@ class ProvXMLSerializer(Serializer):
                     if value.langtag is not None:
                         subelem.attrib[_ns_xml("lang")] = value.langtag
                     v = value.value
-                elif isinstance(value, prov.model.QualifiedName):
+                elif isinstance(value, prov.identifier.QualifiedName):
                     if attr not in PROV_ATTRIBUTE_QNAMES:
                         subelem.attrib[_ns_xsi("type")] = "xsd:QName"
                     v = str(value)
@@ -324,8 +324,8 @@ class ProvXMLSerializer(Serializer):
 
     def _derive_record_label(
         self,
-        rec_type: prov.model.QualifiedName,
-        attributes: list[tuple[prov.model.QualifiedName, Any]],
+        rec_type: prov.identifier.QualifiedName,
+        attributes: list[tuple[prov.identifier.QualifiedName, Any]],
     ) -> str:
         """
         Helper function trying to derive the record label taking care of
@@ -351,13 +351,13 @@ class ProvXMLSerializer(Serializer):
 
 def _extract_attributes(
     element: etree._Element,
-) -> list[tuple[prov.model.QualifiedName, Any]]:
+) -> list[tuple[prov.identifier.QualifiedName, Any]]:
     """
     Extract the PROV attributes from an etree element.
 
     :param element: The lxml.etree.Element instance.
     """
-    attributes = []  # type: list[tuple[prov.model.QualifiedName, Any]]
+    attributes = []  # type: list[tuple[prov.identifier.QualifiedName, Any]]
     for subel in element:
         sqname = etree.QName(subel)
         qname_str = (
@@ -400,7 +400,7 @@ def _extract_attributes(
 
 def xml_qname_to_QualifiedName(
     element: etree._Element, qname_str: str
-) -> prov.model.QualifiedName:
+) -> prov.identifier.QualifiedName:
     if ":" in qname_str:
         prefix, localpart = qname_str.split(":", 1)
         if prefix in element.nsmap:
@@ -410,7 +410,7 @@ def xml_qname_to_QualifiedName(
             elif ns_uri == PROV.uri:
                 ns = PROV
             else:
-                ns = Namespace(prefix, ns_uri)
+                ns = prov.identifier.Namespace(prefix, ns_uri)
             return ns[localpart]
     # case 1: no colon
     # case 2: unknown prefix
@@ -423,7 +423,7 @@ def xml_qname_to_QualifiedName(
             # here (unlike the prefixed branch above): doing so would change the
             # serialized output for previously-accepted documents, breaking the
             # 2.x output-compatibility promise.
-            ns = Namespace("", ns_uri)
+            ns = prov.identifier.Namespace("", ns_uri)
         return ns[qname_str]
     # no default namespace
     raise ProvXMLException(


### PR DESCRIPTION
## Summary
- Tightens annotations across `model.py`, `graph.py`, `dot.py`, the JSON/XML serializers, and the convert/compare scripts so `mypy --strict src` is clean everywhere except `serializers/provrdf.py` (a later step in the strict-mypy ratchet handles that file).
- Adds the PEP 484 explicit re-export idiom (`from prov.identifier import Identifier as Identifier, ...`) in `model.py` so the historically-public `prov.model.Identifier/QualifiedName/Namespace` re-exports satisfy `no_implicit_reexport`; internal modules that imported these via `prov.model` (`provxml.py`) now import from `prov.identifier` directly.
- Parametrises previously-bare generics (`set`, `tuple`, `dict`, `nx.MultiDiGraph`, `NamespaceManager(dict)`).
- Narrows or removes now-unnecessary `# type: ignore` comments (several were stale after the above fixes).
- Removes the `prov.scripts.convert` mypy override in `pyproject.toml`: the `dot.create()` return-type mismatch is now handled with a single documented `cast(bytes, ...)` instead of a blanket suppression.
- No runtime behaviour changes; no public API changes; `provrdf.py` untouched (left for the follow-up step).

## Test plan
- [x] `uv run mypy --strict src 2>&1 | grep -v provrdf | grep -c 'error:'` → 0
- [x] `uv run mypy src` → clean
- [x] `uv run pytest` → 953 passed, 17 xfailed
- [x] `uv run ruff check src/` → clean
- [x] `uv run ruff format --check src/` → clean