### PR TITLE
style: enable ruff-specific rules (RUF) with reviewed fixes

### DIFF
--- a/docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md
+++ b/docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md
@@ -357,7 +357,7 @@ QualifiedName | None`) and a strict companion that raises instead of returning N
 **Rationale:** every caller currently re-derives "can this be None?" from folklore;
 two small functions with true signatures end that.
 
-### F5. Retire `walk()`'s untypeable sentinel
+### F5. ~~Retire `walk()`'s untypeable sentinel~~ — DONE early, in 2.x (PR #198)
 
 **Evidence:** `provrdf.py:736-739` — `path: dict[Any, Any] = None
 # type: ignore[assignment]`, with the "is this the first call?" test keyed on
@@ -365,12 +365,12 @@ two small functions with true signatures end that.
 workaround that cannot be typed honestly; the strict pass had to keep the ignore
 because switching the guard to `path is None` would (theoretically) change behaviour.
 
-**Change (3.0):** internal helper — retype as `path: dict[Any, Any] | None = None`
-with a `path is None` guard, or fold the recursion's seed into a small wrapper
-function. Also parametrise properly once A1's value union exists.
-
-**Rationale:** the current shape needs a permanent ignore *and* a paragraph of
-explanation; the fixed shape needs neither.
+**Resolution (2026-07-04, PR #198):** the RUF-family lint task (RUF013) retyped it as
+`path: dict[Any, Any] | None = None` with a `path is None` guard after proving the
+invariant "`path is None` ⟺ `level == 0`" holds at every call site in the repo
+(one external call using both defaults; the recursive call always passes a non-None
+path with level ≥ 1). `walk()` is an internal helper, so no API-freeze concern.
+Remaining for 3.0: only the `Any` parametrisation once A1's value union exists.
 
 ---
 
@@ -397,8 +397,9 @@ explanation; the fixed shape needs neither.
    serialize + URL print-path), E1 (star re-export, docs-level); add `GenerationRef`
    alias next to the B3 typo.
 2. **3.0, first wave (mechanical):** B3 removal, C3 honest returns, C4 identifier
-   narrowing, C2 typed factories, F2 dead-code deletion, F3 identifier invariant,
-   F5 walk() sentinel — internal, low-risk, delete most remaining casts/ignores.
+   narrowing, C2 typed factories, F2 dead-code deletion, F3 identifier invariant
+   — internal, low-risk, delete most remaining casts/ignores. (F5's walk() sentinel
+   already landed in 2.x via PR #198.)
 3. **3.0, second wave (design):** A1→A2→A3 as one arc (value model), then B1+F4
    (coercion point with honest None contracts), C1 (NamespaceManager), D1/D2+F1
    (I/O split and non-optional serializer document), E2 (TC lint rules last) — each

--- a/docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md
+++ b/docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md
@@ -370,7 +370,14 @@ because switching the guard to `path is None` would (theoretically) change behav
 invariant "`path is None` ⟺ `level == 0`" holds at every call site in the repo
 (one external call using both defaults; the recursive call always passes a non-None
 path with level ≥ 1). `walk()` is an internal helper, so no API-freeze concern.
-Remaining for 3.0: only the `Any` parametrisation once A1's value union exists.
+Remaining for 3.0:
+- the `Any` parametrisation once A1's value union exists;
+- `level`/`usename=False` are vestigial — no caller ever passes `usename=False`, so
+  the `path[level] = child` branch is dead in practice; drop both or document why
+  they stay (found during PR #198's quality review);
+- the function's doctest has been broken since inception (`for child in func:`
+  iterates the lambda instead of calling it) and doctests aren't wired into pytest —
+  fix or delete it when the function is reworked.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ select = [
     "I",   # isort (import sorting)
     "SIM", # flake8-simplify
     "UP",  # pyupgrade (3.10-safe)
+    "RUF", # ruff-specific rules
 ]
 ignore = [
     "E203",  # whitespace before ':' (black/ruff-format compatible)

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -570,9 +570,10 @@ class ProvRecord:
 
         # Writing out the formal attributes
         for attr in self.FORMAL_ATTRIBUTES:
-            if attr in self._attributes and self._attributes[attr]:
+            values = self._attributes.get(attr)
+            if values:
                 # Formal attributes always have single values
-                value = first(self._attributes[attr])
+                value = first(values)
                 # TODO: QName export
                 items.append(
                     value.isoformat()
@@ -2749,7 +2750,7 @@ class ProvDocument(ProvBundle):
             serializer.serialize(stream, **args)
         else:
             location = str(destination)
-            scheme, netloc, path, params, _query, fragment = urlparse(location)
+            _scheme, netloc, path, _params, _query, _fragment = urlparse(location)
             if netloc != "":
                 print(
                     "WARNING: not saving as location " + "is not a local file reference"

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
 
-__all__ = ["get", "Registry", "Serializer"]
+__all__ = ["Registry", "Serializer", "get"]
 
 
 class Serializer(ABC):

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -700,7 +700,7 @@ class ProvRDFSerializer(Serializer):
             local_key = str(obj)
             if local_key in record_types and "qualified" in pred:
                 formal_attributes[local_key][
-                    list(formal_attributes[local_key].keys())[0]
+                    next(iter(formal_attributes[local_key].keys()))
                 ] = subj
         for subj in record_types:
             attrs = None
@@ -737,7 +737,7 @@ class ProvRDFSerializer(Serializer):
 def walk(
     children: list[tuple[Any, Any]],
     level: int = 0,
-    path: dict[Any, Any] = None,  # type: ignore[assignment]
+    path: dict[Any, Any] | None = None,
     usename: bool = True,
 ) -> Generator[dict[Any, Any]]:
     """Generate all the full paths in a tree, as a dict.
@@ -752,7 +752,7 @@ def walk(
     [3, 4, 3, 4]
     """
     # Entry point
-    if level == 0:
+    if path is None:
         path = {}
 
     # Exit condition

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 import prov
 import prov.identifier
-from prov.constants import *  # NOQA
+from prov.constants import *
 from prov.model import DEFAULT_NAMESPACES, sorted_attributes
 from prov.serializers import Serializer
 

--- a/src/prov/tests/attributes.py
+++ b/src/prov/tests/attributes.py
@@ -1,3 +1,5 @@
+from typing import Any, ClassVar
+
 from prov.model import *
 
 EX_NS = Namespace("ex", "http://example.org/")
@@ -10,7 +12,7 @@ class TestAttributesBase:
     RoundTripTestCase.
     """
 
-    attribute_values = [
+    attribute_values: ClassVar[list[Any]] = [
         "un lieu",
         Literal("un lieu", langtag="fr"),
         Literal("a place", langtag="en"),

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -30,14 +30,14 @@ def find_diff(g_rdf, g0_rdf):
         graphs_equal = False
     matching_indices = [[], []]
     for idx in range(len(g1)):
-        g1_stmt = list(rl.ConjunctiveGraph().parse(BytesIO(g1[idx]), format="nt"))[0]
+        g1_stmt = next(iter(rl.ConjunctiveGraph().parse(BytesIO(g1[idx]), format="nt")))
         match_found = False
         for idx2 in range(len(g2)):
             if idx2 in matching_indices[1]:
                 continue
-            g2_stmt = list(rl.ConjunctiveGraph().parse(BytesIO(g2[idx2]), format="nt"))[
-                0
-            ]
+            g2_stmt = next(
+                iter(rl.ConjunctiveGraph().parse(BytesIO(g2[idx2]), format="nt"))
+            )
             try:
                 all_match = all(g1_stmt[i].eq(g2_stmt[i]) for i in range(3))
             except TypeError:
@@ -268,7 +268,7 @@ class TestRDFSerializer(unittest.TestCase):
                     format=format,
                 )
                 if idx not in skip_match:
-                    match, _, in_first, in_second = find_diff(g_rdf, g0_rdf)
+                    match, _, _in_first, _in_second = find_diff(g_rdf, g0_rdf)
                     self.assertTrue(match)
                 else:
                     logger.info("Skipping match: %s" % fname)

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -362,7 +362,7 @@ class ProvXMLTestCase(unittest.TestCase):
           </entity>
         </document>"""
         document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
-        entity = list(document.get_records(prov.ProvEntity))[0]
+        entity = next(iter(document.get_records(prov.ProvEntity)))
         # the <value> element is in the default (PROV) namespace:
         # it must parse as prov:value, not "None:value"
         values = list(entity.get_attribute(PROV["value"]))
@@ -386,7 +386,7 @@ class ProvXMLTestCase(unittest.TestCase):
           </prov:entity>
         </prov:document>"""
         document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
-        entity = list(document.get_records(prov.ProvEntity))[0]
+        entity = next(iter(document.get_records(prov.ProvEntity)))
         values = list(entity.get_attribute(PROV["value"]))
         self.assertEqual(values, [1])
 


### PR DESCRIPTION
## Summary

Adds `"RUF"` (ruff-specific rules) to the `[tool.ruff.lint] select` list and resolves all 15 findings by hand — no blind autofix, no new suppressions.

## Findings

| Rule | Location | Resolution | Justification |
|---|---|---|---|
| RUF019 | `src/prov/model.py:573` | `if attr in self._attributes and self._attributes[attr]:` → `values = self._attributes.get(attr); if values:` | `_attributes` is a `defaultdict(set)`; `.get()` avoids the redundant double lookup without changing autovivification behaviour (the `in` check already prevented it). |
| RUF059 | `src/prov/model.py:2752` | `scheme, netloc, path, params, _query, fragment = urlparse(...)` → prefix unused names with `_` | Only `netloc`/`path` are read; the rest were always discarded. |
| RUF022 | `src/prov/serializers/__init__.py:15` | `__all__ = ["get", "Registry", "Serializer"]` → `["Registry", "Serializer", "get"]` | Cosmetic isort-style ordering; no behaviour change. |
| RUF015 | `src/prov/serializers/provrdf.py:703` | `list(...keys())[0]` → `next(iter(...keys()))` | Avoids materialising the full list to take the first item; same value returned. |
| RUF013 | `src/prov/serializers/provrdf.py:740` | `path: dict[Any, Any] = None  # type: ignore[assignment]` → `path: dict[Any, Any] \| None = None`; the `if level == 0: path = {}` init guard changed to `if path is None: path = {}` | Makes the implicit-`Optional` explicit and removes the `type: ignore`. `walk()` is only ever called externally with the (`level=0`, `path=None`) defaults and recursively with an explicit non-None `path`, so gating the `{}` init on `path is None` is behaviourally identical and lets strict mypy narrow `path` to `dict` for the rest of the function. |
| RUF100 | `src/prov/serializers/provxml.py:13` | Removed `# NOQA` from `from prov.constants import *` | Redundant: `pyproject.toml` already carries a per-file-ignore for `F403`/`F405` on this module. Verified by removing and re-running `ruff check` — clean. |
| RUF012 | `src/prov/tests/attributes.py:13` | `attribute_values = [...]` → `attribute_values: ClassVar[list[Any]] = [...]` | Annotation-only; grepped for reassignment — it is only ever read via `self.attribute_values[n]`, never written, so `ClassVar` is true. This module is under `src/prov/tests/`, which is excluded from the mypy run, so it doesn't interact with strict mypy. |
| RUF015 | `src/prov/tests/test_rdf.py:33,38` | `list(...)[0]` → `next(iter(...))` | Same single-element-slice simplification as above. |
| RUF059 | `src/prov/tests/test_rdf.py:271` | `match, _, in_first, in_second = find_diff(...)` → prefix unused names with `_` | Both are discarded after unpacking. |
| RUF015 | `src/prov/tests/test_xml.py:365,389` | `list(document.get_records(...))[0]` → `next(iter(document.get_records(...)))` | Same simplification; `get_records` returns a generator so this also avoids building the full list. |

No RUF005 (list-concatenation) findings occurred in this codebase, and no new `# noqa` suppressions were needed — every finding had a clean, behaviour-preserving fix.

## Verification

- `uv run ruff check src/` → All checks passed!
- `uv run ruff format --check src/` → 29 files already formatted
- `uv run mypy src` → Success: no issues found in 14 source files
- `uv run pytest -q` → `953 passed, 17 xfailed`

Public API unchanged (only internal implementation details and test helpers touched).

## Test plan
- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`
- [x] `uv run mypy src`
- [x] `uv run pytest -q`