### PR TITLE
test: cover read(), graph.py, serializer registry (T12)

### DIFF
--- a/docs/test-gap-checklist.md
+++ b/docs/test-gap-checklist.md
@@ -59,10 +59,10 @@ Same subprocess-only situation as `convert.py`.
 
 `prov.read()` is a documented public entry point with zero coverage.
 
-- [ ] `read(source, format="json"|"xml"|"rdf")` with an explicit format deserializes via that serializer (and lower-cases the format string) — **T12**
-- [ ] `read(source)` without a format auto-detects by trying each registered deserializer in turn — one test per detectable format (json, xml, rdf) — **T12**
-- [ ] `read()` on undetectable/garbage input raises `TypeError` with the "specify the format" message after exhausting all serializers — **T12**
-- [ ] `read()` accepts both a filename (`str`/`PathLike`) and a file object, matching `ProvDocument.deserialize` — **T12**
+- [x] `read(source, format="json"|"xml"|"rdf")` with an explicit format deserializes via that serializer (and lower-cases the format string) — **T12**
+- [x] `read(source)` without a format auto-detects by trying each registered deserializer in turn — one test per detectable format (json, xml, rdf) — **T12** (finding: json and rdf/trig genuinely auto-detect; an xml document does not — the registry tries rdf, as trig, before xml, and rdflib's `BadSyntax` on the xml content is a `SyntaxError` that read()'s except clause doesn't catch, so it propagates before xml is ever tried. Test pins this actual behaviour rather than asserting the aspirational "all three auto-detect")
+- [x] `read()` on undetectable/garbage input raises `TypeError` with the "specify the format" message after exhausting all serializers — **T12** (finding: unreachable via any real file — `ProvNSerializer.deserialize()` unconditionally raises uncaught `NotImplementedError` and is tried third, before the loop can ever exhaust normally; test reaches the branch by mocking all four deserializers to raise a caught exception type)
+- [x] `read()` accepts both a filename (`str`/`PathLike`) and a file object, matching `ProvDocument.deserialize` — **T12**
 - [ ] Auto-detection swallows only `(TypeError, ValueError, AttributeError, KeyError)` from candidate deserializers — **T13** (behavioural pin: a deserializer raising something else, e.g. the PROV-N serializer's `NotImplementedError`, must propagate — document the intended behaviour when writing the test)
 
 ## src/prov/graph.py — 83% (missed: 88, 90–93, 116–117 + partial branches)
@@ -71,16 +71,16 @@ The only existing test is one round-trip over the example documents; the inferen
 robustness paths are untested. The mutation spike (below) confirmed these as the real
 gaps: 8 of the 9 non-equivalent surviving mutants live here.
 
-- [ ] `prov_to_graph()` infers element nodes (with the correct inferred class, e.g. `ProvEntity` vs `ProvActivity`) for relation endpoints that have **no** corresponding element record in the document — **T12**
-- [ ] `prov_to_graph()` skips a relation whose endpoint attribute is not in `INFERRED_ELEMENT_CLASS` (the `except KeyError: continue` path) and still processes subsequent relations (mutmut: `continue` → `break` survived) — **T12**
-- [ ] `prov_to_graph()` skips relations where either endpoint QName is `None` — **T12**
-- [ ] `graph_to_prov()` ignores graph nodes that are not `ProvRecord`s or whose `bundle` is `None` (mutmut: `and` → `or` survived) — **T12**
-- [ ] `graph_to_prov()` ignores edges without a `"relation"` key in their edge data — **T12**
+- [x] `prov_to_graph()` infers element nodes (with the correct inferred class, e.g. `ProvEntity` vs `ProvActivity`) for relation endpoints that have **no** corresponding element record in the document — **T12**
+- [x] `prov_to_graph()` skips a relation whose endpoint attribute is not in `INFERRED_ELEMENT_CLASS` (the `except KeyError: continue` path) and still processes subsequent relations (mutmut: `continue` → `break` survived) — **T12**
+- [x] `prov_to_graph()` skips relations where either endpoint QName is `None` — **T12**
+- [x] `graph_to_prov()` ignores graph nodes that are not `ProvRecord`s or whose `bundle` is `None` (mutmut: `and` → `or` survived) — **T12**
+- [x] `graph_to_prov()` ignores edges without a `"relation"` key in their edge data — **T12**
 
 ## src/prov/serializers/__init__.py — 91% (missed: 10, 39, 48)
 
-- [ ] `serializers.get()` on an unknown format raises `DoNotExist` with the format name in the message, chained from `KeyError` — **T12** (the chaining itself is already tested by `test_extras.py::test_get_serializer_for_unknown_format_chains_key_error` from T9 — dedupe with it, one module owns it; only the format-name-in-message assertion is new)
-- [ ] `serializers.get()` lazily populates `Registry.serializers` on first call (registry starts as `None`, holds exactly the four formats json/rdf/provn/xml) — **T12**
+- [x] `serializers.get()` on an unknown format raises `DoNotExist` with the format name in the message, chained from `KeyError` — **T12** (the chaining itself is already tested by `test_extras.py::test_get_serializer_for_unknown_format_chains_key_error` from T9 — extended in place with the format-name-in-message assertion, one module owns it)
+- [x] `serializers.get()` lazily populates `Registry.serializers` on first call (registry starts as `None`, holds exactly the four formats json/rdf/provn/xml) — **T12**
 - [ ] `Serializer.serialize`/`.deserialize` abstract bodies (lines 39, 48) and the `if TYPE_CHECKING:` import (line 10) — **defer** (never executed at runtime by design; consider `pragma: no cover` in T13 instead of tests)
 
 ## src/prov/identifier.py — 87% (missed: 119, 141–146, 156–164)

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -277,6 +277,31 @@ class TestExtras(unittest.TestCase):
         with self.assertRaises(DoNotExist) as ctx:
             get_serializer("no-such-format")
         self.assertIsInstance(ctx.exception.__cause__, KeyError)
+        self.assertIn("no-such-format", str(ctx.exception))
+
+    def test_get_serializer_returns_class_for_each_known_format(self):
+        from prov.serializers.provjson import ProvJSONSerializer
+        from prov.serializers.provn import ProvNSerializer
+        from prov.serializers.provrdf import ProvRDFSerializer
+        from prov.serializers.provxml import ProvXMLSerializer
+
+        self.assertIs(get_serializer("json"), ProvJSONSerializer)
+        self.assertIs(get_serializer("rdf"), ProvRDFSerializer)
+        self.assertIs(get_serializer("provn"), ProvNSerializer)
+        self.assertIs(get_serializer("xml"), ProvXMLSerializer)
+
+    def test_get_serializer_lazily_populates_registry(self):
+        original = Registry.serializers
+        Registry.serializers = None
+        try:
+            self.assertIsNone(Registry.serializers)
+            get_serializer("json")
+            self.assertIsNotNone(Registry.serializers)
+            self.assertEqual(
+                set(Registry.serializers.keys()), {"json", "rdf", "provn", "xml"}
+            )
+        finally:
+            Registry.serializers = original
 
     def test_plot_without_matplotlib_raises_helpful_error(self):
         import builtins

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -1,7 +1,10 @@
 import unittest
 
+import networkx as nx
+
 from prov.graph import graph_to_prov, prov_to_graph
-from prov.tests.examples import tests
+from prov.model import ProvActivity, ProvDocument, ProvEntity
+from prov.tests.examples import primer_example, tests
 
 
 class ProvGraphTestCase(unittest.TestCase):
@@ -18,3 +21,88 @@ class ProvGraphTestCase(unittest.TestCase):
                 prov_org,
                 f"Round trip graph conversion for '{name}' failed.",
             )
+
+    def test_round_trip_against_unified_document(self):
+        # prov_to_graph() unifies the document internally before building
+        # the graph, so a round trip should match the *unified* document,
+        # not necessarily the original one record-for-record.
+        prov_org = primer_example()
+        g = prov_to_graph(prov_org)
+        prov_doc = graph_to_prov(g)
+        self.assertEqual(prov_doc, prov_org.unified())
+
+
+class ProvToGraphTestCase(unittest.TestCase):
+    def setUp(self):
+        self.document = ProvDocument()
+        self.document.add_namespace("ex", "http://example.org/")
+
+    def test_relation_with_missing_end_is_skipped(self):
+        # A generation record with no activity: the "if qn1 and qn2" guard
+        # should skip adding an edge for it since one QualifiedName is None.
+        self.document.generation(entity="ex:e1", activity=None)
+
+        g = prov_to_graph(self.document)
+
+        self.assertEqual(list(g.edges()), [])
+
+    def test_relation_endpoints_get_inferred_nodes(self):
+        # Neither ex:e2 nor ex:a2 is declared as an element record; both
+        # ends should be inferred with the correct PROV class via
+        # INFERRED_ELEMENT_CLASS.
+        self.document.wasGeneratedBy("ex:e2", "ex:a2")
+
+        g = prov_to_graph(self.document)
+
+        nodes_by_id = {str(n.identifier): n for n in g.nodes()}
+        self.assertEqual(len(nodes_by_id), 2)
+        self.assertIsInstance(nodes_by_id["ex:e2"], ProvEntity)
+        self.assertIsInstance(nodes_by_id["ex:a2"], ProvActivity)
+        # Inferred nodes are placeholders, not attached to any bundle.
+        self.assertIsNone(nodes_by_id["ex:e2"].bundle)
+        self.assertIsNone(nodes_by_id["ex:a2"].bundle)
+        self.assertEqual(len(g.edges()), 1)
+
+    def test_relation_with_uninferrable_endpoint_type_is_skipped(self):
+        # ProvInfluence's formal attributes (influencee/influencer) are not
+        # keys of INFERRED_ELEMENT_CLASS, so a generic influence relation
+        # between two undeclared identifiers hits the "except KeyError:
+        # continue" branch and is dropped, while later relations are still
+        # processed normally.
+        self.document.influence("ex:inf1", "ex:inf2")
+        self.document.wasGeneratedBy("ex:e2", "ex:a2")
+
+        g = prov_to_graph(self.document)
+
+        self.assertEqual(len(g.nodes()), 2)
+        self.assertEqual(len(g.edges()), 1)
+        (_, _, edge_data) = next(iter(g.edges(data=True)))
+        self.assertEqual(edge_data["relation"].get_type().localpart, "Generation")
+
+
+class GraphToProvTestCase(unittest.TestCase):
+    def test_ignores_non_record_and_bundle_less_nodes(self):
+        document = ProvDocument()
+        document.add_namespace("ex", "http://example.org/")
+        ghost_id = document.valid_qualified_name("ex:ghost")
+
+        g = nx.MultiDiGraph()
+        g.add_node("not-a-prov-record")
+        # An inferred element, exactly as prov_to_graph() constructs one:
+        # bundle=None, so graph_to_prov() must not add it as a record.
+        ghost = ProvEntity(None, ghost_id)
+        g.add_node(ghost)
+
+        prov_doc = graph_to_prov(g)
+
+        self.assertEqual(list(prov_doc.get_records()), [])
+
+    def test_ignores_edges_without_relation_key(self):
+        g = nx.MultiDiGraph()
+        g.add_node("a")
+        g.add_node("b")
+        g.add_edge("a", "b")  # no relation= kwarg in the edge data
+
+        prov_doc = graph_to_prov(g)
+
+        self.assertEqual(list(prov_doc.get_records()), [])

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -106,3 +106,13 @@ class GraphToProvTestCase(unittest.TestCase):
         prov_doc = graph_to_prov(g)
 
         self.assertEqual(list(prov_doc.get_records()), [])
+
+    def test_ignores_edges_whose_relation_is_not_a_prov_record(self):
+        g = nx.MultiDiGraph()
+        g.add_node("a")
+        g.add_node("b")
+        g.add_edge("a", "b", relation="not-a-record")
+
+        prov_doc = graph_to_prov(g)
+
+        self.assertEqual(list(prov_doc.get_records()), [])

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -107,9 +107,11 @@ class TestRead(unittest.TestCase):
         reached if every registered deserializer raises one of the caught
         exception types. In practice ProvNSerializer.deserialize() always
         raises NotImplementedError (uncaught by read()) regardless of
-        content, and it is tried third, so that branch is unreachable via
-        any real file. Mock all four deserializers to make it reachable and
-        pin the resulting error message.
+        content, and the rdf/xml parsers raise SyntaxError subclasses on
+        garbage, so that branch is unreachable via any real file. (The real
+        json deserializer already fails with a caught JSONDecodeError; it
+        is mocked here too only for uniformity.) Mock the deserializers to
+        make the branch reachable and pin the resulting error message.
         """
 
         def boom(self, stream, **kwargs):

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -1,0 +1,130 @@
+import io
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+import prov
+from prov.serializers import DoNotExist
+from prov.serializers.provjson import ProvJSONSerializer
+from prov.serializers.provn import ProvNSerializer
+from prov.serializers.provrdf import ProvRDFSerializer
+from prov.serializers.provxml import ProvXMLSerializer
+from prov.tests.examples import primer_example
+
+
+class TestRead(unittest.TestCase):
+    """Exercises prov.read(), the documented convenience entry point that
+    wraps ProvDocument.deserialize() with lazy format auto-detection."""
+
+    def setUp(self):
+        self.document = primer_example()
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write(self, fmt, filename, **kwargs):
+        path = os.path.join(self.tmpdir.name, filename)
+        self.document.serialize(destination=path, format=fmt, **kwargs)
+        return path
+
+    # -- explicit format= for each serializer -----------------------------
+
+    def test_read_explicit_json_format(self):
+        path = self._write("json", "doc.json")
+        result = prov.read(path, format="json")
+        self.assertEqual(result, self.document)
+
+    def test_read_explicit_xml_format(self):
+        path = self._write("xml", "doc.xml")
+        result = prov.read(path, format="xml")
+        self.assertEqual(result, self.document)
+
+    def test_read_explicit_rdf_format(self):
+        # Default rdf_format is "trig" on both the write and read sides.
+        path = self._write("rdf", "doc.rdf")
+        result = prov.read(path, format="rdf")
+        self.assertEqual(result, self.document)
+
+    def test_read_explicit_format_is_lowercased(self):
+        path = self._write("json", "doc-upper.json")
+        result = prov.read(path, format="JSON")
+        self.assertEqual(result, self.document)
+
+    # -- source can be a str path, a PathLike, or a file object -----------
+
+    def test_read_accepts_pathlib_path(self):
+        path = self._write("json", "doc-path.json")
+        result = prov.read(pathlib.Path(path), format="json")
+        self.assertEqual(result, self.document)
+
+    def test_read_accepts_file_object(self):
+        path = self._write("json", "doc-fileobj.json")
+        with open(path) as f:
+            result = prov.read(f, format="json")
+        self.assertEqual(result, self.document)
+
+    # -- format=None auto-detection ----------------------------------------
+
+    def test_read_auto_detects_json(self):
+        path = self._write("json", "auto.json")
+        result = prov.read(path)
+        self.assertEqual(result, self.document)
+
+    def test_read_auto_detects_rdf(self):
+        # rdf is attempted (as trig, the default) right after json, so a
+        # trig-serialized document round trips through auto-detection.
+        path = self._write("rdf", "auto.rdf")
+        result = prov.read(path)
+        self.assertEqual(result, self.document)
+
+    def test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error(self):
+        """
+        Documents actual current behaviour rather than the aspirational
+        "xml auto-detects too": Registry order is json, rdf, provn, xml
+        (see prov.serializers.Registry.load_serializers). For an XML
+        document, the json attempt fails cleanly (caught ValueError), but
+        the *rdf* candidate -- deserialized with its default "trig" format
+        -- raises rdflib's BadSyntax, a SyntaxError. read() only catches
+        (TypeError, ValueError, AttributeError, KeyError), so this
+        propagates and auto-detection never reaches the real xml
+        serializer. This is a known limitation (see
+        docs/test-gap-checklist.md, T13 item on the auto-detection
+        exception whitelist), not something fixed by this test-only change.
+        """
+        path = self._write("xml", "auto.xml")
+        with self.assertRaises(SyntaxError):
+            prov.read(path)
+
+    def test_read_unknown_format_propagates_do_not_exist(self):
+        path = self._write("json", "doc-unknown-fmt.json")
+        with self.assertRaises(DoNotExist):
+            prov.read(path, format="nonexistent")
+
+    def test_read_raises_type_error_when_all_serializers_fail_to_parse(self):
+        """
+        The final "exhausted all serializers" branch of read() can only be
+        reached if every registered deserializer raises one of the caught
+        exception types. In practice ProvNSerializer.deserialize() always
+        raises NotImplementedError (uncaught by read()) regardless of
+        content, and it is tried third, so that branch is unreachable via
+        any real file. Mock all four deserializers to make it reachable and
+        pin the resulting error message.
+        """
+
+        def boom(self, stream, **kwargs):
+            raise ValueError("simulated parse failure")
+
+        with (
+            mock.patch.object(ProvJSONSerializer, "deserialize", boom),
+            mock.patch.object(ProvRDFSerializer, "deserialize", boom),
+            mock.patch.object(ProvNSerializer, "deserialize", boom),
+            mock.patch.object(ProvXMLSerializer, "deserialize", boom),
+            self.assertRaises(TypeError) as ctx,
+        ):
+            prov.read(io.StringIO("garbage"))
+        self.assertIn("specify the format", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the Task 12 test gaps from the Phase 2 typing/coverage plan
(`docs/superpowers/plans/2026-07-04-phase-2-typing-coverage.md`, Task 12):
`prov.read()` auto-detection, `graph.py` interop branches, and the
serializer registry error path. No non-test source changes.

- `src/prov/tests/test_read.py` (new): explicit `format=` for json/xml/rdf
  (incl. lower-casing), `os.PathLike`/file-object sources, `format=` auto
  detection, unknown format propagating `DoNotExist`, and the
  exhausted-serializers `TypeError` path.
- `src/prov/tests/test_graphs.py` (extended): `prov_to_graph()`'s
  missing-endpoint skip (`if qn1 and qn2`), inferred-node construction via
  `INFERRED_ELEMENT_CLASS`, the unsupported-attribute `except KeyError:
  continue` skip, and `graph_to_prov()`'s non-record/bundle-less node
  filter and missing-`"relation"`-key tolerance, plus a round-trip-against-
  `unified()` test.
- `src/prov/tests/test_extras.py` (extended): `serializers.get()` returns
  the right class for all four formats, lazily populates
  `Registry.serializers`, and the existing unknown-format/`DoNotExist` test
  now also asserts the format name appears in the message.
- `docs/test-gap-checklist.md`: ticked the T12 items, with two documented
  findings (see below).

## Findings worth flagging

- **XML auto-detection currently doesn't work.** Registry order is
  json, rdf, provn, xml. For an XML document, `json` fails cleanly
  (caught `ValueError`), but the `rdf` candidate — deserialized with its
  default `"trig"` format — raises rdflib's `BadSyntax`, a `SyntaxError`,
  which isn't one of the four exception types `read()` catches. It
  propagates before `xml` is ever tried. `test_read.py` pins this actual
  behaviour instead of asserting the aspirational "all three formats
  auto-detect". Tracked as T13 scope (test-gap-checklist.md already flags
  the exception whitelist as a T13 item).
- **The final "exhausted all serializers → `TypeError`" branch in
  `read()` is unreachable via any real file.** `ProvNSerializer.deserialize()`
  unconditionally raises an uncaught `NotImplementedError`, and it's tried
  third (before `xml`), so the loop can never exhaust normally with real
  content. The corresponding test mocks all four serializers' `deserialize`
  to make the branch reachable and pins the message.
- **`src/prov/__init__.py` coverage lands at 94%, not the ≥95% target.**
  The only remaining miss is the `if TYPE_CHECKING:` import guard (line 7),
  which is unreachable at runtime by design — the same pattern already
  flagged as "defer to T13, consider `pragma: no cover`" for
  `serializers/__init__.py`'s identical guard. No source/config change was
  made here since that's out of scope for a test-only change; `graph.py`
  coverage is 98% (target ≥92%, comfortably met).

## Test plan

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — all formatted
- [x] `uv run mypy src` — Success: no issues found in 14 source files
- [x] `uv run pytest -q` — 991 passed, 17 xfailed (was 972 passed, 17 xfailed)
- [x] `uv run coverage run -m pytest && uv run coverage report -m` — TOTAL 94%, `graph.py` 98%, `__init__.py` 94% (see finding above)