### PR TITLE
style: enable ruff comprehension rules (C4) and autofix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ select = [
     "F",   # pyflakes
     "W",   # pycodestyle warnings
     "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
     "I",   # isort (import sorting)
     "UP",  # pyupgrade (3.10-safe)
 ]

--- a/src/prov/constants.py
+++ b/src/prov/constants.py
@@ -172,6 +172,7 @@ PROV_RECORD_IDS_MAP = {
     PROV_N_MAP[rec_type_id]: rec_type_id for rec_type_id in PROV_N_MAP
 }
 PROV_ID_ATTRIBUTES_MAP = dict(PROV_RECORD_ATTRIBUTES)
+# inverse of PROV_ID_ATTRIBUTES_MAP: maps each attribute name back to its QName
 PROV_ATTRIBUTES_ID_MAP = {
     attribute: prov_id for (prov_id, attribute) in PROV_RECORD_ATTRIBUTES
 }

--- a/src/prov/constants.py
+++ b/src/prov/constants.py
@@ -166,17 +166,15 @@ PROV_ATTRIBUTE_LITERALS = {PROV_ATTR_TIME, PROV_ATTR_STARTTIME, PROV_ATTR_ENDTIM
 
 # Set of formal attributes of PROV records
 PROV_ATTRIBUTES = PROV_ATTRIBUTE_QNAMES | PROV_ATTRIBUTE_LITERALS
-PROV_RECORD_ATTRIBUTES = list((attr, str(attr)) for attr in PROV_ATTRIBUTES)
+PROV_RECORD_ATTRIBUTES = [(attr, str(attr)) for attr in PROV_ATTRIBUTES]
 
-PROV_RECORD_IDS_MAP = dict(
-    (PROV_N_MAP[rec_type_id], rec_type_id) for rec_type_id in PROV_N_MAP
-)
-PROV_ID_ATTRIBUTES_MAP = dict(
-    (prov_id, attribute) for (prov_id, attribute) in PROV_RECORD_ATTRIBUTES
-)
-PROV_ATTRIBUTES_ID_MAP = dict(
-    (attribute, prov_id) for (prov_id, attribute) in PROV_RECORD_ATTRIBUTES
-)
+PROV_RECORD_IDS_MAP = {
+    PROV_N_MAP[rec_type_id]: rec_type_id for rec_type_id in PROV_N_MAP
+}
+PROV_ID_ATTRIBUTES_MAP = dict(PROV_RECORD_ATTRIBUTES)
+PROV_ATTRIBUTES_ID_MAP = {
+    attribute: prov_id for (prov_id, attribute) in PROV_RECORD_ATTRIBUTES
+}
 
 # Extra definition for convenience
 PROV_TYPE = PROV["type"]

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -222,11 +222,11 @@ def prov_to_dot(
     def _bundle_to_dot(dot: pydot.Dot | pydot.Cluster, bundle: ProvBundle) -> None:
         def _attach_attribute_annotation(node: pydot.Node, record: ProvRecord) -> None:
             # Adding a node to show all attributes
-            attributes = list(
+            attributes = [
                 (attr_name, value)
                 for attr_name, value in record.attributes
                 if attr_name not in PROV_ATTRIBUTE_QNAMES
-            )
+            ]
 
             if not attributes:
                 return  # No attribute to display

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -72,7 +72,7 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
     """
     g: nx.MultiDiGraph[Any] = nx.MultiDiGraph()
     unified = prov_document.unified()
-    node_map: dict[QualifiedName | None, ProvRecord] = dict()
+    node_map: dict[QualifiedName | None, ProvRecord] = {}
     for element in unified.get_records(ProvElement):
         g.add_node(element)
         node_map[element.identifier] = element

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -119,7 +119,7 @@ class Namespace:
             raise ValueError("Not a valid URI to create a namespace.")
         self._prefix = prefix
         self._uri = uri
-        self._cache: dict[str, QualifiedName] = dict()
+        self._cache: dict[str, QualifiedName] = {}
 
     @property
     def uri(self) -> str:

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -1164,9 +1164,9 @@ class NamespaceManager(dict[str, Namespace]):
         self.parent = parent
         #  TODO check if default is in the default namespaces
         self._anon_id_count = 0
-        self._uri_map = dict()  # type: dict[str, Namespace]
-        self._rename_map = dict()  # type: dict[Namespace, Namespace]
-        self._prefix_renamed_map = dict()  # type: dict[str, Namespace]
+        self._uri_map = {}  # type: dict[str, Namespace]
+        self._rename_map = {}  # type: dict[Namespace, Namespace]
+        self._prefix_renamed_map = {}  # type: dict[str, Namespace]
         if namespaces is not None:
             self.add_namespaces(namespaces)
 
@@ -1399,7 +1399,7 @@ class ProvBundle:
         """
         #  Initializing bundle-specific attributes
         self._identifier = identifier
-        self._records = list()  # type: list[ProvRecord]
+        self._records = []  # type: list[ProvRecord]
         self._id_map = defaultdict(list)  # type: dict[QualifiedName, list[ProvRecord]]
         self._document = document
         self._namespaces = NamespaceManager(
@@ -1657,7 +1657,7 @@ class ProvBundle:
         """Returns a list of unified records."""
         # TODO: Check unification rules in the PROV-CONSTRAINTS document
         # This method simply merges the records having the same name
-        merged_records = dict()
+        merged_records = {}
         for _identifier, records in self._id_map.items():
             if len(records) > 1:
                 # more than one record having the same identifier
@@ -1673,7 +1673,7 @@ class ProvBundle:
             return list(self._records)
 
         added_merged_records = set()
-        unified_records = list()
+        unified_records = []
         for record in self._records:
             if record in merged_records:
                 merged = merged_records[record]
@@ -2528,7 +2528,7 @@ class ProvDocument(ProvBundle):
         ProvBundle.__init__(
             self, records=records, identifier=None, namespaces=namespaces
         )
-        self._bundles = dict()  # type: dict[QualifiedName, ProvBundle]
+        self._bundles = {}  # type: dict[QualifiedName, ProvBundle]
 
     def __repr__(self) -> str:
         return "<ProvDocument>"

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -169,9 +169,9 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
                         )
                     else:
                         # multiple values
-                        record_json[attr_name] = list(
+                        record_json[attr_name] = [
                             encode_json_representation(value) for value in values
-                        )
+                        ]
         # Check if the container already has the id of the record
         if identifier not in container[rec_label]:
             # this is the first instance, just put in the new record
@@ -190,7 +190,7 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
 
 
 def decode_json_document(content: ProvJSONDict, document: ProvDocument) -> None:
-    bundles = dict()
+    bundles = {}
     if "bundle" in content:
         bundles = content["bundle"]
         del content["bundle"]
@@ -224,7 +224,7 @@ def decode_json_container(jc: ProvJSONDict, bundle: ProvBundle) -> None:
                 elements = content
 
             for element in elements:
-                attributes = dict()  # type: dict[QualifiedNameCandidate, Any]
+                attributes = {}  # type: dict[QualifiedNameCandidate, Any]
                 other_attributes = []  # type: list[tuple[QualifiedNameCandidate, Any]]
                 # this is for the multiple-entity membership hack to come
                 membership_extra_members = None

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -24,9 +24,9 @@ logger = logging.getLogger(__name__)
 FULL_NAMES_MAP = dict(PROV_N_MAP)
 FULL_NAMES_MAP.update(ADDITIONAL_N_MAP)
 # Inverse mapping.
-FULL_PROV_RECORD_IDS_MAP = dict(
-    (FULL_NAMES_MAP[rec_type_id], rec_type_id) for rec_type_id in FULL_NAMES_MAP
-)
+FULL_PROV_RECORD_IDS_MAP = {
+    FULL_NAMES_MAP[rec_type_id]: rec_type_id for rec_type_id in FULL_NAMES_MAP
+}
 
 XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -39,7 +39,7 @@ def find_diff(g_rdf, g0_rdf):
                 0
             ]
             try:
-                all_match = all([g1_stmt[i].eq(g2_stmt[i]) for i in range(3)])
+                all_match = all(g1_stmt[i].eq(g2_stmt[i]) for i in range(3))
             except TypeError:
                 all_match = False
             if all_match:


### PR DESCRIPTION
## Summary
Enable flake8-comprehensions rules (family C4) in ruff configuration and apply the resulting autofixes.

- Added `"C4"` to `[tool.ruff.lint] select` in pyproject.toml
- Applied the 19 C4 autofixes across 8 source files (ruff marks these rewrites unsafe only on general principle — builtin shadowing / comprehension laziness — neither of which applies here):
  - `dict()` / `list()` → `{}` / `[]` literals (C408)
  - `list(x for x in y)` → `[x for x in y]` (C400)
  - `dict((k, v) for ...)` → `{k: v for ...}` (C402)
  - `all([...])` → `all(...)` (C419)

## Verification
- `ruff check src/` — All checks passed
- `ruff format --check src/` — 29 files already formatted
- `mypy src` — Success: no issues found in 14 source files
- `pytest -q` — 953 passed, 17 xfailed