### PR TITLE
fix: chain serializer/CLI exceptions and set warn stacklevel

### DIFF
--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -103,10 +103,8 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
         # Try supported serializers:
         try:
             prov_doc.serialize(outfile, format=output_format)
-        except serializers.DoNotExist:
-            # Not chaining with `from` to preserve the historic CLIError
-            # traceback/behaviour; revisit in a follow-up.
-            raise CLIError(f'Output format "{output_format}" is not supported.')  # noqa: B904
+        except serializers.DoNotExist as e:
+            raise CLIError(f'Output format "{output_format}" is not supported.') from e
 
 
 def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -87,9 +87,7 @@ def get(format_name: str) -> type[Serializer]:
     assert serializers is not None  # load_serializers() always populates it
     try:
         return serializers[format_name]
-    except KeyError:
-        # Not chaining with `from` to preserve the historic DoNotExist
-        # traceback/behaviour; revisit in a follow-up.
-        raise DoNotExist(  # noqa: B904
+    except KeyError as e:
+        raise DoNotExist(
             f'No serializer available for the format "{format_name}"'
-        )
+        ) from e

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -726,11 +726,10 @@ class ProvRDFSerializer(Serializer):
                 del other_attributes[subj]
 
         if other_attributes:
-            # No explicit stacklevel to preserve historic warning behaviour;
-            # revisit in a follow-up.
-            warnings.warn(  # noqa: B028
+            warnings.warn(
                 "The following attributes were not converted: " + str(other_attributes),
                 UserWarning,
+                stacklevel=2,
             )
 
 

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -273,12 +273,11 @@ class ProvXMLSerializer(Serializer):
                 )
             # Ignore the <prov:other> element storing non-PROV information.
             if qname.localname == "other":
-                # No explicit stacklevel to preserve historic warning behaviour;
-                # revisit in a follow-up.
-                warnings.warn(  # noqa: B028
+                warnings.warn(
                     "Document contains non-PROV information in "
                     "<prov:other>. It will be ignored in this package.",
                     UserWarning,
+                    stacklevel=2,
                 )
                 continue
 
@@ -375,13 +374,12 @@ def _extract_attributes(
             elif key == _ns_xml("lang"):
                 _v = prov.model.Literal(subel.text, langtag=value_str)
             else:
-                # No explicit stacklevel to preserve historic warning behaviour;
-                # revisit in a follow-up.
-                warnings.warn(  # noqa: B028
+                warnings.warn(
                     f"The element '{_t}' contains an attribute {key!s}='{value!s}' "
                     "which is not representable in the prov module's "
                     "internal data model and will thus be ignored.",
                     UserWarning,
+                    stacklevel=2,
                 )
 
         if not subel.attrib:

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -2,7 +2,7 @@ import unittest
 
 from prov.dot import prov_to_dot
 from prov.model import *
-from prov.serializers import Registry
+from prov.serializers import DoNotExist, Registry, get as get_serializer
 from prov.tests.examples import primer_example, primer_example_alternate
 
 EX_NS = Namespace("ex", "http://example.org/")
@@ -272,6 +272,11 @@ class TestExtras(unittest.TestCase):
         g1 = primer_example()
         g2 = primer_example_alternate()
         self.assertEqual(g1, g2)
+
+    def test_get_serializer_for_unknown_format_chains_key_error(self):
+        with self.assertRaises(DoNotExist) as ctx:
+            get_serializer("no-such-format")
+        self.assertIsInstance(ctx.exception.__cause__, KeyError)
 
     def test_plot_without_matplotlib_raises_helpful_error(self):
         import builtins


### PR DESCRIPTION
## Summary
- Resolves the 5 remaining B904/B028 ruff noqas (Task 9 of the modernisation plan).
- `prov.serializers.get()` now raises `DoNotExist` with `from e` instead of suppressing the chain.
- `prov.scripts.convert.convert_file()` now raises `CLIError` with `from e`.
- `warnings.warn()` calls in `provrdf.py` and `provxml.py` (x2) now pass `stacklevel=2`.

## Behaviour change (flag for 2.3.0 changelog)
**`DoNotExist`** (serializer registry, `prov.serializers.get`) and **`CLIError`** (`prov-convert` CLI) now set `__cause__` via exception chaining (`raise ... from e`), where previously the originating `KeyError` was suppressed. Exit codes and CLI messages are unchanged — only `__cause__` (and the printed traceback when uncaught) differs.

## Test plan
- [x] Added `test_get_serializer_for_unknown_format_chains_key_error` in `src/prov/tests/test_extras.py`, asserting `DoNotExist.__cause__` is a `KeyError`.
- [x] `uv run ruff check src/` -> All checks passed!
- [x] `uv run ruff format --check src/` -> 29 files already formatted
- [x] `uv run mypy src` -> Success: no issues found in 14 source files
- [x] `uv run pytest -q` -> 954 passed, 17 xfailed (up from 953 passed)
- [x] `grep -rn 'noqa: B9\|noqa: B028' src/` -> empty