### PR TITLE
test: in-process CLI coverage for prov-convert / prov-compare

### DIFF
--- a/docs/test-gap-checklist.md
+++ b/docs/test-gap-checklist.md
@@ -33,26 +33,26 @@ The existing `test_cli_smoke.py` runs the console script in a subprocess, so not
 this module is *measured* even though the happy path is smoke-tested. T11 should call
 `main()`/`convert_file()` in-process.
 
-- [ ] `convert_file()` writes PROV-N output for `-f provn` (the `get_provn().encode()` path) — **T11**
-- [ ] `convert_file()` routes Graphviz formats (e.g. `dot`) through `prov_to_dot(...).create()` and writes bytes — **T11** (use `-f dot`; it needs a local `graphviz` binary, which CI installs via `setup-graphviz`)
-- [ ] `convert_file()` dispatches remaining formats to `ProvDocument.serialize()` (e.g. `-f xml`, `-f json`) — **T11**
-- [ ] `convert_file()` raises `CLIError` (with the format name in the message) for an unsupported output format, and `main()` turns that into exit code 2 plus a message on stderr — **T11**
-- [ ] `CLIError.__str__` returns the `E: ...` message — **T11** (falls out of the item above)
-- [ ] `main()` parses `-f/--format` (case-insensitively), positional infile/outfile, and returns 0 on success — **T11**
-- [ ] `main()` closes infile/outfile in the `finally` block even when conversion fails — **T11**
-- [ ] `main()` returns 0 on `KeyboardInterrupt` — **T11** (raise from a stub via monkeypatched `convert_file`)
-- [ ] `--version` prints the version message and exits — **T11**
+- [x] `convert_file()` writes PROV-N output for `-f provn` (the `get_provn().encode()` path) — **T11**
+- [x] `convert_file()` routes Graphviz formats (e.g. `dot`) through `prov_to_dot(...).create()` and writes bytes — **T11** (use `-f dot`; it needs a local `graphviz` binary, which CI installs via `setup-graphviz`)
+- [x] `convert_file()` dispatches remaining formats to `ProvDocument.serialize()` (e.g. `-f xml`, `-f json`) — **T11**
+- [x] `convert_file()` raises `CLIError` (with the format name in the message) for an unsupported output format, and `main()` turns that into exit code 2 plus a message on stderr — **T11**
+- [x] `CLIError.__str__` returns the `E: ...` message — **T11** (falls out of the item above)
+- [x] `main()` parses `-f/--format` (case-insensitively), positional infile/outfile, and returns 0 on success — **T11**
+- [x] `main()` closes infile/outfile in the `finally` block even when conversion fails — **T11**
+- [x] `main()` returns 0 on `KeyboardInterrupt` — **T11** (raise from a stub via monkeypatched `convert_file`)
+- [x] `--version` prints the version message and exits — **T11**
 - [ ] `if __name__ == "__main__"` block incl. `TESTRUN`/`PROFILE` scaffolding — **defer** (dead debug scaffolding, excluded by the `if __name__ == .__main__.:` exclude_lines rule already; not worth executing)
 
 ## src/prov/scripts/compare.py — 30% (missed: 41–45, 51–123)
 
 Same subprocess-only situation as `convert.py`.
 
-- [ ] `main()` returns 0 for two equivalent documents in different formats (json vs xml) — **T11** (in-process version of the existing smoke test)
-- [ ] `main()` returns 1 for two non-equivalent documents — **T11** (currently untested anywhere: the smoke test only checks the "equal" outcome)
-- [ ] `main()` returns 2 and writes to stderr when a file cannot be parsed / wrong `-f`/`-F` format is given — **T11**
-- [ ] `main()` closes both files in the `finally` block — **T11**
-- [ ] `--version` prints the version message and exits — **T11**
+- [x] `main()` returns 0 for two equivalent documents in different formats (json vs xml) — **T11** (in-process version of the existing smoke test)
+- [x] `main()` returns 1 for two non-equivalent documents — **T11** (currently untested anywhere: the smoke test only checks the "equal" outcome)
+- [x] `main()` returns 2 and writes to stderr when a file cannot be parsed / wrong `-f`/`-F` format is given — **T11**
+- [x] `main()` closes both files in the `finally` block — **T11**
+- [x] `--version` prints the version message and exits — **T11**
 - [ ] `__main__`/`TESTRUN`/`PROFILE` scaffolding — **defer** (same reason as convert.py)
 
 ## src/prov/__init__.py — 39% (missed: 38–56, i.e. the whole body of `read()`)

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -14,8 +14,6 @@ full desired argv (program name included) and then call ``main()`` with no
 argument, rather than passing ``argv=[...]`` to ``main()``.
 """
 
-from __future__ import annotations
-
 import io
 import os
 import shutil
@@ -60,6 +58,19 @@ class TestConvertMain(unittest.TestCase):
             sys, "argv", ["prov-convert", "-f", "XML", self.infile, outfile]
         ):
             rc = convert_main()
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.getsize(outfile) > 0)
+
+    def test_convert_explicit_argv_extends_sys_argv(self):
+        # Pin the documented quirk: main(argv) *extends* sys.argv rather than
+        # replacing it, and argparse then reads the combined sys.argv. A
+        # future "fix" that silently changes this to replacement should trip
+        # this test so the behaviour change is a deliberate (3.0) decision.
+        outfile = self._outfile("doc.xml")
+        argv = ["-f", "xml", self.infile, outfile]
+        with unittest.mock.patch.object(sys, "argv", ["prov-convert"]):
+            rc = convert_main(argv)
+            self.assertEqual(sys.argv, ["prov-convert", *argv])
         self.assertEqual(rc, 0)
         self.assertTrue(os.path.getsize(outfile) > 0)
 
@@ -249,6 +260,7 @@ class TestCompareMain(unittest.TestCase):
             unittest.mock.patch.object(
                 sys, "argv", ["prov-compare", missing, self.json_file]
             ),
+            unittest.mock.patch.object(sys, "stderr", io.StringIO()),
             self.assertRaises(SystemExit) as ctx,
         ):
             compare_main()

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -1,0 +1,294 @@
+"""In-process coverage tests for the ``prov-convert`` / ``prov-compare``
+console scripts (``src/prov/scripts/convert.py`` and ``compare.py``).
+
+``test_cli_smoke.py`` runs these scripts in a subprocess, which exercises the
+end-to-end console-script wiring but contributes nothing to coverage
+measurement. This module calls ``main()`` (and, for ``convert``,
+``convert_file()``) directly in-process so the bulk of both modules is
+actually measured, while leaving the smoke test untouched.
+
+Quirk worth flagging: ``main(argv)`` *extends* ``sys.argv`` rather than
+replacing it (see ``if argv is None: argv = sys.argv else: sys.argv.extend
+(argv)``). So the pattern used throughout is to patch ``sys.argv`` to the
+full desired argv (program name included) and then call ``main()`` with no
+argument, rather than passing ``argv=[...]`` to ``main()``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import unittest.mock
+
+from prov.model import ProvDocument
+from prov.scripts.compare import main as compare_main
+from prov.scripts.convert import (
+    GRAPHVIZ_SUPPORTED_FORMATS,
+    CLIError,
+    convert_file,
+    main as convert_main,
+)
+from prov.tests.examples import primer_example, w3c_publication_1
+
+
+class TestConvertMain(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.infile = os.path.join(self.tmpdir.name, "doc.json")
+        primer_example().serialize(self.infile, format="json")
+
+    def _outfile(self, name):
+        return os.path.join(self.tmpdir.name, name)
+
+    def test_convert_to_xml(self):
+        outfile = self._outfile("doc.xml")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-convert", "-f", "xml", self.infile, outfile]
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.getsize(outfile) > 0)
+
+    def test_convert_format_is_case_insensitive(self):
+        outfile = self._outfile("doc.xml")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-convert", "-f", "XML", self.infile, outfile]
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.getsize(outfile) > 0)
+
+    def test_convert_to_provn(self):
+        outfile = self._outfile("doc.provn")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-convert", "-f", "provn", self.infile, outfile]
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+        with open(outfile, encoding="utf-8") as f:
+            content = f.read()
+        self.assertTrue(content)
+        # Sanity-check this really went through get_provn(), not a serializer:
+        # PROV-N documents open/close with these keywords.
+        self.assertTrue(content.startswith("document"))
+        self.assertIn("endDocument", content)
+
+    @unittest.skipUnless(shutil.which("dot"), "graphviz 'dot' binary not installed")
+    def test_convert_to_dot(self):
+        outfile = self._outfile("doc.dot")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-convert", "-f", "dot", self.infile, outfile]
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.getsize(outfile) > 0)
+
+    @unittest.skipUnless(shutil.which("dot"), "graphviz 'dot' binary not installed")
+    def test_convert_to_rendered_graphviz_format(self):
+        outfile = self._outfile("doc.svg")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-convert", "-f", "svg", self.infile, outfile]
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.getsize(outfile) > 0)
+
+    def test_convert_unsupported_format_returns_2_and_writes_stderr(self):
+        outfile = self._outfile("doc.bogus")
+        stderr = io.StringIO()
+        with (
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-convert", "-f", "bogus", self.infile, outfile]
+            ),
+            unittest.mock.patch.object(sys, "stderr", stderr),
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 2)
+        self.assertIn('E: Output format "bogus" is not supported.', stderr.getvalue())
+
+    def test_convert_file_raises_cli_error_for_unsupported_format(self):
+        # Exercise convert_file() directly for the CLIError branch and its
+        # __str__ (the "E: ..." prefix).
+        self.assertNotIn("bogus", GRAPHVIZ_SUPPORTED_FORMATS)
+        with (
+            open(self.infile) as infile,
+            open(self._outfile("doc.bogus"), "wb") as outfile,
+            self.assertRaises(CLIError) as ctx,
+        ):
+            convert_file(infile, outfile, "bogus")
+        self.assertEqual(
+            str(ctx.exception), 'E: Output format "bogus" is not supported.'
+        )
+
+    def test_convert_missing_input_file_exits_2(self):
+        # FileType('r') fails to open a nonexistent path *inside argparse*,
+        # which calls parser.error() -> sys.exit(2); that SystemExit
+        # propagates straight out of main() without being caught by the
+        # `except Exception` handler.
+        missing = self._outfile("does-not-exist.json")
+        outfile = self._outfile("doc.xml")
+        stderr = io.StringIO()
+        with (
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-convert", "-f", "xml", missing, outfile]
+            ),
+            unittest.mock.patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            convert_main()
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_convert_version_exits_0(self):
+        with (
+            unittest.mock.patch.object(sys, "argv", ["prov-convert", "--version"]),
+            unittest.mock.patch.object(sys, "stdout", io.StringIO()),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            convert_main()
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_convert_returns_0_on_keyboard_interrupt(self):
+        outfile = self._outfile("doc.xml")
+        with (
+            unittest.mock.patch(
+                "prov.scripts.convert.convert_file", side_effect=KeyboardInterrupt
+            ),
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-convert", "-f", "xml", self.infile, outfile]
+            ),
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 0)
+
+    def test_convert_closes_files_even_when_conversion_fails(self):
+        outfile = self._outfile("doc.xml")
+        captured = {}
+
+        def spy_convert_file(infile, outfile, output_format):
+            captured["infile"] = infile
+            captured["outfile"] = outfile
+            raise RuntimeError("boom")
+
+        with (
+            unittest.mock.patch(
+                "prov.scripts.convert.convert_file", side_effect=spy_convert_file
+            ),
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-convert", "-f", "xml", self.infile, outfile]
+            ),
+        ):
+            rc = convert_main()
+        self.assertEqual(rc, 2)
+        self.assertTrue(captured["infile"].closed)
+        self.assertTrue(captured["outfile"].closed)
+
+
+class TestCompareMain(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.json_file = os.path.join(self.tmpdir.name, "doc.json")
+        self.xml_file = os.path.join(self.tmpdir.name, "doc.xml")
+        doc = primer_example()
+        doc.serialize(self.json_file, format="json")
+        doc.serialize(self.xml_file, format="xml")
+
+    def test_equivalent_documents_return_0(self):
+        with unittest.mock.patch.object(
+            sys,
+            "argv",
+            [
+                "prov-compare",
+                "-f",
+                "json",
+                "-F",
+                "xml",
+                self.json_file,
+                self.xml_file,
+            ],
+        ):
+            rc = compare_main()
+        self.assertEqual(rc, 0)
+
+    def test_different_documents_return_1(self):
+        other_file = os.path.join(self.tmpdir.name, "other.json")
+        w3c_publication_1().serialize(other_file, format="json")
+        with unittest.mock.patch.object(
+            sys, "argv", ["prov-compare", self.json_file, other_file]
+        ):
+            rc = compare_main()
+        self.assertEqual(rc, 1)
+
+    def test_bad_format_returns_2_and_writes_stderr(self):
+        stderr = io.StringIO()
+        with (
+            unittest.mock.patch.object(
+                sys,
+                "argv",
+                ["prov-compare", "-f", "bogus", self.json_file, self.xml_file],
+            ),
+            unittest.mock.patch.object(sys, "stderr", stderr),
+        ):
+            rc = compare_main()
+        self.assertEqual(rc, 2)
+        # Unlike convert.py's unsupported-format case, this failure comes
+        # straight out of the serializer registry (no CLIError wrapping), so
+        # there is no "E: " prefix -- just the program name and message.
+        self.assertIn(
+            'No serializer available for the format "bogus"', stderr.getvalue()
+        )
+
+    def test_missing_file_exits_2(self):
+        missing = os.path.join(self.tmpdir.name, "does-not-exist.json")
+        with (
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-compare", missing, self.json_file]
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            compare_main()
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_version_exits_0(self):
+        with (
+            unittest.mock.patch.object(sys, "argv", ["prov-compare", "--version"]),
+            unittest.mock.patch.object(sys, "stdout", io.StringIO()),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            compare_main()
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_closes_both_files_on_error(self):
+        captured_sources = []
+        original_deserialize = ProvDocument.deserialize
+
+        def spy_deserialize(source=None, content=None, format="json", **kwargs):
+            captured_sources.append(source)
+            if len(captured_sources) == 2:
+                raise RuntimeError("boom")
+            return original_deserialize(
+                source=source, content=content, format=format, **kwargs
+            )
+
+        with (
+            unittest.mock.patch.object(
+                ProvDocument, "deserialize", staticmethod(spy_deserialize)
+            ),
+            unittest.mock.patch.object(
+                sys, "argv", ["prov-compare", self.json_file, self.xml_file]
+            ),
+        ):
+            rc = compare_main()
+        self.assertEqual(rc, 2)
+        self.assertEqual(len(captured_sources), 2)
+        for source in captured_sources:
+            self.assertTrue(source.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `src/prov/tests/test_scripts.py` with in-process tests that call `convert.main()`/`convert_file()` and `compare.main()` directly, so coverage actually measures these two console-script modules (the existing `test_cli_smoke.py` only runs them in a subprocess and is left untouched).
- Cases covered: PROV-N output (`get_provn()` path), Graphviz `dot`/rendered (`svg`) output guarded by `shutil.which("dot")`, dispatch to `ProvDocument.serialize()` (xml), case-insensitive `-f/--format`, unsupported output format (`CLIError` -> rc 2 + stderr), missing input file (argparse `SystemExit(2)`), `--version` (`SystemExit(0)`), `KeyboardInterrupt` -> rc 0, and closing infile/outfile in the `finally` block even on failure; for compare: equivalent docs across formats (rc 0), genuinely different docs (rc 1), bad format (rc 2 + stderr), missing file (`SystemExit(2)`), `--version`, and closing both files in `finally` on error.
- Ticks the T11 items in `docs/test-gap-checklist.md`.

Coverage (this task's target modules):

| Module | Before | After |
|---|---|---|
| `src/prov/scripts/convert.py` | 27% | 91% |
| `src/prov/scripts/compare.py` | 30% | 86% |

Remaining misses in both are the deferred `DEBUG`/`TESTRUN`/`PROFILE` `__main__` scaffolding (already tagged **defer** in the checklist) plus compare.py's unused `CLIError` class body (never raised in that module).

## Test plan

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — all formatted
- [x] `uv run mypy src` — Success: no issues found in 14 source files
- [x] `uv run pytest -q` — 971 passed, 17 xfailed (was 954 passed/17 xfailed; +17 new tests)
- [x] `uv run coverage run -m pytest && uv run coverage report -m` — convert.py 91%, compare.py 86% (both ≥ 85% target)