### PR TITLE
chore: widen rdflib to >=6.0.0,<8; fix bundle-IRI decoding under rdflib 7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,30 @@ jobs:
           flag-name: Python${{ matrix.python-version }}
           parallel: true
 
+  rdflib-compat:
+    # The main matrix tests the locked rdflib; this job proves the declared
+    # bounds of the `rdf` extra (rdflib>=6.0.0,<8) by running the RDF tests
+    # against the floor and the newest allowed 7.x (see docs/dependencies.md).
+    name: rdf tests on rdflib ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - rdflib-version: "==6.0.0"
+            label: "6.0.0 (floor)"
+          - rdflib-version: ">=7,<8"
+            label: "latest 7.x"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: "3.12"
+      - run: |
+          uv sync --locked --extra rdf --extra xml --group dev
+          uv pip install "rdflib${{ matrix.rdflib-version }}"
+          uv run --no-sync python -c "import rdflib; print('rdflib', rdflib.__version__)"
+          uv run --no-sync pytest src/prov/tests/test_rdf.py
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -37,15 +37,20 @@ without an extra installed.
 Install with `prov[extra]`; omitting them makes the corresponding serializer/module raise
 `ModuleNotFoundError` when used, not at `import prov` time.
 
-- **`rdf` → `rdflib>=4.2.1,<7`** — backs `prov.serializers.provrdf` (PROV-O/RDF
-  serialization). Floor `4.2.1` is the oldest version this project has tested against.
-  The `<7` ceiling is deliberate, not incidental: rdflib 7.6.0 fails 5 tests
-  (`RoundTripRDFTests::test_bundle_1..4`, `::test_default_namespace_inheritance` in
-  `src/prov/tests/test_rdf.py`), traced to rdflib 7's `Dataset`/graph-identifier and
-  namespace-binding changes (e.g. `bind_namespaces` defaults). Widening to `<8` is T15, a
-  separate, explicitly time-boxed investigation — its outcome (fixed-and-widened, or kept
-  pinned with a filed issue) is not yet known as of this writing; check T15's PR/issue
-  before assuming either way.
+- **`rdf` → `rdflib>=6.0.0,<8`** — backs `prov.serializers.provrdf` (PROV-O/RDF
+  serialization). Both bounds revised 2026-07-05 (T15). Floor: the historic `4.2.1` no
+  longer builds on the Pythons this project supports and 5.x fails xsd:base64Binary
+  literal round-trips, so `6.0.0` is the oldest version that passes the suite. Ceiling:
+  rdflib 7's `Memory` store stopped retaining foreign context `Graph`s passed through
+  `addN()` (rdflib 6 accidentally carried bundle prefix bindings into TriG output that
+  way), which broke re-parsing of serialized bundles; fixed deserialize-side only
+  (`decode_document` falls back to `compute_qname` for bundle IRIs), leaving rdflib-6
+  serialization output unchanged. The `rdflib-compat` CI job proves both bounds (floor
+  and newest 7.x); the main matrix uses the locked version. Under rdflib 7,
+  bundle-local namespaces serialize as full IRIs instead of their original prefixes
+  (round-trips stay equivalent — `QualifiedName` equality is by IRI) and
+  `ConjunctiveGraph` deprecation warnings appear; the `Dataset` migration is deferred
+  to 3.0 (its defaults, e.g. `default_union`, are not behaviour-neutral for 2.x).
 - **`xml` → `lxml>=3.3.5`** — backs `prov.serializers.provxml` (PROV-XML). Floor predates
   this project's adoption; no known upper-bound issue.
 - **`plot` → `matplotlib>=3.6`** — backs the interactive-display path of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 rdf = [
-    "rdflib>=4.2.1,<7",
+    "rdflib>=6.0.0,<8",
 ]
 xml = [
     "lxml>=3.3.5",

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -537,7 +537,13 @@ class ProvRDFSerializer(Serializer):
                         predicate_mapper=predicate_mapper,
                     )
                 else:
-                    bundle_id = str(graph.identifier)
+                    # Resolve the bundle IRI to a qualified name; if no
+                    # registered namespace matches (rdflib >= 7 no longer
+                    # carries bundle-graph prefix bindings into TriG output,
+                    # so re-parsed documents may lack them), fall back to
+                    # minting a namespace via compute_qname, as
+                    # decode_rdf_representation does for all other IRIs.
+                    bundle_id = self.decode_rdf_representation(graph.identifier, graph)
                     bundle = document.bundle(bundle_id)
                     self.decode_container(
                         graph,

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -298,6 +298,36 @@ class TestRDFSerializer(unittest.TestCase):
 
         self.assertEqual(len(document.get_records()), 1)
 
+    def test_decode_document_bundle_iri_without_registered_namespace(self):
+        # rdflib >= 7 no longer carries bundle-graph prefix bindings into
+        # TriG output, so a re-parsed document may name a bundle context by
+        # an IRI matching no registered namespace; decode_document() must
+        # fall back to compute_qname instead of raising ProvException.
+        from rdflib import RDF, URIRef
+        from rdflib.graph import ConjunctiveGraph
+
+        from prov.serializers.provrdf import ProvRDFSerializer
+
+        content = ConjunctiveGraph()
+        bundle_graph = content.get_context(URIRef("http://example.org/bundle1"))
+        bundle_graph.add(
+            (
+                URIRef("http://example.org/e1"),
+                RDF.type,
+                URIRef("http://www.w3.org/ns/prov#Entity"),
+            )
+        )
+
+        document = ProvDocument()
+        serializer = ProvRDFSerializer()
+        serializer.document = document
+        serializer.decode_document(content, document)
+
+        bundles = list(document.bundles)
+        self.assertEqual(len(bundles), 1)
+        self.assertEqual(bundles[0].identifier.uri, "http://example.org/bundle1")
+        self.assertEqual(len(bundles[0].get_records()), 1)
+
     def test_decode_multi_valued_qualified_relation_produces_cartesian_product(self):
         # A hand-authored (non-2.x-encoder-produced) PROV-O document may
         # legally repeat a formal-attribute predicate on the same qualified-

--- a/uv.lock
+++ b/uv.lock
@@ -1639,7 +1639,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=2.0" },
     { name = "pydot", specifier = ">=1.2.0" },
     { name = "python-dateutil", specifier = ">=2.2" },
-    { name = "rdflib", marker = "extra == 'rdf'", specifier = ">=4.2.1,<7" },
+    { name = "rdflib", marker = "extra == 'rdf'", specifier = ">=6.0.0,<8" },
 ]
 provides-extras = ["rdf", "xml", "plot"]
 


### PR DESCRIPTION
## Summary

Phase 2, T15: the time-boxed rdflib <8 widening investigation concluded with the **code path** — the `rdf` extra's pin widens from `rdflib>=4.2.1,<7` to `rdflib>=6.0.0,<8`.

### Root cause of the rdflib 7 failures
rdflib 7's `Memory` store no longer retains foreign context `Graph` objects passed through `addN()`. Under rdflib 6, `encode_document()`'s `container.addN(bundle.quads())` accidentally carried each bundle graph's prefix bindings into the TriG output; under 7 those bindings vanish, so re-parsing a serialized document hit `decode_document()` with a full-IRI bundle identifier and no registered namespace, raising `ProvException`.

### Fix (deserialize-side only)
`decode_document()` now resolves bundle graph identifiers via `decode_rdf_representation()`, which falls back to minting a namespace with `compute_qname()` — the same handling every other IRI already gets. rdflib-6 serialization output is byte-identical; the only behaviour change is a path that previously crashed. A dedicated unit test exercises the fallback on any rdflib version.

### Floor raised 4.2.1 → 6.0.0 (deviation from the plan's `>=4.2.1,<8`, deliberate)
Independently verified: rdflib 4.2.1 no longer builds at all on the Pythons this project supports (its `setup.py` uses the removed `distutils` 2to3 hook), and 5.0.0 fails the xsd:base64Binary literal round-trip. 6.0.0 is the oldest version that installs and passes the suite, so the new floor states what is actually supported instead of an unsatisfiable claim.

### CI
New `rdflib-compat` job proves both declared bounds by running the RDF tests against `==6.0.0` (floor) and `>=7,<8` (latest 7.x); the main matrix stays on the locked 6.3.2. Verified green locally on 6.0.0–6.3.2 and 7.0.0/7.1.1/7.6.0.

### Cosmetic note under rdflib 7
Bundle-local namespaces serialize as full IRIs instead of their original prefixes (round-trips stay semantically equivalent — `QualifiedName` equality is by IRI); `ConjunctiveGraph` deprecation warnings appear. The `Dataset` migration is deferred to 3.0 (its defaults, e.g. `default_union`, are not behaviour-neutral for 2.x). All recorded in `docs/dependencies.md`.

## Verification
- `uv run ruff check src/` and `uv run ruff format --check src/` clean
- `uv run mypy src`: Success: no issues found in 14 source files
- `uv run pytest -q`: 1085 passed, 17 xfailed