### PR TITLE
test: close remaining audit gaps, fix coverage omit, ratchet to 97%

### DIFF
--- a/docs/test-gap-checklist.md
+++ b/docs/test-gap-checklist.md
@@ -63,7 +63,7 @@ Same subprocess-only situation as `convert.py`.
 - [x] `read(source)` without a format auto-detects by trying each registered deserializer in turn — one test per detectable format (json, xml, rdf) — **T12** (finding: json and rdf/trig genuinely auto-detect; an xml document does not — the registry tries rdf, as trig, before xml, and rdflib's `BadSyntax` on the xml content is a `SyntaxError` that read()'s except clause doesn't catch, so it propagates before xml is ever tried. Test pins this actual behaviour rather than asserting the aspirational "all three auto-detect")
 - [x] `read()` on undetectable/garbage input raises `TypeError` with the "specify the format" message after exhausting all serializers — **T12** (finding: unreachable via any real file — `ProvNSerializer.deserialize()` unconditionally raises uncaught `NotImplementedError` and is tried third, before the loop can ever exhaust normally; test reaches the branch by mocking all four deserializers to raise a caught exception type)
 - [x] `read()` accepts both a filename (`str`/`PathLike`) and a file object, matching `ProvDocument.deserialize` — **T12**
-- [ ] Auto-detection swallows only `(TypeError, ValueError, AttributeError, KeyError)` from candidate deserializers — **T13** (behavioural pin: a deserializer raising something else, e.g. the PROV-N serializer's `NotImplementedError`, must propagate — document the intended behaviour when writing the test)
+- [x] Auto-detection swallows only `(TypeError, ValueError, AttributeError, KeyError)` from candidate deserializers — **T13** (`test_read.py::test_read_auto_detect_only_swallows_the_documented_exception_types` mocks a deserializer to raise `RuntimeError` and asserts it propagates instead of being swallowed)
 
 ## src/prov/graph.py — 83% (missed: 88, 90–93, 116–117 + partial branches)
 
@@ -81,48 +81,57 @@ gaps: 8 of the 9 non-equivalent surviving mutants live here.
 
 - [x] `serializers.get()` on an unknown format raises `DoNotExist` with the format name in the message, chained from `KeyError` — **T12** (the chaining itself is already tested by `test_extras.py::test_get_serializer_for_unknown_format_chains_key_error` from T9 — extended in place with the format-name-in-message assertion, one module owns it)
 - [x] `serializers.get()` lazily populates `Registry.serializers` on first call (registry starts as `None`, holds exactly the four formats json/rdf/provn/xml) — **T12**
-- [ ] `Serializer.serialize`/`.deserialize` abstract bodies (lines 39, 48) and the `if TYPE_CHECKING:` import (line 10) — **defer** (never executed at runtime by design; consider `pragma: no cover` in T13 instead of tests)
+- [x] `Serializer.serialize`/`.deserialize` abstract bodies (lines 39, 48) and the `if TYPE_CHECKING:` import (line 10) — **T13 defer, resolved via config**: added `# pragma: no cover` to both abstract `pass` bodies and `"if TYPE_CHECKING:"` to `[tool.coverage.report] exclude_lines` in `pyproject.toml` (also fixes the matching `prov/__init__.py:7` TYPE_CHECKING guard). Both modules are now 100%.
 
-## src/prov/identifier.py — 87% (missed: 119, 141–146, 156–164)
+## src/prov/identifier.py — 87% → 100% (T13)
 
-- [ ] `Namespace(prefix, uri)` rejects an empty/whitespace URI with `ValueError` — **T13**
-- [ ] `Namespace.contains()` for a str, an `Identifier`, a non-matching URI, and a non-str/non-Identifier argument (returns False) — **T13**
-- [ ] `Namespace.qname()` returns a `QualifiedName` for a contained URI (str and `Identifier` inputs) and `None` for a non-contained or non-string input — **T13**
+- [x] `Namespace(prefix, uri)` rejects an empty/whitespace URI with `ValueError` — **T13** (`test_identifier.py::TestNamespace::test_namespace_rejects_empty_uri` / `test_namespace_rejects_whitespace_only_uri`)
+- [x] `Namespace.contains()` for a str, an `Identifier`, a non-matching URI, and a non-str/non-Identifier argument (returns False) — **T13** (new `test_identifier.py`)
+- [x] `Namespace.qname()` returns a `QualifiedName` for a contained URI (str and `Identifier` inputs) and `None` for a non-contained or non-string input — **T13** (new `test_identifier.py`)
 
-## src/prov/model.py — 90% (79 missed lines, 31 partial branches)
+## src/prov/model.py — 90% → 98% (T13)
 
-Large module; misses are scattered single lines, but they cluster into these behaviours:
+Large module; misses were scattered single lines, clustering into these behaviours (all
+in `test_model.py` unless noted):
 
-- [ ] Literal handling: `parse_xsd_datetime` returning `None` on unparseable input; `parse_boolean` on `"true"/"1"/"false"/"0"/other`; `Literal.__eq__`/`__ne__`/`__hash__`; langtag forcing datatype to `prov:InternationalizedString` with a warning (lines 74–85, 167–194, 248–258) — **T13**
-- [ ] Attribute validation errors: `ProvException` on a `None`-identifier record used as an attribute value, on unparseable datetime formal attributes, on `None` literal conversion, and on conflicting duplicate values for a single-valued PROV attribute (lines 480–537) — **T13**
-- [ ] `ProvElement` creation without an identifier raises `ProvElementIdentifierRequired` (line 634) — **T13**
-- [ ] Element convenience methods not exercised by `examples.py`: `ProvEntity.wasInvalidatedBy`, `ProvActivity.wasStartedBy`/`wasEndedBy` fluent wrappers, membership helper (712–713, 779–780, 861–908) — **T13**
-- [ ] `NamespaceManager`: default-namespace-less construction, `get_namespace()` miss/hit, rename-map reuse of already-renamed namespaces, blank-node (`_:`) and non-str/Identifier inputs to `valid_qualified_name` returning `None`, `get_anonymous_identifier()`, `_get_unused_prefix` counting (1159–1181, 1219, 1320–1373) — **T13**
-- [ ] `ProvBundle` API edges: `ProvBundle.bundles` raising `ProvException`, `.records`/`.identifier`/`.document` properties on standalone bundles, `add_namespace` without URI raising, `mandatory_valid_qname` failure, `__eq__` early-outs (1429–1517, 1570–1630) — **T13**
-- [ ] `ProvDocument` bundle management errors: `bundle(None)`, invalid/duplicate bundle identifier, `add_bundle` of a document with nested bundles, `update()` merging bundles with the same id (2664–2704) — **T13**
-- [ ] `plot()` (2437–2485): format inference from filename, unknown format `ValueError`, matplotlib `ImportError` message — **defer** for the interactive/matplotlib display path (needs matplotlib + a display; not in the test env); the filename-based save path and the `ValueError` are testable if graphviz is present, park under **T13** as optional
-- [ ] `serialize()` to a file path via the tempfile+move path, and `deserialize()` `TypeError` when neither source nor content given (2756–2757, 2801) — **T12** (natural neighbours of the `read()` tests)
+- [x] Literal handling: `parse_xsd_datetime` returning `None` on unparseable input; `parse_boolean` on `"true"/"1"/"false"/"0"/other`; `Literal.__eq__`/`__ne__`/`__hash__`; langtag forcing datatype to `prov:InternationalizedString` with a warning (lines 74–85, 167–194, 248–258) — **T13** (`TestLiteralHandling`)
+- [x] Attribute validation errors: `ProvException` on a `None`-identifier record used as an attribute value, on unparseable datetime formal attributes, and on conflicting duplicate values for a single-valued PROV attribute (lines 480–537) — **T13** (`TestAttributeValidationErrors`). Two sub-branches deferred: line 503 (`_auto_literal_conversion`'s "value is None" guard) and 521-523 (`except TypeError` on the duplicate-value comparison) are dead for any value this library can construct — `_auto_literal_conversion` never returns `None` for a non-`None` input (traced all branches), and no `PROV_ATTRIBUTES` value type (`QualifiedName`/`Identifier`, `datetime.datetime`) raises `TypeError` on `!=` (confirmed empirically, including naive-vs-aware datetimes, which return `True` rather than raising).
+- [x] `ProvElement` creation without an identifier raises `ProvElementIdentifierRequired` (line 634) — **T13** (`TestElementIdentifierRequired`, plus both exceptions' `__str__`)
+- [x] Element convenience methods not exercised by `examples.py`: `ProvEntity.wasInvalidatedBy`/`hadMember`, `ProvActivity.wasStartedBy`/`wasEndedBy`/`wasInformedBy`, `set_time()` — **T13** (`TestElementConvenienceMethods`)
+- [x] `NamespaceManager`: default-namespace-less/with-default construction, `get_namespace()` miss/hit, rename-map reuse of already-renamed namespaces, blank-node (`_:`) and non-str/Identifier inputs to `valid_qualified_name` returning `None`, `get_anonymous_identifier()`, `_get_unused_prefix` counting and its "prefix free" branch, empty `add_namespaces()` — **T13** (`TestNamespaceManagerEdges`)
+- [x] `ProvBundle` API edges: `ProvBundle.bundles` raising `ProvException`, `.records`/`.identifier`/`.document`/`.default_ns_uri`/`get_registered_namespaces()`/`has_bundles()` on standalone bundles, `add_namespace` without URI raising, `mandatory_valid_qname` failure, `__eq__` early-outs — **T13** (`TestProvBundleEdges`, `TestRecordMiscProperties`)
+- [x] `ProvDocument` bundle management errors: `bundle(None)`, `bundle()` with an unresolvable/duplicate identifier, `add_bundle` of a document with nested bundles, `update()` merging bundles with the same id and skipping the merge block when `other` has no bundles, `__eq__` bundle-mismatch early-outs, `unified()` with no bundles — **T13** (`TestAddBundle`, `TestBundleUpdate`, `TestDocumentEqualityAndUnification`)
+- [x] `plot()` (2437–2485): format inference from filename and the unknown-format `ValueError` are covered (`TestPlot`, guarded by `skipUnless(shutil.which("dot"))`). The matplotlib-requiring interactive-display path (2463, 2470–2485) stays **deferred**: matplotlib is an optional `plot` extra not installed in this dev/CI environment, and `test_extras.py::test_plot_without_matplotlib_raises_helpful_error` (pre-existing) already covers the `ImportError`-message branch by mocking the import to fail — line 2463 specifically (`import matplotlib.pylab`) can't be reached without the real package.
+- [x] `serialize()` to a file path via the tempfile+move path, and `deserialize()` `TypeError` when neither source nor content given — **T13** (`TestSerializeDeserializeEdgeCases`; natural neighbours of the T12 `read()` tests). The `shutil.move`-missing `else` fallback (2756-2757) stays **deferred**: `shutil.move` always exists on every supported interpreter, so `hasattr(shutil, "move")` is always `True`.
 
-## src/prov/serializers/provrdf.py — 88% (40 missed lines, 18 partial branches)
+## src/prov/serializers/provrdf.py — 88% → 95% (T13)
 
-- [ ] `serialize()`/`deserialize()` datatype corner cases: `xsd:QName`, `xsd:gYear`, `xsd:gYearMonth`, XMLLiteral, base64Binary decoding (221–231, 754–771) — **T13**
-- [ ] `literal_rdf_representation()`: langtag branch, base64 encode branch, `ValueError` on datatype-less literal (754–771) — **T13**
-- [ ] Decode robustness: `ValueError` on untransformable objects, "attributes not converted" warning path, multi-valued unique-set walking (690–730) — **T13**
-- [ ] `ProvRDFException` "No document to serialize." (137) — **T13**
-- [ ] Known-dead branches: the `False and ...`-disabled block (~549) and the unreachable `rec_type in [PROV_ACTIVITY]` relation branch (~493–506) — **defer** (documented in-source as frozen 2.x behaviour, scheduled for deletion in 3.0; do not write tests against dead code)
+- [x] `serialize()`/`deserialize()` datatype corner cases: `xsd:QName`, `xsd:gYear`, `xsd:gYearMonth`, base64Binary decoding — **T13** (`test_rdf.py::TestRDFSerializer::test_decode_xsd_qname_gyear_gyearmonth_round_trip`, `test_literal_rdf_representation_base64binary`). XMLLiteral decoding is a one-line passthrough (`value = literal`, no distinct branch to hit beyond the datatype check already exercised) — no separate test needed.
+- [x] `literal_rdf_representation()`: langtag branch, base64 encode branch, `ValueError` on datatype-less literal — **T13** (`test_literal_rdf_representation_langtag`, `test_literal_rdf_representation_base64binary`, `test_literal_rdf_representation_without_datatype_raises`)
+- [x] Decode robustness: "attributes not converted" warning path (already exercised by the pre-existing `RoundTripRDFTests::test_membership_*`/`test_json_to_ttl_match`, visible as `UserWarning` output in the suite), multi-valued unique-set walking — **T13** (`test_decode_multi_valued_qualified_relation_produces_cartesian_product`: a hand-authored qualified-`Usage` bnode with two `prov:entity` triples decodes into two separate `Usage` records via `walk()`'s cartesian product). `ValueError` on untransformable objects (line 669, `if obj is not None and obj1 is None: raise ValueError`) is **deferred**: traced `decode_rdf_representation()` exhaustively — for any non-`None` RDF term (`RDFLiteral`, `URIRef`, or the implicit `BNode`/other passthrough) it always returns a non-`None` value, so `obj1 is None` cannot occur for a real triple.
+- [x] `ProvRDFException` "No document to serialize." (137) — **T13** (`test_serialize_without_a_document_raises`)
+- [x] `encode_container()`'s `container=` parameter (defaults to `None` at every internal call site, so the "reuse a provided container" branch was previously dead code from the test suite's perspective) — **T13** (`test_encode_container_reuses_a_provided_container`, calling the method directly as an external caller would)
+- [x] `decode_document()`'s `hasattr(content, "contexts")` `else` branch, for a plain `rdflib.Graph` rather than a `ConjunctiveGraph` — **T13** (`test_decode_document_without_contexts_uses_plain_graph_path`)
+- [ ] Known-dead branches, confirmed unreachable via any value this library can construct (traced each, left **deferred**, do not write tests against dead code):
+  - the `False and ...`-disabled block (~493, documented in-source as frozen 2.x behaviour scheduled for deletion in 3.0) and the unreachable `rec_type in [PROV_ACTIVITY]` relation branch (~456-459, also documented in-source: unreachable inside the `is_relation()` path)
+  - `AnonymousIDGenerator.get_anon_id()` (67-70) and the `isinstance(value, pm.ProvRecord)` branch that would call it (482): `_auto_literal_conversion()` already converts any `ProvRecord` attribute value to its identifier before storage, so `encode_container()` never sees a raw `ProvRecord` value
+  - the `IndexError` fallback at 335-336 (`record.formal_attributes[1]`): every relation subclass has ≥2 `FORMAL_ATTRIBUTES`, so the tuple always has a second element
+  - the `elif isinstance(attr, pm.QualifiedName): ... else:` fallback at 418 and the `elif attr == PROV["plan"]:` branch at 410: for a formal `prov:plan` attribute, `attr in formal_objects` (line 405) always intercepts first: exercising 410 legitimately would require a non-`Association` relation carrying a generic extra attribute literally named `prov:plan`, which is a contrived construction with no realistic PROV-O source
+  - the `except AttributeError` at 586-587: guards a `dict[obj]` lookup already proven present by the enclosing `if obj in PROV_CLS_MAP:`, so a `KeyError` (not `AttributeError`) would be the only possible failure, and it can't happen here either
 
-## src/prov/serializers/provxml.py — 97% / provjson.py — 96% / provn.py — 87%
+## src/prov/serializers/provxml.py — 97% → 99% / provjson.py — 96% → 99% / provn.py — 87% → 100% (T13)
 
-- [ ] XML: "Non PROV element discovered" `ProvXMLException`, ignored-attribute warning, "Could not create a valid QualifiedName" error (59, 271, 377, 423) — **T13**
-- [ ] JSON: `ProvJSONException` on multi-valued PROV attributes; encoder fallback for non-document objects (103, 254–259) — **T13**
-- [ ] PROV-N: "No document to serialize" error (22) — **T13**
+- [x] XML: "Non PROV element discovered" `ProvXMLException` (`test_xml.py::ProvXMLSerializerErrorsTestCase::test_non_prov_top_level_element_raises`), "No document to serialize." (`test_serialize_without_a_document_raises`, line 59), ignored-attribute warning (`test_unrepresentable_sub_element_attribute_warns_and_is_ignored`), "Could not create a valid QualifiedName" error (`test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises`) — **T13**. Two deep partial branches left unaddressed (not explicit checklist items, low value): 109->108 (a bundle reusing a namespace prefix already registered at the document level — needs a contrived multi-namespace nested-bundle fixture) and 398->409 (an XML sub-element with no attributes at all combined with one that has some, in the same `_extract_attributes` call).
+- [x] JSON: `ProvJSONException` on multi-valued PROV attributes; encoder fallback for non-document objects; the "attribute touched but never explicitly set" defaultdict-skip (`if not values: continue`, found while writing these tests — accessing `.label`/`.value` auto-vivifies an empty attribute-set entry that the encoder must not emit); the third-or-later record sharing an identifier appending directly to the existing list — **T13** (`test_json.py::TestJSONSerializer`, 4 new tests). One deep partial branch left (not an explicit checklist item): 43->46 in `AnonymousIDGenerator.get_anon_id` (the "already cached" branch, needs the same anonymous record referenced twice during one encode pass).
+- [x] PROV-N: "No document to serialize" error (22) — **T13** (`test_extras.py::TestProvNSerializer`). Module now 100%.
 
-## src/prov/dot.py — 89% (missed: 183–187, 216, 281–287, 356, 376)
+## src/prov/dot.py — 89% → 96% (T13)
 
-- [ ] `htlm_link_if_uri()` returns an `<a href>` for values with a `.uri` and `str(value)` otherwise — **T13**
-- [ ] Invalid `direction` argument falls back to `"BT"` — **T13**
-- [ ] `use_labels=True` rendering, both label==identifier and label!=identifier variants (281–287) — **T13**
-- [ ] Skipping relations with fewer than two endpoint nodes / empty-args records (356, 376) — **T13**
+- [x] `htlm_link_if_uri()` returns an `<a href>` for values with a `.uri` and `str(value)` otherwise — **T13** (`test_dot.py::HtlmLinkIfUriTest`; the function is unused internally by `prov_to_dot()` but is a public module-level helper)
+- [x] Invalid `direction` argument falls back to `"BT"` — **T13** (`ProvToDotDirectionTest`)
+- [x] `show_element_attributes=False` skips the attribute-annotation node (found while covering this module; every other test left it at its `True` default) — **T13** (`ProvToDotShowElementAttributesTest`)
+- [x] `use_labels=True` rendering, `label != identifier` variant (the realistic case) — **T13** (`ProvToDotUseLabelsTest`). The `label == identifier` variant (dot.py:281-282) is **deferred**: `ProvRecord.label` always returns a plain `str`, `.identifier` is always a `QualifiedName`, and `str.__eq__`/`QualifiedName.__eq__` can never consider the two equal regardless of content (confirmed empirically: `entity.label == entity.identifier` is `False` even when their string forms match) — this branch is dead for any real record.
+- [ ] Skipping relations with fewer than two endpoint nodes / empty-args records (356, 376) — **defer**: both branches require a `ProvRelation` with `FORMAL_ATTRIBUTES` shorter than the 2 entries every concrete relation subclass in `model.py` declares. The only way to construct such a record is instantiating the abstract base `ProvRelation` directly (bypassing every named subclass), and any document containing it fails earlier: `prov_to_dot()` unconditionally calls `bundle.unified()`, which reconstructs every record via `add_record()` → `record.get_type()`, and `ProvRelation.get_type()` raises `NotImplementedError` (no `_prov_type` set) before the drawing loop is ever reached. Confirmed by tracing the call chain; not worth a contrived monkeypatch-heavy test.
 
 ---
 
@@ -133,7 +142,7 @@ Large module; misses are scattered single lines, but they cluster into these beh
 lifting TOTAL from 87.4% (package only) to 91.2%. CI has always measured it this way, so
 the `fail_under = 91` ratchet set by this task is consistent with what CI enforces, but:
 
-- [ ] Fix the omit pattern (e.g. `omit = ["*/prov/tests/*"]`) so the report reflects package code only, and re-base `fail_under` to the package-only number in the same commit — **T13** (do this *before* ratcheting toward 95, otherwise the target is measured against inflated numbers)
+- [x] Fix the omit pattern (e.g. `omit = ["*/prov/tests/*"]`) so the report reflects package code only, and re-base `fail_under` to the package-only number in the same commit — **T13**: changed to `omit = ["*/prov/tests/*"]`; re-measured before doing any further test work (see closing note below for the before/after numbers).
 
 ---
 
@@ -187,3 +196,36 @@ Survivor analysis — every survivor was informative:
   harvesting survivors into test items. Do not wire it into CI, do not add it to
   project dependencies, and re-evaluate mutmut 3.x (or `cosmic-ray`) only if the ad hoc
   workflow proves too manual.
+
+---
+
+## T13 closing note
+
+Every checklist item above is now either ticked or explicitly marked **defer** with a
+one-line (or longer, where the reasoning wasn't obvious) rationale; none are left
+unresolved.
+
+**Coverage, before/after this task, `uv run coverage run -m pytest && uv run coverage
+report -m` (branch coverage on):**
+
+| Scope | Before T13 | After T13 |
+|---|---|---|
+| TOTAL as CI measured it pre-fix (inflated by `src/prov/tests/`, buggy omit) | 91.218% | n/a, omit fixed |
+| Package-only TOTAL (honest, `omit = ["*/prov/tests/*"]`) | 91.458% | **97.42%** |
+
+Per-module: `__init__.py`, `graph.py`, `identifier.py`, `serializers/__init__.py`,
+`serializers/provn.py` all reached 100%; `model.py` 98%; `provjson.py`/`provxml.py` 99%;
+`dot.py` 96%; `provrdf.py` 95% (the largest/most complex serializer, with several
+confirmed-dead branches around 2.x-frozen RDF encoding quirks); `scripts/convert.py`
+93% and `scripts/compare.py` 86% (unchanged from T11, already fully ticked there).
+
+The new coverage ratchet is `fail_under = 97` (rounded down from 97.42%, comfortably
+above the ≥95 target and the ≥93 floor), measured against the fixed omit pattern — i.e.
+package code only, matching what `[tool.coverage.run] source = ["prov"]` +
+`omit = ["*/prov/tests/*"]` actually reports. CI's 3.12 job (the only one that runs
+`coverage report`) should land within a few hundredths of the same number; the ~0.4
+point margin above the 97 floor absorbs the cross-interpreter drift noted in T10.
+
+Test suite: 1083 passed, 17 xfailed (up from the 992 passed / 17 xfailed baseline
+recorded before this task — all 91 new tests pass, none of the pre-existing ones were
+modified in behaviour). `ruff check`, `ruff format --check`, and `mypy src` all clean.

--- a/docs/test-gap-checklist.md
+++ b/docs/test-gap-checklist.md
@@ -18,9 +18,12 @@ CI-visible TOTAL is inflated by ~3.8 points of near-fully-covered test code. Fix
 omit pattern is a T13 item and requires re-basing the ratchet at the same time.
 
 Owner tags: **T11** = in-process CLI tests for `prov-convert`/`prov-compare` exercising
-`main()`; **T12** = `prov.read()` auto-detection, `graph.py` branches, serializer
-registry; **T13** = remaining gaps + ratchet toward ~95; **defer** = documented
-won't-test (reason given inline).
+`main()` (completed 2026-07-05, PR #202); **T12** = `prov.read()` auto-detection,
+`graph.py` branches, serializer registry (completed 2026-07-05, PR #203); **T13** =
+remaining gaps + ratchet toward ~95 (completed 2026-07-05, see closing note); **defer**
+= documented won't-test (reason given inline). Dates matter here: every "line N" /
+"module X%" reference is against the code as of the run recorded next to it, and will
+drift in later versions — re-measure rather than trusting old numbers.
 
 Per-module numbers below are from the audit run; re-measure before starting each task —
 they will drift.
@@ -95,7 +98,7 @@ Large module; misses were scattered single lines, clustering into these behaviou
 in `test_model.py` unless noted):
 
 - [x] Literal handling: `parse_xsd_datetime` returning `None` on unparseable input; `parse_boolean` on `"true"/"1"/"false"/"0"/other`; `Literal.__eq__`/`__ne__`/`__hash__`; langtag forcing datatype to `prov:InternationalizedString` with a warning (lines 74–85, 167–194, 248–258) — **T13** (`TestLiteralHandling`)
-- [x] Attribute validation errors: `ProvException` on a `None`-identifier record used as an attribute value, on unparseable datetime formal attributes, and on conflicting duplicate values for a single-valued PROV attribute (lines 480–537) — **T13** (`TestAttributeValidationErrors`). Two sub-branches deferred: line 503 (`_auto_literal_conversion`'s "value is None" guard) and 521-523 (`except TypeError` on the duplicate-value comparison) are dead for any value this library can construct — `_auto_literal_conversion` never returns `None` for a non-`None` input (traced all branches), and no `PROV_ATTRIBUTES` value type (`QualifiedName`/`Identifier`, `datetime.datetime`) raises `TypeError` on `!=` (confirmed empirically, including naive-vs-aware datetimes, which return `True` rather than raising).
+- [x] Attribute validation errors: `ProvException` on a `None`-identifier record used as an attribute value, on unparseable datetime formal attributes, and on conflicting duplicate values for a single-valued PROV attribute (lines 480–537) — **T13** (`TestAttributeValidationErrors`). Line 503 (the "value is None" guard after `_auto_literal_conversion`) is reachable through the generic-attribute path — an anonymous (identifier-less) record used as a plain attribute value converts to `None` — and is covered by `test_identifierless_record_as_generic_attribute_value_raises`. One sub-branch deferred: 521-523 (`except TypeError` on the duplicate-value comparison) is dead for any value this library can construct — no `PROV_ATTRIBUTES` value type (`QualifiedName`/`Identifier`, `datetime.datetime`) raises `TypeError` on `!=` (confirmed empirically, including naive-vs-aware datetimes, which return `True` rather than raising).
 - [x] `ProvElement` creation without an identifier raises `ProvElementIdentifierRequired` (line 634) — **T13** (`TestElementIdentifierRequired`, plus both exceptions' `__str__`)
 - [x] Element convenience methods not exercised by `examples.py`: `ProvEntity.wasInvalidatedBy`/`hadMember`, `ProvActivity.wasStartedBy`/`wasEndedBy`/`wasInformedBy`, `set_time()` — **T13** (`TestElementConvenienceMethods`)
 - [x] `NamespaceManager`: default-namespace-less/with-default construction, `get_namespace()` miss/hit, rename-map reuse of already-renamed namespaces, blank-node (`_:`) and non-str/Identifier inputs to `valid_qualified_name` returning `None`, `get_anonymous_identifier()`, `_get_unused_prefix` counting and its "prefix free" branch, empty `add_namespaces()` — **T13** (`TestNamespaceManagerEdges`)
@@ -199,7 +202,7 @@ Survivor analysis — every survivor was informative:
 
 ---
 
-## T13 closing note
+## T13 closing note (2026-07-05)
 
 Every checklist item above is now either ticked or explicitly marked **defer** with a
 one-line (or longer, where the reasoning wasn't obvious) rationale; none are left
@@ -226,6 +229,6 @@ package code only, matching what `[tool.coverage.run] source = ["prov"]` +
 `coverage report`) should land within a few hundredths of the same number; the ~0.4
 point margin above the 97 floor absorbs the cross-interpreter drift noted in T10.
 
-Test suite: 1083 passed, 17 xfailed (up from the 992 passed / 17 xfailed baseline
-recorded before this task — all 91 new tests pass, none of the pre-existing ones were
+Test suite: 1084 passed, 17 xfailed (up from the 992 passed / 17 xfailed baseline
+recorded before this task — all 92 new tests pass, none of the pre-existing ones were
 modified in behaviour). `ruff check`, `ruff format --check`, and `mypy src` all clean.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ python_classes = []
 [tool.coverage.run]
 branch = true
 source = ["prov"]
-omit = ["*/tests*"]
+omit = ["*/prov/tests/*"]
 
 [tool.coverage.paths]
 source = [
@@ -165,15 +165,23 @@ source = [
 ]
 
 [tool.coverage.report]
-# Coverage ratchet (docs/test-gap-checklist.md): measured 91.218% at the Phase 2
-# audit. Raise as T11-T13 close gaps; never lower without a documented reason.
-fail_under = 91
+# Coverage ratchet (docs/test-gap-checklist.md). T13 fixed the `omit` glob
+# above (it previously did not exclude src/prov/tests/, inflating TOTAL by
+# ~3.8pt with near-fully-covered test code) and closed the remaining
+# checklist gaps; the honest package-only TOTAL measured after that work is
+# 97.42%, rounded down to this floor. Never lower without a documented
+# reason. Remaining misses are individually annotated as "defer" in the
+# checklist (dead/defensive branches unreachable via the public API, plus
+# the matplotlib-requiring interactive plot() path not installed in the
+# test env).
+fail_under = 97
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",
     "raise AssertionError",
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
 ]
 
 [tool.mypy]

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -36,7 +36,7 @@ class Serializer(ABC):
 
         :param stream: Stream object to serialize the document into.
         """
-        pass
+        pass  # pragma: no cover -- abstract body, never executed directly
 
     @abstractmethod
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:
@@ -45,7 +45,7 @@ class Serializer(ABC):
 
         :param stream: Stream object to deserialize the document from.
         """
-        pass
+        pass  # pragma: no cover -- abstract body, never executed directly
 
 
 class DoNotExist(Error):

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -10,7 +10,8 @@ import unittest
 from importlib.util import find_spec
 
 if find_spec("pydot") is not None:
-    from prov.dot import prov_to_dot
+    from prov.dot import htlm_link_if_uri, prov_to_dot
+    from prov.model import ProvDocument
     from prov.tests.test_model import AllTestsBase
     from prov.tests.utility import DocumentBaseTestCase
 
@@ -31,6 +32,71 @@ if find_spec("pydot") is not None:
                 "The size of the generated SVG content should be greater than "
                 f"{self.MIN_SVG_SIZE} bytes",
             )
+
+    class HtlmLinkIfUriTest(unittest.TestCase):
+        """Covers dot.htlm_link_if_uri() (docs/test-gap-checklist.md, T13
+        item under dot.py); not called internally by prov_to_dot() but a
+        module-level function usable by external callers."""
+
+        def test_value_with_uri_becomes_a_link(self):
+            doc = ProvDocument()
+            doc.add_namespace("ex", "http://example.org/")
+            e1 = doc.entity("ex:e1")
+            result = htlm_link_if_uri(e1.identifier)
+            self.assertIn("<a href=", result)
+            self.assertIn("http://example.org/e1", result)
+
+        def test_plain_value_returned_as_str(self):
+            self.assertEqual(htlm_link_if_uri("just a string"), "just a string")
+
+    class ProvToDotDirectionTest(unittest.TestCase):
+        """Covers the direction-validation fallback in prov_to_dot()
+        (docs/test-gap-checklist.md, T13 item under dot.py)."""
+
+        def setUp(self):
+            self.doc = ProvDocument()
+            self.doc.add_namespace("ex", "http://example.org/")
+            self.doc.entity("ex:e1")
+
+        def test_invalid_direction_falls_back_to_bt(self):
+            dot = prov_to_dot(self.doc, direction="SIDEWAYS")
+            self.assertEqual(dot.get_rankdir(), "BT")
+
+        def test_valid_direction_is_preserved(self):
+            dot = prov_to_dot(self.doc, direction="LR")
+            self.assertEqual(dot.get_rankdir(), "LR")
+
+    class ProvToDotUseLabelsTest(unittest.TestCase):
+        """Covers the use_labels=True node-rendering branch
+        (docs/test-gap-checklist.md, T13 item under dot.py). The
+        label==identifier branch (dot.py:281-282) is unreachable via any
+        real record: ProvRecord.label always returns a plain `str`, while
+        `.identifier` is a QualifiedName, and `str.__eq__`/`QualifiedName.
+        __eq__` can never consider the two equal -- confirmed empirically;
+        left deferred (see checklist)."""
+
+        def test_use_labels_with_explicit_label_differing_from_identifier(self):
+            doc = ProvDocument()
+            doc.add_namespace("ex", "http://example.org/")
+            doc.entity("ex:e1", other_attributes={"prov:label": "My Entity"})
+
+            dot = prov_to_dot(doc, use_labels=True)
+            svg_content = dot.create(format="svg", encoding="utf-8")
+            self.assertIn(b"My Entity", svg_content)
+
+    class ProvToDotShowElementAttributesTest(unittest.TestCase):
+        """Covers prov_to_dot(show_element_attributes=False) (docs/test-gap-
+        checklist.md, T13 item under dot.py); every other test in this
+        module leaves it at its True default."""
+
+        def test_show_element_attributes_false_skips_annotation(self):
+            doc = ProvDocument()
+            doc.add_namespace("ex", "http://example.org/")
+            doc.entity("ex:e1", other_attributes={"ex:extra": "value"})
+
+            dot = prov_to_dot(doc, show_element_attributes=False)
+            svg_content = dot.create(format="svg", encoding="utf-8")
+            self.assertNotIn(b"value", svg_content)
 
 
 if __name__ == "__main__":

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 
 from prov.dot import prov_to_dot
@@ -323,6 +324,19 @@ class TestExtras(unittest.TestCase):
             self.assertIn("prov[plot]", str(ctx.exception))
         finally:
             builtins.__import__ = real_import
+
+
+class TestProvNSerializer(unittest.TestCase):
+    """Covers ProvNSerializer.serialize()'s "no document" guard
+    (docs/test-gap-checklist.md, T13 item under serializers/provn.py)."""
+
+    def test_serialize_without_a_document_raises(self):
+        from prov.serializers.provn import ProvNSerializer
+
+        serializer = ProvNSerializer(document=None)
+        with self.assertRaises(Exception) as ctx:
+            serializer.serialize(io.StringIO())
+        self.assertIn("No document to serialize", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/src/prov/tests/test_identifier.py
+++ b/src/prov/tests/test_identifier.py
@@ -1,0 +1,54 @@
+import unittest
+
+from prov.identifier import Identifier, Namespace
+
+
+class TestNamespace(unittest.TestCase):
+    """Exercises prov.identifier.Namespace edges not otherwise covered by the
+    serializer round-trip tests (docs/test-gap-checklist.md, T13)."""
+
+    def test_namespace_rejects_empty_uri(self):
+        with self.assertRaises(ValueError):
+            Namespace("ex", "")
+
+    def test_namespace_rejects_whitespace_only_uri(self):
+        with self.assertRaises(ValueError):
+            Namespace("ex", "   ")
+
+    def test_contains_with_matching_str(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertTrue(ns.contains("http://example.org/thing"))
+
+    def test_contains_with_matching_identifier(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertTrue(ns.contains(Identifier("http://example.org/thing")))
+
+    def test_contains_with_non_matching_uri(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertFalse(ns.contains("http://other.org/thing"))
+
+    def test_contains_with_non_str_non_identifier_returns_false(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertFalse(ns.contains(12345))
+
+    def test_qname_for_contained_str(self):
+        ns = Namespace("ex", "http://example.org/")
+        qname = ns.qname("http://example.org/thing")
+        self.assertEqual(str(qname), "ex:thing")
+
+    def test_qname_for_contained_identifier(self):
+        ns = Namespace("ex", "http://example.org/")
+        qname = ns.qname(Identifier("http://example.org/thing"))
+        self.assertEqual(str(qname), "ex:thing")
+
+    def test_qname_for_non_contained_uri_returns_none(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertIsNone(ns.qname("http://other.org/thing"))
+
+    def test_qname_for_non_str_non_identifier_returns_none(self):
+        ns = Namespace("ex", "http://example.org/")
+        self.assertIsNone(ns.qname(12345))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/prov/tests/test_json.py
+++ b/src/prov/tests/test_json.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 
 from prov.model import ProvDocument
+from prov.serializers.provjson import ProvJSONEncoder, ProvJSONException
 from prov.tests.test_model import AllTestsBase
 from prov.tests.utility import RoundTripTestCase
 
@@ -25,6 +26,62 @@ class TestJSONSerializer(unittest.TestCase):
         prov_doc = ProvDocument.deserialize(content=json_content, format="json")
         e1 = prov_doc.get_record("ex:unicode_char")[0]
         self.assertIn(unicode_char, e1.get_attribute("prov:label"))
+
+    def test_multi_valued_prov_attribute_raises(self):
+        # PROV attributes (e.g. usage's prov:entity) must be single-valued;
+        # a JSON list of more than one value is rejected (docs/test-gap-
+        # checklist.md, T13 item under serializers/provjson.py).
+        json_content = """{
+    "prefix": {"ex": "http://example.org/"},
+    "used": {
+        "ex:u1": {
+            "prov:activity": "ex:a1",
+            "prov:entity": ["ex:e1", "ex:e2"]
+        }
+    }
+}"""
+        self.assertRaises(
+            ProvJSONException,
+            ProvDocument.deserialize,
+            content=json_content,
+            format="json",
+        )
+
+    def test_encoder_default_fallback_for_non_document(self):
+        # ProvJSONEncoder.default() is only ever invoked by json.dump() for
+        # objects it does not natively know how to encode; for anything
+        # other than a ProvDocument it falls back to the base encoder.
+        encoder = ProvJSONEncoder()
+        self.assertEqual(encoder.default("plain string"), '"plain string"')
+
+    def test_attribute_touched_but_never_set_is_omitted_from_json(self):
+        # Accessing .label/.value auto-vivifies an empty set entry in the
+        # record's attribute dict (a plain defaultdict); the encoder must
+        # skip empty attribute value sets rather than emitting them.
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        e1 = doc.entity("ex:e1")
+        _ = e1.label  # touches (and auto-vivifies) the "prov:label" entry
+
+        json_str = doc.serialize(format="json")
+
+        self.assertNotIn("prov:label", json_str)
+
+    def test_third_record_with_same_identifier_appends_to_existing_list(self):
+        # The first duplicate-identifier record turns the container entry
+        # into a singleton list; a third (or later) record with the same
+        # identifier must append directly to that list without re-wrapping
+        # it (docs/test-gap-checklist.md, T13 item under provjson.py).
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        doc.activity("ex:a1", other_attributes={"ex:tag": "one"})
+        doc.activity("ex:a1", other_attributes={"ex:tag": "two"})
+        doc.activity("ex:a1", other_attributes={"ex:tag": "three"})
+
+        json_str = doc.serialize(format="json")
+        reloaded = ProvDocument.deserialize(content=json_str, format="json")
+
+        self.assertEqual(len(reloaded.get_record("ex:a1")), 3)
 
 
 class RoundTripJSONTests(RoundTripTestCase, AllTestsBase):

--- a/src/prov/tests/test_json.py
+++ b/src/prov/tests/test_json.py
@@ -48,9 +48,11 @@ class TestJSONSerializer(unittest.TestCase):
         )
 
     def test_encoder_default_fallback_for_non_document(self):
-        # ProvJSONEncoder.default() is only ever invoked by json.dump() for
-        # objects it does not natively know how to encode; for anything
-        # other than a ProvDocument it falls back to the base encoder.
+        # Pins the isolated method's contract: for anything other than a
+        # ProvDocument, default() falls back to the base encoder. In the
+        # real serialize() path json.dump() only ever hands default() the
+        # top-level ProvDocument (everything nested is already plain
+        # dicts/strings), so this branch is not reachable end-to-end today.
         encoder = ProvJSONEncoder()
         self.assertEqual(encoder.default("plain string"), '"plain string"')
 

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -4,11 +4,27 @@ Created on Jan 25, 2012
 @author: Trung Dong Huynh
 """
 
+import datetime
 import logging
 import os
+import shutil
+import tempfile
 import unittest
 
-from prov.model import Literal, ProvBundle, ProvDocument, ProvException, first
+from prov.constants import PROV_INTERNATIONALIZEDSTRING, XSD
+from prov.identifier import Namespace
+from prov.model import (
+    Literal,
+    NamespaceManager,
+    ProvBundle,
+    ProvDocument,
+    ProvElementIdentifierRequired,
+    ProvException,
+    ProvExceptionInvalidQualifiedName,
+    first,
+    parse_boolean,
+    parse_xsd_datetime,
+)
 from prov.tests import examples
 from prov.tests.attributes import TestAttributesBase
 from prov.tests.qnames import TestQualifiedNamesBase
@@ -156,6 +172,43 @@ class TestBundleUpdate(unittest.TestCase):
         self.assertEqual(len(d1.get_records()), 2)
         self.assertEqual(len(d1.bundles), 2)
 
+    def test_document_update_merges_bundles_with_same_identifier(self):
+        # When both documents already have a bundle with the same identifier,
+        # update() must merge the records of the other's bundle into the
+        # existing one rather than raising/duplicating (model.py ~2664).
+        d1 = ProvDocument()
+        d1.set_default_namespace(EX_URI)
+        b1 = d1.bundle("b1")
+        b1.entity("e1")
+
+        d2 = ProvDocument()
+        d2.set_default_namespace(EX_URI)
+        b1_other = d2.bundle("b1")
+        b1_other.entity("e2")
+
+        d1.update(d2)
+
+        self.assertEqual(len(d1.bundles), 1)
+        (merged_bundle,) = d1.bundles
+        self.assertEqual(len(merged_bundle.get_records()), 2)
+
+    def test_document_update_from_other_with_no_bundles(self):
+        # ProvDocument.update()'s bundle-merging block is only entered when
+        # `other.has_bundles()`; a document with only top-level records must
+        # skip it cleanly (model.py ~2629).
+        d1 = ProvDocument()
+        d1.set_default_namespace(EX_URI)
+        d1.entity("e1")
+
+        d2 = ProvDocument()
+        d2.set_default_namespace(EX_URI)
+        d2.entity("e2")
+
+        d1.update(d2)
+
+        self.assertEqual(len(d1.get_records()), 2)
+        self.assertEqual(list(d1.bundles), [])
+
 
 class TestAddBundle(unittest.TestCase):
     def document_1(self):
@@ -214,6 +267,30 @@ class TestAddBundle(unittest.TestCase):
         b2.update(d2)
         self.assertIn(b2, d1.bundles)
 
+    def test_bundle_requires_an_identifier(self):
+        d1 = self.document_1()
+        self.assertRaises(ProvException, d1.bundle, None)
+
+    def test_bundle_rejects_unresolvable_identifier(self):
+        # No default namespace and an unregistered prefix: valid_qualified_name()
+        # returns None, which bundle() must turn into a ProvException.
+        d1 = self.document_1()
+        self.assertRaises(ProvException, d1.bundle, "bogus:x")
+
+    def test_bundle_rejects_duplicate_identifier(self):
+        d1 = self.document_1()
+        d1.bundle("ex:b1")
+        self.assertRaises(ProvException, d1.bundle, "ex:b1")
+
+    def test_add_bundle_rejects_document_with_nested_bundles(self):
+        # A ProvDocument that itself already contains bundles cannot be
+        # folded into another document as a single bundle (model.py ~2664).
+        d1 = self.document_1()
+        d2 = self.document_2()
+        d2.bundle("ex:nested").entity("ex:nested-e1")
+
+        self.assertRaises(ProvException, d1.add_bundle, d2)
+
 
 class TestLiteralRepresentation(unittest.TestCase):
     def test_literal_provn_with_single_quotes(self):
@@ -225,6 +302,439 @@ class TestLiteralRepresentation(unittest.TestCase):
         literal = Literal('"""foo\\nbar"""')
         string_rep = literal.provn_representation()
         self.assertTrue('\\"\\"\\"f' in string_rep)
+
+
+class TestLiteralHandling(unittest.TestCase):
+    """Covers the Literal/datatype-parsing helpers (docs/test-gap-checklist.md,
+    T13 item under model.py: parse_xsd_datetime, parse_boolean, Literal
+    __eq__/__ne__/__hash__, and the langtag-forces-InternationalizedString
+    warning)."""
+
+    def test_parse_xsd_datetime_returns_none_on_unparseable_input(self):
+        self.assertIsNone(parse_xsd_datetime("not a date at all!!"))
+
+    def test_parse_boolean_variants(self):
+        self.assertTrue(parse_boolean("true"))
+        self.assertTrue(parse_boolean("1"))
+        self.assertFalse(parse_boolean("false"))
+        self.assertFalse(parse_boolean("0"))
+        self.assertIsNone(parse_boolean("neither"))
+
+    def test_literal_equality_and_hash(self):
+        l1 = Literal("hello", datatype=XSD["string"])
+        l2 = Literal("hello", datatype=XSD["string"])
+        l3 = Literal("bye", datatype=XSD["string"])
+
+        self.assertEqual(l1, l2)
+        self.assertNotEqual(l1, l3)
+        self.assertEqual(hash(l1), hash(l2))
+
+    def test_literal_not_equal_to_non_literal(self):
+        literal = Literal("hello")
+        self.assertFalse(literal == "hello")
+        self.assertTrue(literal != "hello")
+
+    def test_langtag_forces_internationalizedstring_datatype_with_warning(self):
+        with self.assertLogs("prov.model", level="WARNING") as ctx:
+            literal = Literal("bonjour", datatype=XSD["string"], langtag="fr")
+        self.assertEqual(literal.datatype, PROV_INTERNATIONALIZEDSTRING)
+        self.assertTrue(
+            any("overridden as" in message for message in ctx.output),
+            ctx.output,
+        )
+
+    def test_langtag_without_datatype_defaults_to_internationalizedstring(self):
+        literal = Literal("bonjour", langtag="fr")
+        self.assertEqual(literal.datatype, PROV_INTERNATIONALIZEDSTRING)
+
+
+class TestAttributeValidationErrors(unittest.TestCase):
+    """Covers ProvException paths in ProvRecord.add_attributes()
+    (docs/test-gap-checklist.md, T13 item under model.py)."""
+
+    def setUp(self):
+        self.doc = ProvDocument()
+        self.doc.add_namespace("ex", "http://example.org/")
+
+    def test_identifierless_record_as_qname_attribute_value_raises(self):
+        e1 = self.doc.entity("ex:e1")
+        a1 = self.doc.activity("ex:a1")
+        # An anonymous (identifier-less) relation used as the value of an
+        # attribute expecting a qualified name (here: attribution's agent).
+        anonymous_usage = self.doc.usage(a1, e1)
+        self.assertIsNone(anonymous_usage.identifier)
+
+        self.assertRaises(ProvException, self.doc.attribution, e1, anonymous_usage)
+
+    def test_unparseable_datetime_formal_attribute_raises(self):
+        activity = self.doc.activity("ex:a2")
+        self.assertRaises(
+            ProvException,
+            activity.add_attributes,
+            {"prov:startTime": "not a date"},
+        )
+
+    def test_conflicting_duplicate_value_raises(self):
+        activity = self.doc.activity("ex:a3", startTime=datetime.datetime(2020, 1, 1))
+        self.assertRaises(
+            ProvException,
+            activity.add_attributes,
+            {"prov:startTime": datetime.datetime(2020, 1, 2)},
+        )
+
+    def test_conflicting_duplicate_value_with_naive_vs_aware_datetime(self):
+        # Naive and timezone-aware datetimes for the same single-valued
+        # formal attribute still compare as "different" (Python's `!=`
+        # between them returns True rather than raising -- confirmed
+        # separately: no PROV_ATTRIBUTES value type raises TypeError on
+        # `!=`, so the `except TypeError` branch at model.py:521-523 is
+        # dead code for any value this library can construct; left
+        # deferred per docs/test-gap-checklist.md). This still exercises
+        # the duplicate-value ProvException with two "different" datetimes.
+        activity = self.doc.activity("ex:a4", startTime=datetime.datetime(2020, 1, 1))
+        aware_time = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+        self.assertRaises(
+            ProvException, activity.add_attributes, {"prov:startTime": aware_time}
+        )
+
+    def test_record_not_equal_to_non_record(self):
+        e1 = self.doc.entity("ex:e1")
+        self.assertFalse(e1 == "not a record")
+        self.assertNotEqual(e1, object())
+
+    def test_record_value_converted_from_provrecord_for_generic_attribute(self):
+        # A ProvRecord used as the value of a *generic* (non-formal) attribute
+        # is converted to a QualifiedName via its identifier
+        # (_auto_literal_conversion's ProvRecord branch, model.py:415-417).
+        e1 = self.doc.entity("ex:e1")
+        e2 = self.doc.entity("ex:e2")
+        e2.add_attributes({"ex:ref": e1})
+        self.assertEqual(e2.get_attribute("ex:ref"), {e1.identifier})
+
+
+class TestElementIdentifierRequired(unittest.TestCase):
+    def test_entity_without_identifier_raises(self):
+        doc = ProvDocument()
+        self.assertRaises(ProvElementIdentifierRequired, doc.entity, None)
+
+    def test_activity_without_identifier_raises(self):
+        doc = ProvDocument()
+        self.assertRaises(ProvElementIdentifierRequired, doc.activity, None)
+
+    def test_provelementidentifierrequired_str(self):
+        self.assertEqual(
+            str(ProvElementIdentifierRequired()),
+            "An identifier is missing. All PROV elements require a valid identifier.",
+        )
+
+    def test_provexceptioninvalidqualifiedname_str(self):
+        exc = ProvExceptionInvalidQualifiedName("bogus")
+        self.assertEqual(str(exc), "Invalid Qualified Name: bogus")
+
+
+class TestRecordMiscProperties(unittest.TestCase):
+    """Covers small ProvRecord accessors not otherwise exercised
+    (docs/test-gap-checklist.md, T13 item under model.py)."""
+
+    def setUp(self):
+        self.doc = ProvDocument()
+        self.doc.add_namespace("ex", "http://example.org/")
+
+    def test_get_asserted_types_default_empty(self):
+        e1 = self.doc.entity("ex:e1")
+        self.assertEqual(e1.get_asserted_types(), set())
+
+    def test_label_falls_back_to_identifier(self):
+        e1 = self.doc.entity("ex:e1")
+        self.assertEqual(e1.label, str(e1.identifier))
+
+    def test_value_property_default_empty(self):
+        e1 = self.doc.entity("ex:e1")
+        self.assertEqual(e1.value, set())
+
+
+class TestElementConvenienceMethods(unittest.TestCase):
+    """Exercises the fluent convenience wrappers on ProvEntity/ProvActivity
+    that examples.py does not otherwise reach (docs/test-gap-checklist.md,
+    T13 item under model.py)."""
+
+    def setUp(self):
+        self.doc = ProvDocument()
+        self.doc.set_default_namespace("http://example.org/")
+
+    def test_entity_was_invalidated_by(self):
+        e1 = self.doc.entity("e1")
+        a1 = self.doc.activity("a1")
+        result = e1.wasInvalidatedBy(a1)
+        self.assertIs(result, e1)
+        self.assertTrue(
+            any(
+                r.get_type().localpart == "Invalidation" for r in self.doc.get_records()
+            )
+        )
+
+    def test_entity_had_member(self):
+        collection = self.doc.entity("collection1")
+        member = self.doc.entity("member1")
+        result = collection.hadMember(member)
+        self.assertIs(result, collection)
+        self.assertTrue(
+            any(r.get_type().localpart == "Membership" for r in self.doc.get_records())
+        )
+
+    def test_activity_was_started_by(self):
+        a1 = self.doc.activity("a1")
+        trigger = self.doc.entity("trigger1")
+        result = a1.wasStartedBy(trigger)
+        self.assertIs(result, a1)
+        self.assertTrue(
+            any(r.get_type().localpart == "Start" for r in self.doc.get_records())
+        )
+
+    def test_activity_was_ended_by(self):
+        a1 = self.doc.activity("a1")
+        trigger = self.doc.entity("trigger1")
+        result = a1.wasEndedBy(trigger)
+        self.assertIs(result, a1)
+        self.assertTrue(
+            any(r.get_type().localpart == "End" for r in self.doc.get_records())
+        )
+
+    def test_activity_was_informed_by(self):
+        a1 = self.doc.activity("a1")
+        a2 = self.doc.activity("a2")
+        result = a1.wasInformedBy(a2)
+        self.assertIs(result, a1)
+        self.assertTrue(
+            any(
+                r.get_type().localpart == "Communication"
+                for r in self.doc.get_records()
+            )
+        )
+
+    def test_activity_set_time_both(self):
+        a1 = self.doc.activity("a1")
+        start = datetime.datetime(2020, 1, 1)
+        end = datetime.datetime(2020, 1, 2)
+        a1.set_time(startTime=start, endTime=end)
+        self.assertEqual(a1.get_startTime(), start)
+        self.assertEqual(a1.get_endTime(), end)
+
+    def test_activity_set_time_start_only(self):
+        a1 = self.doc.activity("a1")
+        start = datetime.datetime(2020, 1, 1)
+        a1.set_time(startTime=start)
+        self.assertEqual(a1.get_startTime(), start)
+        self.assertIsNone(a1.get_endTime())
+
+    def test_activity_set_time_end_only(self):
+        a1 = self.doc.activity("a1")
+        end = datetime.datetime(2020, 1, 2)
+        a1.set_time(endTime=end)
+        self.assertIsNone(a1.get_startTime())
+        self.assertEqual(a1.get_endTime(), end)
+
+
+class TestNamespaceManagerEdges(unittest.TestCase):
+    """Covers NamespaceManager branches not exercised by round-trip
+    serialization (docs/test-gap-checklist.md, T13 item under model.py)."""
+
+    def test_construction_without_default_namespace(self):
+        nm = NamespaceManager()
+        self.assertIsNone(nm.get_default_namespace())
+
+    def test_get_namespace_miss_and_hit(self):
+        nm = NamespaceManager()
+        self.assertIsNone(nm.get_namespace("http://example.org/"))
+        ns = Namespace("ex", "http://example.org/")
+        nm.add_namespace(ns)
+        self.assertEqual(nm.get_namespace("http://example.org/"), ns)
+
+    def test_add_namespace_reuses_renamed_namespace_from_cache(self):
+        nm = NamespaceManager()
+        nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+        conflicting = Namespace("ex", "http://b.example.org/")
+        first_add = nm.add_namespace(conflicting)
+        # Prefix conflict: the second namespace is registered under a new
+        # ("ex_1") prefix and cached in the rename map.
+        self.assertEqual(first_add.prefix, "ex_1")
+        # Adding the *same* conflicting namespace object again should reuse
+        # the cached renamed namespace (the `namespace in self._rename_map`
+        # branch) rather than renaming it again.
+        second_add = nm.add_namespace(conflicting)
+        self.assertIs(second_add, first_add)
+
+    def test_valid_qualified_name_rejects_blank_node_and_bad_types(self):
+        nm = NamespaceManager()
+        self.assertIsNone(nm.valid_qualified_name("_:blank1"))
+        self.assertIsNone(nm.valid_qualified_name(12345))
+
+    def test_get_anonymous_identifier_increments_and_uses_prefix(self):
+        nm = NamespaceManager()
+        first_id = nm.get_anonymous_identifier()
+        second_id = nm.get_anonymous_identifier("custom")
+        self.assertNotEqual(str(first_id), str(second_id))
+        self.assertTrue(str(second_id).startswith("_:custom"))
+
+    def test_get_unused_prefix_counts_up(self):
+        nm = NamespaceManager()
+        nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+        # Force two successive conflicts on the same prefix so
+        # _get_unused_prefix must count past "ex_1".
+        second = nm.add_namespace(Namespace("ex", "http://b.example.org/"))
+        third = nm.add_namespace(Namespace("ex", "http://c.example.org/"))
+        self.assertEqual(second.prefix, "ex_1")
+        self.assertEqual(third.prefix, "ex_2")
+
+    def test_construction_with_default_namespace(self):
+        nm = NamespaceManager(default="http://example.org/")
+        default_ns = nm.get_default_namespace()
+        self.assertIsNotNone(default_ns)
+        self.assertEqual(default_ns.uri, "http://example.org/")
+
+    def test_add_namespaces_with_empty_collection_is_a_no_op(self):
+        nm = NamespaceManager()
+        nm.add_namespaces([])
+        self.assertEqual(list(nm.get_registered_namespaces()), [])
+
+    def test_get_unused_prefix_returns_original_when_available(self):
+        # _get_unused_prefix() is only ever called internally once its
+        # caller (add_namespace) has already confirmed a conflict, so this
+        # "prefix is actually free" branch is otherwise unreachable; call
+        # the helper directly to cover it.
+        nm = NamespaceManager()
+        self.assertEqual(nm._get_unused_prefix("neverused"), "neverused")
+
+
+class TestProvBundleEdges(unittest.TestCase):
+    """Covers ProvBundle API edges not reached by round-trip serialization
+    (docs/test-gap-checklist.md, T13 item under model.py)."""
+
+    def test_bundles_property_raises_on_a_plain_bundle(self):
+        b = ProvBundle()
+        with self.assertRaises(ProvException):
+            list(b.bundles)
+
+    def test_standalone_bundle_properties(self):
+        b = ProvBundle()
+        self.assertEqual(b.records, [])
+        self.assertIsNone(b.identifier)
+        self.assertIsNone(b.document)
+
+    def test_add_namespace_without_uri_raises(self):
+        b = ProvBundle()
+        self.assertRaises(ProvException, b.add_namespace, "ex")
+
+    def test_mandatory_valid_qname_failure(self):
+        b = ProvBundle()
+        self.assertRaises(
+            ProvExceptionInvalidQualifiedName, b.mandatory_valid_qname, None
+        )
+
+    def test_eq_early_out_for_non_bundle(self):
+        b = ProvBundle()
+        self.assertFalse(b == "not a bundle")
+        self.assertNotEqual(b, 42)
+
+    def test_default_ns_uri_present_and_absent(self):
+        b = ProvBundle()
+        self.assertIsNone(b.default_ns_uri)
+        b.set_default_namespace("http://example.org/")
+        self.assertEqual(b.default_ns_uri, "http://example.org/")
+
+    def test_get_registered_namespaces(self):
+        b = ProvBundle()
+        b.add_namespace("ex", "http://example.org/")
+        uris = {ns.uri for ns in b.get_registered_namespaces()}
+        self.assertIn("http://example.org/", uris)
+
+    def test_has_bundles_false_for_plain_bundle(self):
+        b = ProvBundle()
+        self.assertFalse(b.has_bundles())
+
+
+class TestSerializeDeserializeEdgeCases(unittest.TestCase):
+    """Covers ProvDocument.serialize()'s file-path save path and
+    .deserialize()'s argument-validation error (docs/test-gap-checklist.md,
+    T13 item under model.py, natural neighbours of the T12 read() tests)."""
+
+    def test_serialize_to_file_path_uses_tempfile_and_move(self):
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        doc.entity("ex:e1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "out.json")
+            result = doc.serialize(destination=path, format="json")
+            self.assertIsNone(result)
+            self.assertTrue(os.path.exists(path))
+            reloaded = ProvDocument.deserialize(path, format="json")
+            self.assertEqual(reloaded, doc)
+
+    def test_deserialize_without_source_or_content_raises_type_error(self):
+        self.assertRaises(TypeError, ProvDocument.deserialize)
+
+
+class TestDocumentEqualityAndUnification(unittest.TestCase):
+    """Covers ProvDocument.__eq__'s bundle-comparison early-outs and
+    unified()'s no-bundles loop (docs/test-gap-checklist.md, T13 item under
+    model.py)."""
+
+    def test_not_equal_when_other_is_missing_a_bundle(self):
+        d1 = ProvDocument()
+        d1.set_default_namespace("http://example.org/")
+        d1.bundle("b1").entity("e1")
+
+        d2 = ProvDocument()
+        d2.set_default_namespace("http://example.org/")
+
+        self.assertNotEqual(d1, d2)
+
+    def test_not_equal_when_matching_bundle_content_differs(self):
+        d1 = ProvDocument()
+        d1.set_default_namespace("http://example.org/")
+        d1.bundle("b1").entity("e1")
+
+        d2 = ProvDocument()
+        d2.set_default_namespace("http://example.org/")
+        d2.bundle("b1").entity("e2")
+
+        self.assertNotEqual(d1, d2)
+
+    def test_unified_with_no_bundles(self):
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        doc.entity("ex:e1")
+
+        unified = doc.unified()
+
+        self.assertEqual(list(unified.bundles), [])
+        self.assertEqual(unified, doc)
+
+
+@unittest.skipUnless(shutil.which("dot"), "graphviz 'dot' binary not available")
+class TestPlot(unittest.TestCase):
+    """Covers ProvDocument.plot()'s filename-based save path and its
+    unknown-format ValueError (docs/test-gap-checklist.md, T13 item under
+    model.py; the matplotlib/interactive-display path remains deferred, see
+    checklist)."""
+
+    def setUp(self):
+        self.doc = ProvDocument()
+        self.doc.add_namespace("ex", "http://example.org/")
+        self.doc.entity("ex:e1")
+
+    def test_plot_to_filename_infers_format_and_saves(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "out.png")
+            self.doc.plot(filename=path)
+            self.assertTrue(os.path.exists(path))
+            self.assertGreater(os.path.getsize(path), 0)
+
+    def test_plot_unknown_format_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "out.not-a-real-format")
+            self.assertRaises(ValueError, self.doc.plot, filename=path)
 
 
 class AllTestsBase(

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -366,6 +366,19 @@ class TestAttributeValidationErrors(unittest.TestCase):
 
         self.assertRaises(ProvException, self.doc.attribution, e1, anonymous_usage)
 
+    def test_identifierless_record_as_generic_attribute_value_raises(self):
+        # Same anonymous-relation value, but through the generic (non-formal)
+        # attribute path: _auto_literal_conversion() reduces a ProvRecord to
+        # its identifier, which is None here, tripping the "value is None"
+        # guard rather than a formal-attribute check.
+        e1 = self.doc.entity("ex:e1b")
+        a1 = self.doc.activity("ex:a1b")
+        anonymous_usage = self.doc.usage(a1, e1)
+        self.assertIsNone(anonymous_usage.identifier)
+
+        e2 = self.doc.entity("ex:e2b")
+        self.assertRaises(ProvException, e2.add_attributes, {"ex:ref": anonymous_usage})
+
     def test_unparseable_datetime_formal_attribute_raises(self):
         activity = self.doc.activity("ex:a2")
         self.assertRaises(

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -200,6 +200,140 @@ class TestRDFSerializer(unittest.TestCase):
         e1 = prov_doc.get_record("ex:unicode_char")[0]
         self.assertIn(unicode_char, e1.get_attribute("prov:label"))
 
+    def test_serialize_without_a_document_raises(self):
+        from prov.serializers.provrdf import ProvRDFException, ProvRDFSerializer
+
+        serializer = ProvRDFSerializer(document=None)
+        with self.assertRaises(ProvRDFException) as ctx:
+            serializer.serialize(BytesIO())
+        self.assertIn("No document to serialize", str(ctx.exception))
+
+    def test_literal_rdf_representation_langtag(self):
+        from prov.serializers.provrdf import literal_rdf_representation
+
+        literal = pm.Literal("bonjour", langtag="fr")
+        rdf_literal = literal_rdf_representation(literal)
+        self.assertEqual(str(rdf_literal), "bonjour")
+        self.assertEqual(rdf_literal.language, "fr")
+
+    def test_literal_rdf_representation_base64binary(self):
+        from prov.serializers.provrdf import literal_rdf_representation
+
+        literal = pm.Literal("aGVsbG8=", datatype=pm.XSD["base64Binary"])
+        rdf_literal = literal_rdf_representation(literal)
+        self.assertEqual(str(rdf_literal), "aGVsbG8=")
+
+    def test_literal_rdf_representation_without_datatype_raises(self):
+        from prov.serializers.provrdf import literal_rdf_representation
+
+        with self.assertRaises(ValueError):
+            literal_rdf_representation(pm.Literal("no datatype, no langtag"))
+
+    def test_decode_xsd_qname_gyear_gyearmonth_round_trip(self):
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        doc.entity(
+            "ex:e1",
+            other_attributes={
+                "ex:year": pm.Literal(2020, datatype=pm.XSD["gYear"]),
+                "ex:yearmonth": pm.Literal("2020-05", datatype=pm.XSD["gYearMonth"]),
+                "ex:qname": pm.Literal("ex:e1", datatype=pm.XSD["QName"]),
+            },
+        )
+
+        ttl = doc.serialize(format="rdf", rdf_format="turtle")
+        reloaded = ProvDocument.deserialize(
+            content=ttl, format="rdf", rdf_format="turtle"
+        )
+        e1 = reloaded.get_record("ex:e1")[0]
+
+        self.assertEqual({lit.value for lit in e1.get_attribute("ex:year")}, {"2020"})
+        self.assertEqual(
+            {lit.value for lit in e1.get_attribute("ex:yearmonth")}, {"2020-05"}
+        )
+        self.assertEqual({lit.value for lit in e1.get_attribute("ex:qname")}, {"ex:e1"})
+
+    def test_encode_container_reuses_a_provided_container(self):
+        # encode_container()'s `container` parameter defaults to None
+        # everywhere it is called internally; passing one explicitly (as an
+        # external caller might) must reuse it rather than creating a new
+        # ConjunctiveGraph.
+        from rdflib.graph import ConjunctiveGraph
+
+        from prov.serializers.provrdf import ProvRDFSerializer
+
+        doc = ProvDocument()
+        doc.add_namespace("ex", "http://example.org/")
+        doc.entity("ex:e1")
+
+        serializer = ProvRDFSerializer(document=doc)
+        container = ConjunctiveGraph()
+        result = serializer.encode_container(doc, container=container)
+
+        self.assertIs(result, container)
+        self.assertGreater(len(list(container.triples((None, None, None)))), 0)
+
+    def test_decode_document_without_contexts_uses_plain_graph_path(self):
+        # decode_document()'s `hasattr(content, "contexts")` branch is False
+        # for a plain rdflib Graph (as opposed to a ConjunctiveGraph), which
+        # every other test in this module parses into.
+        from rdflib import RDF, URIRef
+        from rdflib.graph import Graph
+
+        from prov.serializers.provrdf import ProvRDFSerializer
+
+        graph = Graph()
+        graph.add(
+            (
+                URIRef("http://example.org/e1"),
+                RDF.type,
+                URIRef("http://www.w3.org/ns/prov#Entity"),
+            )
+        )
+
+        document = ProvDocument()
+        serializer = ProvRDFSerializer()
+        serializer.document = document
+        serializer.decode_document(graph, document)
+
+        self.assertEqual(len(document.get_records()), 1)
+
+    def test_decode_multi_valued_qualified_relation_produces_cartesian_product(self):
+        # A hand-authored (non-2.x-encoder-produced) PROV-O document may
+        # legally repeat a formal-attribute predicate on the same qualified-
+        # relation bnode; decode_container()'s walk() helper must expand
+        # that into one new_record() call per combination rather than
+        # silently overwriting (docs/test-gap-checklist.md, T13 item under
+        # provrdf.py: "multi-valued unique-set walking").
+        turtle = """
+        @prefix prov: <http://www.w3.org/ns/prov#> .
+        @prefix ex: <http://example.org/> .
+
+        ex:e1 a prov:Entity .
+        ex:e2 a prov:Entity .
+        ex:a1 a prov:Activity .
+
+        _:u1 a prov:Usage ;
+             prov:entity ex:e1 ;
+             prov:entity ex:e2 ;
+             prov:activity ex:a1 .
+
+        ex:a1 prov:qualifiedUsage _:u1 .
+        """
+        doc = ProvDocument.deserialize(
+            content=turtle, format="rdf", rdf_format="turtle"
+        )
+
+        usages = [r for r in doc.get_records() if r.get_type().localpart == "Usage"]
+        self.assertEqual(len(usages), 2)
+        used_entities = {
+            value
+            for usage in usages
+            for name, value in usage.formal_attributes
+            if name.localpart == "entity"
+        }
+        self.assertEqual({str(qn) for qn in used_entities}, {"ex:e1", "ex:e2"})
+
     def test_json_to_ttl_match(self):
         json_files = sorted(
             glob(os.path.join(os.path.dirname(__file__), "json", "*.json"))

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -127,6 +127,24 @@ class TestRead(unittest.TestCase):
             prov.read(io.StringIO("garbage"))
         self.assertIn("specify the format", str(ctx.exception))
 
+    def test_read_auto_detect_only_swallows_the_documented_exception_types(self):
+        """
+        Pins the intended behaviour of the auto-detection loop (checklist
+        item under prov/__init__.py, T13): only (TypeError, ValueError,
+        AttributeError, KeyError) from a candidate deserializer are caught
+        and treated as "try the next format"; anything else must propagate
+        immediately rather than being swallowed.
+        """
+
+        def boom(self, stream, **kwargs):
+            raise RuntimeError("not one of the caught types")
+
+        with (
+            mock.patch.object(ProvJSONSerializer, "deserialize", boom),
+            self.assertRaises(RuntimeError),
+        ):
+            prov.read(io.StringIO("garbage"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -391,6 +391,81 @@ class ProvXMLTestCase(unittest.TestCase):
         self.assertEqual(values, [1])
 
 
+class ProvXMLSerializerErrorsTestCase(unittest.TestCase):
+    """Covers ProvXMLSerializer error/warning paths not reached by the
+    round-trip fixtures (docs/test-gap-checklist.md, T13 item under
+    serializers/provxml.py)."""
+
+    def test_serialize_without_a_document_raises(self):
+        from prov.serializers.provxml import ProvXMLException, ProvXMLSerializer
+
+        serializer = ProvXMLSerializer(document=None)
+        with self.assertRaises(ProvXMLException) as ctx:
+            serializer.serialize(io.BytesIO())
+        self.assertIn("No document to serialize", str(ctx.exception))
+
+    def test_non_prov_top_level_element_raises(self):
+        from prov.serializers.provxml import ProvXMLException
+
+        xml_string = """<?xml version="1.0" encoding="UTF-8"?>
+        <prov:document
+            xmlns:prov="http://www.w3.org/ns/prov#"
+            xmlns:ex="http://example.com/ns/ex#">
+          <ex:notAProvElement/>
+        </prov:document>
+        """
+        with (
+            self.assertRaises(ProvXMLException) as ctx,
+            io.StringIO(xml_string) as xml,
+        ):
+            prov.ProvDocument.deserialize(source=xml, format="xml")
+        self.assertIn("Non PROV element discovered", str(ctx.exception))
+
+    def test_unrepresentable_sub_element_attribute_warns_and_is_ignored(self):
+        # An attribute on a PROV-XML sub-element other than prov:ref,
+        # xsi:type, or xml:lang cannot be represented in the internal data
+        # model; it is dropped with a warning rather than raising.
+        xml_string = """<?xml version="1.0" encoding="UTF-8"?>
+        <prov:document
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:prov="http://www.w3.org/ns/prov#"
+            xmlns:ex="http://example.com/ns/ex#">
+          <prov:entity prov:id="ex:e1">
+            <ex:version xsi:type="xsd:string" custom="oops">2</ex:version>
+          </prov:entity>
+        </prov:document>
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with io.StringIO(xml_string) as xml:
+                doc = prov.ProvDocument.deserialize(source=xml, format="xml")
+
+        self.assertTrue(
+            any(
+                "not representable in the prov module's internal data model"
+                in str(warning.message)
+                for warning in w
+            )
+        )
+        e1 = doc.get_record("ex:e1")[0]
+        self.assertEqual(list(e1.get_attribute("ex:version")), ["2"])
+
+    def test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises(self):
+        from prov.serializers.provxml import (
+            ProvXMLException,
+            xml_qname_to_QualifiedName,
+        )
+
+        element = etree.fromstring(
+            '<root xmlns:ex="http://example.com/ns/ex#"><child/></root>'
+        )
+        child = element[0]
+        with self.assertRaises(ProvXMLException) as ctx:
+            xml_qname_to_QualifiedName(child, "noColonNoDefaultNs")
+        self.assertIn("Could not create a valid QualifiedName", str(ctx.exception))
+
+
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
     def _perform_round_trip(self, filename, force_types=False):
         document = prov.ProvDocument.deserialize(source=filename, format="xml")


### PR DESCRIPTION
## Summary

- Fixes the `[tool.coverage.run]` `omit` glob: `"*/tests*"` never actually
  excluded `src/prov/tests/` (a single `*` in a coverage.py glob doesn't cross
  `/`), so TOTAL was inflated by ~3.8 points of near-fully-covered test code.
  Changed to `"*/prov/tests/*"`.
- With the omit fixed, the honest package-only baseline (post T11/T12,
  pre this PR's new tests) was **91.458%**.
- Works through every remaining unticked item in `docs/test-gap-checklist.md`
  with behaviour tests: `identifier.py` (new `test_identifier.py`), `model.py`
  (Literal/attribute-validation/NamespaceManager/ProvBundle/ProvDocument edge
  cases in `test_model.py`), `dot.py`, and the json/xml/rdf/provn serializers.
  Items that would need contrived setups to reach (confirmed-dead/unreachable
  branches, matplotlib's interactive `plot()` display path not installed in
  this env) are documented inline in the checklist as deferred, with the
  tracing/reasoning for why each is unreachable.
- Adds `"if TYPE_CHECKING:"` to `exclude_lines` and `# pragma: no cover` on
  the two abstract `Serializer` method bodies, per the checklist's own
  suggestion, resolving the last `serializers/__init__.py` gap.
- Raises `fail_under` from 91 (measured against the inflated TOTAL) to **97**
  (rounded down from the new honest TOTAL of 97.42%, comfortably clear of the
  ≥93 floor / ≥95 target, with margin for the ~0.04pt cross-interpreter drift
  CI's 3.12 job may see).

No runtime/public-API behaviour changes — test modules, coverage config, and
the checklist doc only.

## Test plan

- [x] `uv run pytest -q` — 1083 passed, 17 xfailed (up from the 992/17
      baseline; all new tests, no existing test's behaviour changed)
- [x] `uv run ruff check src/` clean
- [x] `uv run ruff format --check src/` clean
- [x] `uv run mypy src` — Success: no issues found in 14 source files
- [x] `uv run coverage run -m pytest && uv run coverage report` exits 0,
      TOTAL 97%