### PR TITLE
style: modernise Optional annotations and printf formatting (UP045/UP031)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,6 @@ select = [
 ignore = [
     "E203",  # whitespace before ':' (black/ruff-format compatible)
     "E501",  # line length handled by the formatter
-    # These two pyupgrade rules only offer *unsafe* fixes when targeting py39
-    # (ruff can't prove nothing relies on runtime evaluation of the old
-    # syntax, e.g. via typing.get_type_hints()), so they fire on almost every
-    # annotated/`%`-formatted line in the project without an autofix.
-    # Deferred to a dedicated follow-up rather than mass hand-editing here.
-    "UP045",  # non-pep604-annotation-optional (`Optional[X]` -> `X | None`)
-    "UP031",  # printf-string-formatting (`%` -> `.format()`/f-string)
 ]
 
 [tool.ruff.lint.isort]

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -16,7 +16,7 @@ from __future__ import annotations  # needed for | type annotations in Python < 
 
 from datetime import datetime
 from html import escape
-from typing import Any, Optional
+from typing import Any
 
 import pydot
 
@@ -91,7 +91,7 @@ GENERIC_NODE_STYLE = {
         "fillcolor": "lightgray",
         "color": "dimgray",
     },
-}  # type: dict[Optional[type[ProvElement | ProvBundle]], dict[str, Any]]
+}  # type: dict[type[ProvElement | ProvBundle] | None, dict[str, Any]]
 # Value type is widened to Any (rather than str) because mypy treats a
 # dict[str, str] unpacked via `**style` as needing to satisfy *every*
 # named parameter pydot.Node/Edge/Cluster declare (e.g. `obj_dict`), not
@@ -182,7 +182,7 @@ ANNOTATION_END_ROW = "    </TABLE>>"
 def htlm_link_if_uri(value: Any) -> str:
     try:
         uri = value.uri
-        return '<a href="%s">%s</a>' % (uri, str(value))
+        return f'<a href="{uri}">{value!s}</a>'
     except AttributeError:
         return str(value)
 
@@ -240,7 +240,7 @@ def prov_to_dot(
                 % (
                     attr.uri,
                     escape(str(attr)),
-                    ' href="%s"' % value.uri if isinstance(value, Identifier) else "",
+                    f' href="{value.uri}"' if isinstance(value, Identifier) else "",
                     escape(
                         str(value)
                         if not isinstance(value, datetime)
@@ -252,7 +252,7 @@ def prov_to_dot(
             ann_rows.append(ANNOTATION_END_ROW)
             count[3] += 1
             annotations = pydot.Node(
-                "ann%d" % count[3], label="\n".join(ann_rows), **ANNOTATION_STYLE
+                f"ann{count[3]}", label="\n".join(ann_rows), **ANNOTATION_STYLE
             )
             dot.add_node(annotations)
             dot.add_edge(pydot.Edge(annotations, node, **ANNOTATION_LINK_STYLE))
@@ -260,13 +260,13 @@ def prov_to_dot(
         def _add_bundle(bundle: ProvBundle) -> pydot.Cluster:
             count[2] += 1
             subdot = pydot.Cluster(
-                graph_name="c%d" % count[2],
+                graph_name=f"c{count[2]}",
                 URL=f'"{bundle.identifier.uri}"',  # type: ignore[union-attr]
             )
             # set_label is generated at runtime by pydot via setattr() for
             # every Graphviz attribute (see pydot.core.__generate_attribute_methods),
             # so it exists on Cluster instances but isn't visible to mypy.
-            subdot.set_label('"%s"' % str(bundle.identifier))  # type: ignore[attr-defined]
+            subdot.set_label(f'"{bundle.identifier!s}"')  # type: ignore[attr-defined]
             _bundle_to_dot(subdot, bundle)
             # pydot types Graph.add_subgraph() as accepting only a Subgraph,
             # but Cluster (a Graph subclass, not a Subgraph subclass) is the
@@ -276,7 +276,7 @@ def prov_to_dot(
 
         def _add_node(record: ProvRecord) -> pydot.Node:
             count[0] += 1
-            node_id = "n%d" % count[0]
+            node_id = f"n{count[0]}"
             if use_labels:
                 if record.label == record.identifier:
                     node_label = f'"{record.label}"'
@@ -294,7 +294,7 @@ def prov_to_dot(
 
             uri = record.identifier.uri  # type: ignore[union-attr]
             style = DOT_PROV_STYLE[record.get_type()]
-            node = pydot.Node(node_id, label=node_label, URL='"%s"' % uri, **style)
+            node = pydot.Node(node_id, label=node_label, URL=f'"{uri}"', **style)
             node_map[uri] = node
             dot.add_node(node)
 
@@ -303,29 +303,29 @@ def prov_to_dot(
             return node
 
         def _add_generic_node(
-            qname: QualifiedName, prov_type: Optional[type[ProvElement]] = None
+            qname: QualifiedName, prov_type: type[ProvElement] | None = None
         ) -> pydot.Node:
             count[0] += 1
-            node_id = "n%d" % count[0]
+            node_id = f"n{count[0]}"
             node_label = f'"{qname}"'
 
             uri = qname.uri
             style = GENERIC_NODE_STYLE[prov_type] if prov_type else DOT_PROV_STYLE[0]
-            node = pydot.Node(node_id, label=node_label, URL='"%s"' % uri, **style)
+            node = pydot.Node(node_id, label=node_label, URL=f'"{uri}"', **style)
             node_map[uri] = node
             dot.add_node(node)
             return node
 
         def _get_bnode() -> pydot.Node:
             count[1] += 1
-            bnode_id = "b%d" % count[1]
+            bnode_id = f"b{count[1]}"
             bnode = pydot.Node(bnode_id, label='""', shape="point", color="gray")
             dot.add_node(bnode)
             return bnode
 
         def _get_node(
-            qname: Optional[QualifiedName],
-            prov_type: Optional[type[ProvElement]] = None,
+            qname: QualifiedName | None,
+            prov_type: type[ProvElement] | None = None,
         ) -> pydot.Node:
             if qname is None:
                 return _get_bnode()

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -40,7 +40,7 @@ class Identifier:
         return hash((self.uri, self.__class__))
 
     def __repr__(self) -> str:
-        return "<%s: %s>" % (self.__class__.__name__, self._uri)
+        return f"<{self.__class__.__name__}: {self._uri}>"
 
     def provn_representation(self) -> str:
         """
@@ -49,7 +49,7 @@ class Identifier:
         Returns:
             str: The PROV-N representation of the URI.
         """
-        return '"%s" %%%% xsd:anyURI' % self._uri
+        return f'"{self._uri}" %% xsd:anyURI'
 
 
 class QualifiedName(Identifier):
@@ -95,14 +95,14 @@ class QualifiedName(Identifier):
         return self._str
 
     def __repr__(self) -> str:
-        return "<%s: %s>" % (self.__class__.__name__, self._str)
+        return f"<{self.__class__.__name__}: {self._str}>"
 
     def __hash__(self) -> int:
         return hash(self.uri)
 
     def provn_representation(self) -> str:
         """PROV-N representation of qualified name in a string."""
-        return "'%s'" % self._str
+        return f"'{self._str}'"
 
 
 class Namespace:
@@ -181,7 +181,7 @@ class Namespace:
         return hash((self._uri, self._prefix))
 
     def __repr__(self) -> str:
-        return "<%s: %s {%s}>" % (self.__class__.__name__, self._prefix, self._uri)
+        return f"<{self.__class__.__name__}: {self._prefix} {{{self._uri}}}>"
 
     def __getitem__(self, localpart: str) -> QualifiedName:
         if localpart in self._cache:

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -22,7 +22,6 @@ from collections.abc import Callable, Iterable
 from io import IOBase
 from typing import (
     Any,
-    Optional,
     Union,
 )
 from urllib.parse import urlparse
@@ -46,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 # Type aliases for convenience
 QualifiedNameCandidate = QualifiedName | str | Identifier  # type: typing.TypeAlias
-OptionalID = Optional[QualifiedNameCandidate]  # type: typing.TypeAlias
+OptionalID = QualifiedNameCandidate | None  # type: typing.TypeAlias
 EntityRef = Union["ProvEntity", QualifiedNameCandidate]  # type: typing.TypeAlias
 ActivityRef = Union["ProvActivity", QualifiedNameCandidate]  # type: typing.TypeAlias
 AgentRef = Union["ProvAgent", "ProvEntity", "ProvActivity", QualifiedNameCandidate]  # type: typing.TypeAlias
@@ -62,14 +61,14 @@ PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
 
 
 # Data Types
-def _ensure_datetime(value: Optional[DatetimeOrStr]) -> Optional[datetime.datetime]:
+def _ensure_datetime(value: DatetimeOrStr | None) -> datetime.datetime | None:
     if isinstance(value, str):
         return dateutil.parser.parse(value)
     else:
         return value
 
 
-def parse_xsd_datetime(value: str) -> Optional[datetime.datetime]:
+def parse_xsd_datetime(value: str) -> datetime.datetime | None:
     try:
         return dateutil.parser.parse(value)
     except ValueError:
@@ -77,7 +76,7 @@ def parse_xsd_datetime(value: str) -> Optional[datetime.datetime]:
     return None
 
 
-def parse_boolean(value: str) -> Optional[bool]:
+def parse_boolean(value: str) -> bool | None:
     if value.lower() in ("false", "0"):
         return False
     elif value.lower() in ("true", "1"):
@@ -124,9 +123,9 @@ def _ensure_multiline_string_triple_quoted(value: str) -> str:
     # Escaping any double quote
     s = s.replace('"', '\\"')
     if "\n" in s:
-        return '"""%s"""' % s
+        return f'"""{s}"""'
     else:
-        return '"%s"' % s
+        return f'"{s}"'
 
 
 def encoding_provn_value(
@@ -137,9 +136,9 @@ def encoding_provn_value(
     elif isinstance(value, datetime.datetime):
         return f'"{value.isoformat()}" %% xsd:dateTime'
     elif isinstance(value, float):
-        return '"%g" %%%% xsd:float' % value
+        return f'"{value:g}" %% xsd:float'
     elif isinstance(value, bool):
-        return '"%i" %%%% xsd:boolean' % value
+        return f'"{value:d}" %% xsd:boolean'
     else:
         # TODO: QName export
         return str(value)
@@ -149,15 +148,15 @@ class Literal:
     def __init__(
         self,
         value: Any,
-        datatype: Optional[QualifiedName] = None,
-        langtag: Optional[str] = None,
+        datatype: QualifiedName | None = None,
+        langtag: str | None = None,
     ):
         self._value: str = str(value)  # value is always a string
         if langtag:
             if datatype is None:
                 logger.debug(
                     "Assuming prov:InternationalizedString as the type of "
-                    '"%s"@%s' % (value, langtag)
+                    f'"{value}"@{langtag}'
                 )
                 datatype = PROV_INTERNATIONALIZEDSTRING
             # PROV JSON states that the type field must not be set when
@@ -165,19 +164,19 @@ class Literal:
             # internationalized string.
             elif datatype != PROV_INTERNATIONALIZEDSTRING:
                 logger.warning(
-                    'Invalid data type (%s) for "%s"@%s, overridden as '
-                    "prov:InternationalizedString." % (datatype, value, langtag)
+                    f'Invalid data type ({datatype}) for "{value}"@{langtag}, overridden as '
+                    "prov:InternationalizedString."
                 )
                 datatype = PROV_INTERNATIONALIZEDSTRING
-        self._datatype: Optional[QualifiedName] = datatype
+        self._datatype: QualifiedName | None = datatype
         # langtag is always a string
-        self._langtag: Optional[str] = str(langtag) if langtag is not None else None
+        self._langtag: str | None = str(langtag) if langtag is not None else None
 
     def __str__(self) -> str:
         return self.provn_representation()
 
     def __repr__(self) -> str:
-        return "<Literal: %s>" % self.provn_representation()
+        return f"<Literal: {self.provn_representation()}>"
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -214,15 +213,9 @@ class Literal:
     def provn_representation(self) -> str:
         if self._langtag:
             # a language tag can only go with prov:InternationalizedString
-            return "%s@%s" % (
-                _ensure_multiline_string_triple_quoted(self._value),
-                str(self._langtag),
-            )
+            return f"{_ensure_multiline_string_triple_quoted(self._value)}@{self._langtag!s}"
         else:
-            return "%s %%%% %s" % (
-                _ensure_multiline_string_triple_quoted(self._value),
-                str(self._datatype),
-            )
+            return f"{_ensure_multiline_string_triple_quoted(self._value)} %% {self._datatype!s}"
 
 
 # Exceptions and warnings
@@ -253,7 +246,7 @@ class ProvExceptionInvalidQualifiedName(ProvException):
         self.qname = qname
 
     def __str__(self) -> str:
-        return "Invalid Qualified Name: %s" % self.qname
+        return f"Invalid Qualified Name: {self.qname}"
 
 
 class ProvElementIdentifierRequired(ProvException):
@@ -270,14 +263,14 @@ class ProvRecord:
     FORMAL_ATTRIBUTES = ()  # type: tuple[QualifiedName, ...]
     """Formal attributes names of this record type, in the expected order."""
 
-    _prov_type: Optional[QualifiedName] = None
+    _prov_type: QualifiedName | None = None
     """PROV type of record."""
 
     def __init__(
         self,
         bundle: ProvBundle,
-        identifier: Optional[QualifiedName],
-        attributes: Optional[RecordAttributesArg] = None,
+        identifier: QualifiedName | None,
+        attributes: RecordAttributesArg | None = None,
     ):
         """
         Constructor.
@@ -506,7 +499,7 @@ class ProvRecord:
 
                 if value is None:
                     raise ProvException(
-                        "Invalid value for attribute %s: %s" % (attr, original_value)
+                        f"Invalid value for attribute {attr}: {original_value}"
                     )
 
                 if (
@@ -529,7 +522,7 @@ class ProvRecord:
 
                     if is_not_same_value:
                         raise ProvException(
-                            "Cannot have more than one value for attribute %s" % attr
+                            f"Cannot have more than one value for attribute {attr}"
                         )
                     else:
                         # Same value, ignore it
@@ -594,11 +587,11 @@ class ProvRecord:
                     except AttributeError:
                         provn_represenation = encoding_provn_value(value)
                     # TODO: QName export
-                    extra.append("%s=%s" % (str(attr), provn_represenation))
+                    extra.append(f"{attr!s}={provn_represenation}")
 
         if extra:
-            items.append("[%s]" % ", ".join(extra))
-        prov_n = "%s(%s%s)" % (
+            items.append("[{}]".format(", ".join(extra)))
+        prov_n = "{}({}{})".format(
             PROV_N_MAP[self.get_type()],
             relation_id,
             ", ".join(items),
@@ -629,8 +622,8 @@ class ProvElement(ProvRecord):
     def __init__(
         self,
         bundle: ProvBundle,
-        identifier: Optional[QualifiedName],
-        attributes: Optional[RecordAttributesArg] = None,
+        identifier: QualifiedName | None,
+        attributes: RecordAttributesArg | None = None,
     ):
         if identifier is None:
             # All types of PROV elements require a valid identifier
@@ -647,7 +640,7 @@ class ProvElement(ProvRecord):
         return True
 
     def __repr__(self) -> str:
-        return "<%s: %s>" % (self.__class__.__name__, self._identifier)
+        return f"<{self.__class__.__name__}: {self._identifier}>"
 
 
 class ProvRelation(ProvRecord):
@@ -662,14 +655,9 @@ class ProvRelation(ProvRecord):
         return True
 
     def __repr__(self) -> str:
-        identifier = " %s" % self._identifier if self._identifier else ""
+        identifier = f" {self._identifier}" if self._identifier else ""
         element_1, element_2 = [qname for _, qname in self.formal_attributes[:2]]
-        return "<%s:%s (%s, %s)>" % (
-            self.__class__.__name__,
-            identifier,
-            element_1,
-            element_2,
-        )
+        return f"<{self.__class__.__name__}:{identifier} ({element_1}, {element_2})>"
 
 
 # Component 1: Entities and Activities
@@ -682,9 +670,9 @@ class ProvEntity(ProvElement):
     # (formal) argument
     def wasGeneratedBy(
         self,
-        activity: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        activity: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvEntity:
         """
         Creates a new generation record to this entity.
@@ -702,9 +690,9 @@ class ProvEntity(ProvElement):
 
     def wasInvalidatedBy(
         self,
-        activity: Optional[ActivityRef],
-        time: Optional[DatetimeOrStr] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        activity: ActivityRef | None,
+        time: DatetimeOrStr | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvEntity:
         """
         Creates a new invalidation record for this entity.
@@ -723,10 +711,10 @@ class ProvEntity(ProvElement):
     def wasDerivedFrom(
         self,
         usedEntity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        generation: Optional[GenrationRef] = None,
-        usage: Optional[UsageRef] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvEntity:
         """
         Creates a new derivation record for this entity from a used entity.
@@ -747,7 +735,7 @@ class ProvEntity(ProvElement):
         return self
 
     def wasAttributedTo(
-        self, agent: AgentRef, attributes: Optional[RecordAttributesArg] = None
+        self, agent: AgentRef, attributes: RecordAttributesArg | None = None
     ) -> ProvEntity:
         """
         Creates a new attribution record between this entity and an agent.
@@ -798,8 +786,8 @@ class ProvActivity(ProvElement):
     #  Convenient methods
     def set_time(
         self,
-        startTime: Optional[datetime.datetime] = None,
-        endTime: Optional[datetime.datetime] = None,
+        startTime: datetime.datetime | None = None,
+        endTime: datetime.datetime | None = None,
     ) -> None:
         """
         Sets the time this activity took place.
@@ -839,8 +827,8 @@ class ProvActivity(ProvElement):
     def used(
         self,
         entity: EntityRef,
-        time: Optional[DatetimeOrStr] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        time: DatetimeOrStr | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvActivity:
         """
         Creates a new usage record for this activity.
@@ -857,7 +845,7 @@ class ProvActivity(ProvElement):
         return self
 
     def wasInformedBy(
-        self, informant: ActivityRef, attributes: Optional[RecordAttributesArg] = None
+        self, informant: ActivityRef, attributes: RecordAttributesArg | None = None
     ) -> ProvActivity:
         """
         Creates a new communication record for this activity.
@@ -871,10 +859,10 @@ class ProvActivity(ProvElement):
 
     def wasStartedBy(
         self,
-        trigger: Optional[EntityRef],
-        starter: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        trigger: EntityRef | None,
+        starter: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvActivity:
         """
         Creates a new start record for this activity. The activity did not exist
@@ -895,10 +883,10 @@ class ProvActivity(ProvElement):
 
     def wasEndedBy(
         self,
-        trigger: Optional[EntityRef],
-        ender: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        trigger: EntityRef | None,
+        ender: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvActivity:
         """
         Creates a new end record for this activity.
@@ -918,8 +906,8 @@ class ProvActivity(ProvElement):
     def wasAssociatedWith(
         self,
         agent: AgentRef,
-        plan: Optional[EntityRef] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        plan: EntityRef | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvActivity:
         """
         Creates a new association record for this activity.
@@ -1019,8 +1007,8 @@ class ProvAgent(ProvElement):
     def actedOnBehalfOf(
         self,
         responsible: AgentRef,
-        activity: Optional[ActivityRef] = None,
-        attributes: Optional[RecordAttributesArg] = None,
+        activity: ActivityRef | None = None,
+        attributes: RecordAttributesArg | None = None,
     ) -> ProvAgent:
         """
         Creates a new delegation record on behalf of this agent.
@@ -1140,14 +1128,14 @@ DEFAULT_NAMESPACES = {"prov": PROV, "xsd": XSD, "xsi": XSI}
 class NamespaceManager(dict[str, Namespace]):
     """Manages namespaces for PROV documents and bundles."""
 
-    parent = None  # type: Optional[NamespaceManager]
+    parent = None  # type: NamespaceManager | None
     """Parent :py:class:`NamespaceManager` this manager one is a child of."""
 
     def __init__(
         self,
-        namespaces: Optional[NSCollection] = None,
-        default: Optional[str] = None,
-        parent: Optional[NamespaceManager] = None,
+        namespaces: NSCollection | None = None,
+        default: str | None = None,
+        parent: NamespaceManager | None = None,
     ):
         """
         Constructor.
@@ -1166,7 +1154,7 @@ class NamespaceManager(dict[str, Namespace]):
         if default is not None:
             self.set_default_namespace(default)
         else:
-            self._default = None  # type: Optional[Namespace]
+            self._default = None  # type: Namespace | None
         self.parent = parent
         #  TODO check if default is in the default namespaces
         self._anon_id_count = 0
@@ -1369,7 +1357,7 @@ class NamespaceManager(dict[str, Namespace]):
         :return: :py:class:`~prov.identifier.Identifier`
         """
         self._anon_id_count += 1
-        return Identifier("_:%s%d" % (local_prefix, self._anon_id_count))
+        return Identifier(f"_:{local_prefix}{self._anon_id_count}")
 
     def _get_unused_prefix(self, original_prefix: str) -> str:
         if original_prefix not in self:
@@ -1388,10 +1376,10 @@ class ProvBundle:
 
     def __init__(
         self,
-        records: Optional[Iterable[ProvRecord]] = None,
-        identifier: Optional[QualifiedName] = None,
-        namespaces: Optional[NSCollection] = None,
-        document: Optional[ProvDocument] = None,
+        records: Iterable[ProvRecord] | None = None,
+        identifier: QualifiedName | None = None,
+        namespaces: NSCollection | None = None,
+        document: ProvDocument | None = None,
     ):
         """
         Constructor.
@@ -1416,7 +1404,7 @@ class ProvBundle:
                 self.add_record(record)
 
     def __repr__(self) -> str:
-        return "<%s: %s>" % (self.__class__.__name__, self._identifier)
+        return f"<{self.__class__.__name__}: {self._identifier}>"
 
     @property
     def namespaces(self) -> set[Namespace]:
@@ -1478,7 +1466,7 @@ class ProvBundle:
         return self._namespaces.get_default_namespace()
 
     def add_namespace(
-        self, namespace_or_prefix: Namespace | str, uri: Optional[str] = None
+        self, namespace_or_prefix: Namespace | str, uri: str | None = None
     ) -> Namespace:
         """
         Adds a namespace (if not available, yet).
@@ -1508,7 +1496,7 @@ class ProvBundle:
 
     def valid_qualified_name(
         self, identifier: QualifiedNameCandidate
-    ) -> Optional[QualifiedName]:
+    ) -> QualifiedName | None:
         return self._namespaces.valid_qualified_name(identifier)
 
     def mandatory_valid_qname(
@@ -1525,7 +1513,7 @@ class ProvBundle:
             raise ProvExceptionInvalidQualifiedName(identifier)
 
     def get_records(
-        self, class_or_type_or_tuple: Optional[type | tuple[type]] = None
+        self, class_or_type_or_tuple: type | tuple[type] | None = None
     ) -> Iterable[ProvRecord]:
         """
         Returns all records. Returned records may be filtered by the optional
@@ -1597,17 +1585,17 @@ class ProvBundle:
 
         #  if this is the document, start the document;
         # otherwise, start the bundle
-        lines = ["document"] if self.is_document() else ["bundle %s" % self._identifier]
+        lines = ["document"] if self.is_document() else [f"bundle {self._identifier}"]
 
         default_namespace = self._namespaces.get_default_namespace()
         if default_namespace:
-            lines.append("default <%s>" % default_namespace.uri)
+            lines.append(f"default <{default_namespace.uri}>")
 
         registered_namespaces = self._namespaces.get_registered_namespaces()
         if registered_namespaces:
             lines.extend(
                 [
-                    "prefix %s <%s>" % (namespace.prefix, namespace.uri)
+                    f"prefix {namespace.prefix} <{namespace.uri}>"
                     for namespace in registered_namespaces
                 ]
             )
@@ -1721,7 +1709,7 @@ class ProvBundle:
         else:
             raise ProvException(
                 "ProvBundle.update(): The other bundle is not a ProvBundle "
-                "instance (%s)" % type(other)
+                f"instance ({type(other)})"
             )
 
     # Provenance statements
@@ -1737,8 +1725,8 @@ class ProvBundle:
         self,
         record_type: QualifiedName,
         identifier: OptionalID,
-        attributes: Optional[RecordAttributesArg] = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        attributes: RecordAttributesArg | None = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvRecord:
         """
         Creates a new record.
@@ -1786,7 +1774,7 @@ class ProvBundle:
     def entity(
         self,
         identifier: QualifiedNameCandidate,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvEntity:
         """
         Creates a new entity.
@@ -1800,9 +1788,9 @@ class ProvBundle:
     def activity(
         self,
         identifier: QualifiedNameCandidate,
-        startTime: Optional[DatetimeOrStr] = None,
-        endTime: Optional[DatetimeOrStr] = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        startTime: DatetimeOrStr | None = None,
+        endTime: DatetimeOrStr | None = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvActivity:
         """
         Creates a new activity.
@@ -1831,10 +1819,10 @@ class ProvBundle:
     def generation(
         self,
         entity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
+        activity: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvRecord:
         """
         Creates a new generation record for an entity.
@@ -1864,10 +1852,10 @@ class ProvBundle:
     def usage(
         self,
         activity: ActivityRef,
-        entity: Optional[EntityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
+        entity: EntityRef | None = None,
+        time: DatetimeOrStr | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvUsage:
         """
         Creates a new usage record for an activity.
@@ -1897,11 +1885,11 @@ class ProvBundle:
     def start(
         self,
         activity: ActivityRef,
-        trigger: Optional[EntityRef] = None,
-        starter: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
+        trigger: EntityRef | None = None,
+        starter: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvStart:
         """
         Creates a new start record for an activity.
@@ -1934,11 +1922,11 @@ class ProvBundle:
     def end(
         self,
         activity: ActivityRef,
-        trigger: Optional[EntityRef] = None,
-        ender: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
+        trigger: EntityRef | None = None,
+        ender: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvEnd:
         """
         Creates a new end record for an activity.
@@ -1971,10 +1959,10 @@ class ProvBundle:
     def invalidation(
         self,
         entity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        time: Optional[DatetimeOrStr] = None,
+        activity: ActivityRef | None = None,
+        time: DatetimeOrStr | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvInvalidation:
         """
         Creates a new invalidation record for an entity.
@@ -2006,7 +1994,7 @@ class ProvBundle:
         informed: ActivityRef,
         informant: ActivityRef,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvCommunication:
         """
         Creates a new communication record for an entity.
@@ -2031,7 +2019,7 @@ class ProvBundle:
     def agent(
         self,
         identifier: QualifiedNameCandidate,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvAgent:
         """
         Creates a new agent.
@@ -2047,7 +2035,7 @@ class ProvBundle:
         entity: EntityRef,
         agent: AgentRef,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvAttribution:
         """
         Creates a new attribution record between an entity and an agent.
@@ -2074,10 +2062,10 @@ class ProvBundle:
     def association(
         self,
         activity: ActivityRef,
-        agent: Optional[AgentRef] = None,
-        plan: Optional[EntityRef] = None,
+        agent: AgentRef | None = None,
+        plan: EntityRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvAssociation:
         """
         Creates a new association record for an activity.
@@ -2107,9 +2095,9 @@ class ProvBundle:
         self,
         delegate: AgentRef,
         responsible: AgentRef,
-        activity: Optional[ActivityRef] = None,
+        activity: ActivityRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvDelegation:
         """
         Creates a new delegation record on behalf of an agent.
@@ -2140,7 +2128,7 @@ class ProvBundle:
         influencee: EntityRef | ActivityRef | AgentRef,
         influencer: EntityRef | ActivityRef | AgentRef,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvInfluence:
         """
         Creates a new influence record between two entities, activities or agents.
@@ -2168,11 +2156,11 @@ class ProvBundle:
         self,
         generatedEntity: EntityRef,
         usedEntity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        generation: Optional[GenrationRef] = None,
-        usage: Optional[UsageRef] = None,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvDerivation:
         """
         Creates a new derivation record for a generated entity from a used entity.
@@ -2205,11 +2193,11 @@ class ProvBundle:
         self,
         generatedEntity: EntityRef,
         usedEntity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        generation: Optional[GenrationRef] = None,
-        usage: Optional[UsageRef] = None,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvDerivation:
         """
         Creates a new revision record for a generated entity from a used entity.
@@ -2243,11 +2231,11 @@ class ProvBundle:
         self,
         generatedEntity: EntityRef,
         usedEntity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        generation: Optional[GenrationRef] = None,
-        usage: Optional[UsageRef] = None,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvDerivation:
         """
         Creates a new quotation record for a generated entity from a used entity.
@@ -2281,11 +2269,11 @@ class ProvBundle:
         self,
         generatedEntity: EntityRef,
         usedEntity: EntityRef,
-        activity: Optional[ActivityRef] = None,
-        generation: Optional[GenrationRef] = None,
-        usage: Optional[UsageRef] = None,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
         identifier: OptionalID = None,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvDerivation:
         """
         Creates a new primary source record for a generated entity from a used
@@ -2382,7 +2370,7 @@ class ProvBundle:
     def collection(
         self,
         identifier: QualifiedNameCandidate,
-        other_attributes: Optional[RecordAttributesArg] = None,
+        other_attributes: RecordAttributesArg | None = None,
     ) -> ProvEntity:
         """
         Creates a new collection record for a particular record.
@@ -2414,7 +2402,7 @@ class ProvBundle:
 
     def plot(
         self,
-        filename: Optional[PathLike] = None,
+        filename: PathLike | None = None,
         show_nary: bool = True,
         use_labels: bool = False,
         show_element_attributes: bool = True,
@@ -2453,9 +2441,9 @@ class ProvBundle:
             show_element_attributes=show_element_attributes,
             show_relation_attributes=show_relation_attributes,
         )
-        method = "create_%s" % format
+        method = f"create_{format}"
         if not hasattr(d, method):
-            raise ValueError("Format '%s' cannot be saved." % format)
+            raise ValueError(f"Format '{format}' cannot be saved.")
         with io.BytesIO() as buf:
             buf.write(getattr(d, method)())
 
@@ -2518,8 +2506,8 @@ class ProvDocument(ProvBundle):
 
     def __init__(
         self,
-        records: Optional[Iterable[ProvRecord]] = None,
-        namespaces: Optional[NSCollection] = None,
+        records: Iterable[ProvRecord] | None = None,
+        namespaces: NSCollection | None = None,
     ):
         """
         Constructor.
@@ -2646,12 +2634,12 @@ class ProvDocument(ProvBundle):
         else:
             raise ProvException(
                 "ProvDocument.update(): The other is not a ProvDocument or "
-                "ProvBundle instance (%s)" % type(other)
+                f"ProvBundle instance ({type(other)})"
             )
 
     # Bundle operations
     def add_bundle(
-        self, bundle: ProvBundle, identifier: Optional[QualifiedName] = None
+        self, bundle: ProvBundle, identifier: QualifiedName | None = None
     ) -> None:
         """
         Add a bundle to the current document.
@@ -2709,9 +2697,7 @@ class ProvDocument(ProvBundle):
             )
         valid_id = self.valid_qualified_name(identifier)
         if valid_id is None:
-            raise ProvException(
-                'The provided identifier "%s" is not valid' % identifier
-            )
+            raise ProvException(f'The provided identifier "{identifier}" is not valid')
         if valid_id in self._bundles:
             raise ProvException("A bundle with that identifier already exists")
         b = ProvBundle(identifier=valid_id, document=self)
@@ -2721,7 +2707,7 @@ class ProvDocument(ProvBundle):
     # Serializing and deserializing
     def serialize(
         self,
-        destination: Optional[io.IOBase | PathLike] = None,
+        destination: io.IOBase | PathLike | None = None,
         format: str = "json",
         **args: Any,
     ) -> str | None:
@@ -2769,8 +2755,8 @@ class ProvDocument(ProvBundle):
 
     @staticmethod
     def deserialize(
-        source: Optional[io.IOBase | PathLike] = None,
-        content: Optional[str | bytes] = None,
+        source: io.IOBase | PathLike | None = None,
+        content: str | bytes | None = None,
         format: str = "json",
         **args: Any,
     ) -> ProvDocument:

--- a/src/prov/model.py
+++ b/src/prov/model.py
@@ -138,6 +138,7 @@ def encoding_provn_value(
     elif isinstance(value, float):
         return f'"{value:g}" %% xsd:float'
     elif isinstance(value, bool):
+        # bool is an int subtype, so :d renders "1"/"0" (not "True"/"False")
         return f'"{value:d}" %% xsd:boolean'
     else:
         # TODO: QName export
@@ -211,11 +212,12 @@ class Literal:
         return self._langtag is None
 
     def provn_representation(self) -> str:
+        quoted_value = _ensure_multiline_string_triple_quoted(self._value)
         if self._langtag:
             # a language tag can only go with prov:InternationalizedString
-            return f"{_ensure_multiline_string_triple_quoted(self._value)}@{self._langtag!s}"
+            return f"{quoted_value}@{self._langtag!s}"
         else:
-            return f"{_ensure_multiline_string_triple_quoted(self._value)} %% {self._datatype!s}"
+            return f"{quoted_value} %% {self._datatype!s}"
 
 
 # Exceptions and warnings
@@ -590,6 +592,8 @@ class ProvRecord:
                     extra.append(f"{attr!s}={provn_represenation}")
 
         if extra:
+            # .format(), not an f-string: the nested string literals reuse the
+            # same quote character, which f-strings only allow from py3.12 (PEP 701)
             items.append("[{}]".format(", ".join(extra)))
         prov_n = "{}({}{})".format(
             PROV_N_MAP[self.get_type()],

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -12,12 +12,13 @@ prov-compare -- Compare two PROV-JSON, PROV-XML, or RDF (PROV-O) files for equiv
 @deffield    updated: 2025-06-07
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
 import traceback
 from argparse import ArgumentParser, FileType, RawDescriptionHelpFormatter
-from typing import Optional
 
 from prov.model import ProvDocument
 
@@ -38,13 +39,13 @@ class CLIError(Exception):
 
     def __init__(self, msg: str):
         super().__init__(type(self))
-        self.msg = "E: %s" % msg
+        self.msg = f"E: {msg}"
 
     def __str__(self) -> str:
         return self.msg
 
 
-def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
+def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     """Command line options."""
 
     if argv is None:
@@ -53,15 +54,11 @@ def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
         sys.argv.extend(argv)
 
     program_name = os.path.basename(sys.argv[0])
-    program_version = "v%s" % __version__
+    program_version = f"v{__version__}"
     program_build_date = str(__updated__)
-    program_version_message = "%%(prog)s %s (%s)" % (
-        program_version,
-        program_build_date,
-    )
+    program_version_message = f"%(prog)s {program_version} ({program_build_date})"
     program_shortdesc = __doc__.split("\n")[1]
-    program_license = (
-        """%s
+    program_license = f"""{program_shortdesc}
 
   Copyright 2025 Trung Dong Huynh.
 
@@ -73,8 +70,6 @@ def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
 
 USAGE
 """
-        % program_shortdesc
-    )
 
     try:
         # Setup argument parser

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -12,13 +12,15 @@ convert -- Convert PROV-JSON to RDF, PROV-N, PROV-XML, or graphical formats (SVG
 @deffield    updated: 2025-06-07
 """
 
+from __future__ import annotations
+
 import io
 import logging
 import os
 import sys
 import traceback
 from argparse import ArgumentParser, FileType, RawDescriptionHelpFormatter
-from typing import Optional, cast
+from typing import cast
 
 from prov import serializers
 from prov.model import ProvDocument
@@ -76,7 +78,7 @@ class CLIError(Exception):
 
     def __init__(self, msg: str):
         super().__init__(type(self))
-        self.msg = "E: %s" % msg
+        self.msg = f"E: {msg}"
 
     def __str__(self) -> str:
         return self.msg
@@ -104,10 +106,10 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
         except serializers.DoNotExist:
             # Not chaining with `from` to preserve the historic CLIError
             # traceback/behaviour; revisit in a follow-up.
-            raise CLIError('Output format "%s" is not supported.' % output_format)  # noqa: B904
+            raise CLIError(f'Output format "{output_format}" is not supported.')  # noqa: B904
 
 
-def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
+def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     """Command line options."""
 
     if argv is None:
@@ -116,15 +118,11 @@ def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
         sys.argv.extend(argv)
 
     program_name = os.path.basename(sys.argv[0])
-    program_version = "v%s" % __version__
+    program_version = f"v{__version__}"
     program_build_date = str(__updated__)
-    program_version_message = "%%(prog)s %s (%s)" % (
-        program_version,
-        program_build_date,
-    )
+    program_version_message = f"%(prog)s {program_version} ({program_build_date})"
     program_shortdesc = __doc__.split("\n")[1]
-    program_license = (
-        """%s
+    program_license = f"""{program_shortdesc}
 
   Copyright 2025 Trung Dong Huynh.
 
@@ -136,8 +134,6 @@ def main(argv: Optional[list[str]] = None) -> int:  # IGNORE:C0111
 
 USAGE
 """
-        % program_shortdesc
-    )
 
     try:
         # Setup argument parser

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -91,5 +91,5 @@ def get(format_name: str) -> type[Serializer]:
         # Not chaining with `from` to preserve the historic DoNotExist
         # traceback/behaviour; revisit in a follow-up.
         raise DoNotExist(  # noqa: B904
-            'No serializer available for the format "%s"' % format_name
+            f'No serializer available for the format "{format_name}"'
         )

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -5,7 +5,7 @@ import io
 import json
 import logging
 from collections import defaultdict
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from prov import Error
 from prov.constants import *
@@ -42,7 +42,7 @@ class AnonymousIDGenerator:
     def get_anon_id(self, obj: ProvRecord, local_prefix: str = "id") -> Identifier:
         if obj not in self._cache:
             self._count += 1
-            self._cache[obj] = Identifier("_:%s%d" % (local_prefix, self._count))
+            self._cache[obj] = Identifier(f"_:{local_prefix}{self._count}")
         return self._cache[obj]
 
 
@@ -113,7 +113,7 @@ class ProvJSONDecoder(json.JSONDecoder):
 
 # Encoding/decoding functions
 def valid_qualified_name(
-    bundle: ProvBundle, value: Optional[QualifiedNameCandidate]
+    bundle: ProvBundle, value: QualifiedNameCandidate | None
 ) -> QualifiedName | None:
     if value is None:
         return None
@@ -309,7 +309,7 @@ def decode_json_representation(literal: Any, bundle: ProvBundle) -> Any:
     if isinstance(literal, dict):
         # complex type
         value = literal["$"]
-        datatype_str = literal.get("type", None)  # type: Optional[str]
+        datatype_str = literal.get("type", None)  # type: str | None
         datatype = valid_qualified_name(bundle, datatype_str)
         langtag = literal.get("lang", None)
         if datatype == XSD_ANYURI:

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -8,7 +8,7 @@ import io
 import warnings
 from collections import OrderedDict
 from collections.abc import Generator, Iterable
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import dateutil.parser
 from rdflib import RDF, RDFS, XSD
@@ -66,7 +66,7 @@ class AnonymousIDGenerator:
     def get_anon_id(self, obj: pm.ProvRecord, local_prefix: str = "id") -> str:
         if obj not in self._cache:
             self._count += 1
-            self._cache[obj] = "_:%s%d" % (local_prefix, self._count)
+            self._cache[obj] = f"_:{local_prefix}{self._count}"
         return self._cache[obj]
 
 
@@ -272,8 +272,8 @@ class ProvRDFSerializer(Serializer):
         self,
         bundle: pm.ProvBundle,
         PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
-        container: Optional[ConjunctiveGraph] = None,
-        identifier: Optional[str] = None,
+        container: ConjunctiveGraph | None = None,
+        identifier: str | None = None,
     ) -> ConjunctiveGraph:
         if container is None:
             container = ConjunctiveGraph(identifier=identifier)
@@ -562,7 +562,7 @@ class ProvRDFSerializer(Serializer):
     ) -> None:
         record_types = {}  # type: dict[str, pm.QualifiedName]
         PROV_CLS_MAP = {}  # type: dict[str, pm.QualifiedName]
-        formal_attributes = {}  # type: dict[str, dict[pm.QualifiedName, Optional[pm.QualifiedNameCandidate | datetime.datetime]]]
+        formal_attributes = {}  # type: dict[str, dict[pm.QualifiedName, pm.QualifiedNameCandidate | datetime.datetime | None]]
         unique_sets = {}  # type: dict[str, dict[pm.QualifiedName, list[pm.QualifiedNameCandidate | datetime.datetime]]]
         for prov_type, _ in PROV_BASE_CLS.items():
             PROV_CLS_MAP[prov_type.uri] = PROV_BASE_CLS[prov_type]

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -4,7 +4,7 @@ import datetime
 import io
 import logging
 import warnings
-from typing import Any, Optional
+from typing import Any
 
 from lxml import etree
 
@@ -79,7 +79,7 @@ class ProvXMLSerializer(Serializer):
     def serialize_bundle(
         self,
         bundle: prov.model.ProvBundle,
-        element: Optional[etree._Element] = None,
+        element: etree._Element | None = None,
         force_types: bool = False,
     ) -> etree._Element:
         """
@@ -149,9 +149,8 @@ class ProvXMLSerializer(Serializer):
                         value.datatype is not None
                         and value.datatype != PROV_INTERNATIONALIZEDSTRING
                     ):
-                        subelem.attrib[_ns_xsi("type")] = "%s:%s" % (
-                            value.datatype.namespace.prefix,
-                            value.datatype.localpart,
+                        subelem.attrib[_ns_xsi("type")] = (
+                            f"{value.datatype.namespace.prefix}:{value.datatype.localpart}"
                         )
                     if value.langtag is not None:
                         subelem.attrib[_ns_xml("lang")] = value.langtag
@@ -359,9 +358,7 @@ def _extract_attributes(
     for subel in element:
         sqname = etree.QName(subel)
         qname_str = (
-            "%s:%s" % (subel.prefix, sqname.localname)
-            if subel.prefix
-            else sqname.localname
+            f"{subel.prefix}:{sqname.localname}" if subel.prefix else sqname.localname
         )
         _t = xml_qname_to_QualifiedName(subel, qname_str)
 
@@ -381,10 +378,9 @@ def _extract_attributes(
                 # No explicit stacklevel to preserve historic warning behaviour;
                 # revisit in a follow-up.
                 warnings.warn(  # noqa: B028
-                    "The element '%s' contains an attribute %s='%s' "
+                    f"The element '{_t}' contains an attribute {key!s}='{value!s}' "
                     "which is not representable in the prov module's "
-                    "internal data model and will thus be ignored."
-                    % (_t, str(key), str(value)),
+                    "internal data model and will thus be ignored.",
                     UserWarning,
                 )
 
@@ -426,13 +422,11 @@ def xml_qname_to_QualifiedName(
             ns = prov.identifier.Namespace("", ns_uri)
         return ns[qname_str]
     # no default namespace
-    raise ProvXMLException(
-        'Could not create a valid QualifiedName for "%s"' % qname_str
-    )
+    raise ProvXMLException(f'Could not create a valid QualifiedName for "{qname_str}"')
 
 
 def _ns(ns: str, tag: str) -> str:
-    return "{%s}%s" % (ns, tag)
+    return f"{{{ns}}}{tag}"
 
 
 def _ns_prov(tag: str) -> str:

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -426,6 +426,7 @@ def xml_qname_to_QualifiedName(
 
 
 def _ns(ns: str, tag: str) -> str:
+    # Clark notation ("{uri}tag") as used by lxml/ElementTree
     return f"{{{ns}}}{tag}"
 
 

--- a/src/prov/tests/attributes.py
+++ b/src/prov/tests/attributes.py
@@ -48,7 +48,7 @@ class TestAttributesBase:
 
     def run_entity_with_one_type_attribute(self, n):
         document = self.new_document()
-        document.entity(EX_NS["et%d" % n], {"prov:type": self.attribute_values[n]})
+        document.entity(EX_NS[f"et{n}"], {"prov:type": self.attribute_values[n]})
         self.do_tests(document)
 
     def test_entity_with_one_type_attribute_0(self):
@@ -138,7 +138,7 @@ class TestAttributesBase:
     def test_entity_with_multiple_attribute(self):
         document = self.new_document()
         attributes = [
-            (EX_NS["v_%d" % i], value) for i, value in enumerate(self.attribute_values)
+            (EX_NS[f"v_{i}"], value) for i, value in enumerate(self.attribute_values)
         ]
         document.entity(EX_NS["emov"], attributes)
         self.do_tests(document)

--- a/src/prov/tests/test_cli_smoke.py
+++ b/src/prov/tests/test_cli_smoke.py
@@ -33,7 +33,7 @@ class TestCLISmoke(unittest.TestCase):
 
     def test_console_scripts_installed(self):
         for script in ("prov-convert", "prov-compare"):
-            self.assertIsNotNone(_console_script(script), "%s not installed" % script)
+            self.assertIsNotNone(_console_script(script), f"{script} not installed")
 
     def test_prov_convert_and_compare_end_to_end(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -28,8 +28,8 @@ if find_spec("pydot") is not None:
             self.assertGreater(
                 len(svg_content),
                 self.MIN_SVG_SIZE,
-                "The size of the generated SVG content should be greater than %d bytes"
-                % self.MIN_SVG_SIZE,
+                "The size of the generated SVG content should be greater than "
+                f"{self.MIN_SVG_SIZE} bytes",
             )
 
 

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -280,7 +280,7 @@ class TestExtras(unittest.TestCase):
 
         def fake_import(name, *args, **kwargs):
             if name.startswith("matplotlib"):
-                raise ImportError("No module named %r" % name)
+                raise ImportError(f"No module named {name!r}")
             return real_import(name, *args, **kwargs)
 
         document = ProvDocument()

--- a/src/prov/tests/test_json.py
+++ b/src/prov/tests/test_json.py
@@ -11,19 +11,16 @@ logger = logging.getLogger(__name__)
 class TestJSONSerializer(unittest.TestCase):
     def test_decoding_unicode_value(self):
         unicode_char = "\u2019"
-        json_content = (
-            """{
-    "prefix": {
+        json_content = f"""{{
+    "prefix": {{
         "ex": "http://www.example.org"
-    },
-    "entity": {
-        "ex:unicode_char": {
-            "prov:label": "%s"
-        }
-    }
-}"""
-            % unicode_char
-        )
+    }},
+    "entity": {{
+        "ex:unicode_char": {{
+            "prov:label": "{unicode_char}"
+        }}
+    }}
+}}"""
 
         prov_doc = ProvDocument.deserialize(content=json_content, format="json")
         e1 = prov_doc.get_record("ex:unicode_char")[0]

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -51,7 +51,7 @@ class TestLoadingProvToolboxJSON(unittest.TestCase):
                         self.assertEqual(
                             g1,
                             g2,
-                            "Round-trip JSON encoding/decoding failed:  %s." % filename,
+                            f"Round-trip JSON encoding/decoding failed:  {filename}.",
                         )
                     except:  # noqa: E722 -- intentionally broad to catch any failure
                         self.fails.append(filename)
@@ -70,7 +70,9 @@ class TestLoadingProvToolboxJSON(unittest.TestCase):
                 json_str = g1.serialize(indent=4)
                 g2 = ProvDocument.deserialize(content=json_str)
                 self.assertEqual(
-                    g1, g2, "Round-trip JSON encoding/decoding failed:  %s." % filename
+                    g1,
+                    g2,
+                    f"Round-trip JSON encoding/decoding failed:  {filename}.",
                 )
 
 

--- a/src/prov/tests/test_public_api.py
+++ b/src/prov/tests/test_public_api.py
@@ -102,7 +102,7 @@ class TestPublicAPI(unittest.TestCase):
             for name in names:
                 if not hasattr(module, name):
                     missing.append(f"{module_name}.{name}")
-        self.assertEqual(missing, [], "Public API names missing: %s" % missing)
+        self.assertEqual(missing, [], f"Public API names missing: {missing}")
 
     def test_serializer_registry_formats(self):
         for fmt in ("json", "xml", "rdf", "provn"):

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -183,8 +183,7 @@ class AllTestsBase(
 class TestRDFSerializer(unittest.TestCase):
     def test_decoding_unicode_value(self):
         unicode_char = "\u2019"
-        rdf_content = (
-            """
+        rdf_content = f"""
 @prefix ex: <http://www.example.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -193,10 +192,8 @@ class TestRDFSerializer(unittest.TestCase):
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
     ex:unicode_char a prov:Entity ;
-        rdfs:label "%s"^^xsd:string .
+        rdfs:label "{unicode_char}"^^xsd:string .
 """
-            % unicode_char
-        )
         prov_doc = ProvDocument.deserialize(
             content=rdf_content, format="rdf", rdf_format="turtle"
         )
@@ -271,9 +268,9 @@ class TestRDFSerializer(unittest.TestCase):
                     match, _, _in_first, _in_second = find_diff(g_rdf, g0_rdf)
                     self.assertTrue(match)
                 else:
-                    logger.info("Skipping match: %s" % fname)
+                    logger.info(f"Skipping match: {fname}")
                 if idx in skip:
-                    logger.info("Skipping deserialization: %s" % fname)
+                    logger.info(f"Skipping deserialization: {fname}")
                     continue
                 pm.ProvDocument.deserialize(
                     content=g.serialize(format="rdf", rdf_format=format),

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -407,7 +407,7 @@ class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
 # function names make it clear what is going on.
 for filename in glob.iglob(os.path.join(DATA_PATH, "*" + os.path.extsep + "xml")):
     name = os.path.splitext(os.path.basename(filename))[0]
-    test_name = "test_roundtrip_from_xml_%s" % name
+    test_name = f"test_roundtrip_from_xml_{name}"
 
     # Cannot round trip this one as the namespace in the PROV data model are
     # always defined per bundle and not per element.

--- a/src/prov/tests/utility.py
+++ b/src/prov/tests/utility.py
@@ -36,7 +36,7 @@ class RoundTripTestCase(DocumentBaseTestCase):
             # Assume UTF-8 encoding which is forced by the particular
             # PROV XML implementation and should also work for the PROV
             # JSON implementation.
-            msg_extra = "'%s' serialization content:\n%s" % (
+            msg_extra = "'{}' serialization content:\n{}".format(
                 self.FORMAT,
                 stream.read().decode("utf-8"),
             )

--- a/src/prov/tests/utility.py
+++ b/src/prov/tests/utility.py
@@ -36,6 +36,8 @@ class RoundTripTestCase(DocumentBaseTestCase):
             # Assume UTF-8 encoding which is forced by the particular
             # PROV XML implementation and should also work for the PROV
             # JSON implementation.
+            # .format(), not an f-string: the nested "utf-8" literal reuses the
+            # same quote character, which f-strings only allow from py3.12 (PEP 701)
             msg_extra = "'{}' serialization content:\n{}".format(
                 self.FORMAT,
                 stream.read().decode("utf-8"),


### PR DESCRIPTION
## Summary

- Drops `UP045` (`Optional[X]`/`Union[X, None]` → `X | None`) and `UP031` (printf-style `%`-formatting → `.format()`/f-strings) from the `[tool.ruff.lint] ignore` list in `pyproject.toml`, along with the now-stale comment explaining the (outdated, py3.9-era) deferral.
- Fixes all resulting findings:
  - **UP045**: 117 sites across `src/prov/model.py`, `dot.py`, `identifier.py` (no direct hits but forward-ref aliases reviewed), `scripts/compare.py`, `scripts/convert.py`, `serializers/provjson.py`, `serializers/provrdf.py`, `serializers/provxml.py`. 116 via `ruff --fix`; 1 manual (`model.py`'s `OptionalID` type alias, a runtime assignment rather than an annotation, changed to `QualifiedNameCandidate | None`).
  - **UP031**: 74 sites. 62 via `ruff --unsafe-fixes --fix` (reviewed each hunk, including the `%%` → literal `%` escaping in PROV-N output and the `program_version_message`'s `%%(prog)s` argparse placeholder). The remaining 12 were `%d`/`%i` sites ruff won't autofix (since `.format()`/f-strings don't coerce non-ints the way `%d` does) — all confirmed to only ever receive statically-known `int` (id counters) or `bool` (`encoding_provn_value`'s boolean branch, kept exact via an explicit `{:d}` format spec) and fixed by hand.
  - Fixing UP031 turned many `%`-strings into `.format()` calls, which surfaced 71 new **UP032** (`.format()` → f-string) and 7 **RUF010** (redundant `str()` in an f-string) findings on that newly introduced code; both are pyupgrade/ruff rules already enabled (not part of this task's ignore list) so they were fixed too to keep `ruff check` clean — all straightforward syntactic rewrites with no behavioural change.
- Added `from __future__ import annotations` to `scripts/compare.py` and `scripts/convert.py` (both had `Optional[...]` annotations that benefit); `constants.py` and `serializers/provn.py` were left untouched since they have no annotations that would benefit.

No behaviour changes: the PROV-N/PROV-XML/DOT-serialized output bytes are unchanged (verified by re-running the affected code paths manually and by the full round-trip test suite).

## Suppressions

None needed — every UP031/UP045 finding was fixable without changing output, so there are no `# noqa` additions.

## Verify command output

```
$ uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
29 files already formatted

$ uv run mypy src
Success: no issues found in 14 source files

$ uv run pytest -q
953 passed, 17 xfailed, 95 warnings, 7 subtests passed in 17.23s
```

## Test plan

- [x] `uv run ruff check src/` clean
- [x] `uv run ruff format --check src/` clean
- [x] `uv run mypy src` clean
- [x] `uv run pytest -q` — 953 passed, 17 xfailed (matches baseline)
- [x] Manually exercised PROV-N (`get_provn()`), DOT (`prov_to_dot()`), and both CLI scripts (`prov-convert --help`, `prov-compare --help`) to confirm output is byte-identical to before