### PR TITLE
docs: add how-to guides (formats, graphics, CLI, NetworkX)

### DIFF
--- a/docs/howto/cli.md
+++ b/docs/howto/cli.md
@@ -1,0 +1,123 @@
+# Use the command-line tools
+
+`prov` installs two console scripts: `prov-convert` (format/graphics conversion) and
+`prov-compare` (equivalence checking). Both wrap the same {py:class}`~prov.model.ProvDocument`
+API described in the other how-to pages.
+
+## `prov-convert`
+
+Convert a PROV-JSON document to PROV-N, PROV-XML, PROV-O/RDF, or any image format
+supported by Graphviz.
+
+### Synopsis
+
+```bash
+prov-convert [-h] [-f FORMAT] [-V] [infile] [outfile]
+```
+
+### Options
+
+| Flag | Argument | Default | Meaning |
+| --- | --- | --- | --- |
+| `-f`, `--format` | `FORMAT` | `json` | Output format: `json`, `xml`, `provn`, or any format name GraphViz's `dot` accepts (e.g. `svg`, `pdf`, `png`) |
+| `-V`, `--version` | — | — | Print the version and exit |
+| `-h`, `--help` | — | — | Print usage and exit |
+| `infile` (positional) | — | stdin | Input file — **always read as PROV-JSON**, there is no input-format flag |
+| `outfile` (positional) | — | stdout | Output file, written in `--format` |
+
+`prov-convert` has no flag to choose the *input* format — the input is always
+deserialized as PROV-JSON (`ProvDocument.deserialize(infile)`, which defaults to
+`format="json"`). To convert from PROV-XML or RDF, load and re-serialize the document as
+PROV-JSON first (or write a two-line Python script using
+{py:meth}`~prov.model.ProvDocument.deserialize`/{py:meth}`~prov.model.ProvDocument.serialize`
+directly — see the format-specific how-to pages).
+
+### Examples
+
+Convert a PROV-JSON file to PROV-N:
+
+```bash
+prov-convert -f provn document.json document.provn
+```
+
+Convert a PROV-JSON file to an SVG diagram (needs a local Graphviz install, see
+{doc}`graphics`):
+
+```bash
+prov-convert -f svg document.json document.svg
+```
+
+Read from stdin, write PROV-JSON (the default) to stdout:
+
+```bash
+cat document.json | prov-convert > copy.json
+```
+
+### Exit behaviour
+
+- Success: exit code `0`; the converted document is written to `outfile`.
+- Unsupported `--format` value, or any other error (bad input, missing file): the error is
+  printed to stderr prefixed with the program name, and the process exits with code `2`.
+
+```bash
+prov-convert -f bogus document.json out.bogus
+# prov-convert: E: Output format "bogus" is not supported.
+#               for help use --help
+echo $?  # 2
+```
+
+## `prov-compare`
+
+Compare two PROV documents for equivalence (after
+{py:meth}`~prov.model.ProvBundle.unified`-style equality — the same `==` used throughout
+`prov`), each independently loadable as PROV-JSON or PROV-XML.
+
+### Synopsis
+
+```bash
+prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] [file1] [file2]
+```
+
+### Options
+
+| Flag | Argument | Default | Meaning |
+| --- | --- | --- | --- |
+| `-f`, `--format1` | `FORMAT1` | `json` | File 1's format: `json` or `xml` |
+| `-F`, `--format2` | `FORMAT2` | `json` | File 2's format: `json` or `xml` |
+| `-V`, `--version` | — | — | Print the version and exit |
+| `-h`, `--help` | — | — | Print usage and exit |
+| `file1`, `file2` (positional) | — | — | The two files to compare |
+
+Although the help text says "`json` or `xml`", any format name registered with
+{py:class}`prov.serializers.Registry` is actually accepted (e.g. `rdf`), because the flag
+value is passed straight through to
+{py:meth}`~prov.model.ProvDocument.deserialize`(format=...).
+
+### Examples
+
+Compare two PROV-JSON files:
+
+```bash
+prov-compare document.json copy.json
+```
+
+Compare a PROV-JSON file against a PROV-XML file:
+
+```bash
+prov-compare -f json -F xml document.json document.xml
+```
+
+### Exit behaviour
+
+`prov-compare` has no textual "equal"/"different" output on success — it communicates the
+result purely through the exit code:
+
+- Exit code `0`: the two documents are equivalent (`doc1 == doc2`).
+- Exit code `1`: the two documents differ (`doc1 != doc2`).
+- Exit code `2`: an error occurred (e.g. a file could not be parsed); a message is printed
+  to stderr.
+
+```bash
+prov-compare document.json document.json; echo $?   # 0 (identical)
+prov-compare document.json copy2.json; echo $?       # 1 (different)
+```

--- a/docs/howto/graphics.md
+++ b/docs/howto/graphics.md
@@ -1,0 +1,101 @@
+# Render a document as a graph (PNG/SVG/PDF)
+
+`prov.dot` turns a document into a [pydot](https://pypi.org/project/pydot/) graph, which
+can then be written out in any format Graphviz supports.
+
+```{important}
+Rendering needs a local **Graphviz** installation (the `dot` executable) in addition to the
+`pydot` Python package (which is a core dependency of `prov`, always installed). Installing
+`pydot` alone is not enough — this is the most common source of confusion:
+
+- **macOS**: `brew install graphviz`
+- **Debian/Ubuntu**: `apt install graphviz`
+- **Windows**: download and run the installer from <https://graphviz.org/download/>
+
+Without it, `dot.write_*()` calls below fail (typically with a `FileNotFoundError` for the
+`dot` executable, surfaced by `pydot` as an assertion/`Exception` depending on version) —
+verify Graphviz is on `PATH` with `dot -V` before debugging your own code.
+```
+
+## Convert a document to a `pydot.Dot`
+
+```python
+import prov.model as pm
+from prov.dot import prov_to_dot
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+e = document.entity("e1")
+a = document.activity("a1")
+document.wasGeneratedBy(e, a)
+
+dot = prov_to_dot(document)
+```
+
+## Write PNG, SVG, or PDF
+
+`pydot.Dot` has a `write_<format>` method for most Graphviz output formats:
+
+```python
+dot.write_png("document.png")
+dot.write_svg("document.svg")
+dot.write_pdf("document.pdf")
+```
+
+## Layout direction
+
+`direction` controls the rank direction Graphviz lays the graph out in — `"BT"`
+(bottom-to-top, the default), `"TB"`, `"LR"`, or `"RL"`:
+
+```python
+dot_lr = prov_to_dot(document, direction="LR")
+dot_lr.write_svg("document-lr.svg")
+```
+
+## Hide attribute annotations
+
+By default every element and relation gets an attached note node listing its non-formal
+attributes. Turn either off to declutter dense graphs:
+
+```python
+dot_plain = prov_to_dot(
+    document,
+    show_element_attributes=False,
+    show_relation_attributes=False,
+)
+```
+
+## Use labels instead of identifiers
+
+Pass `use_labels=True` to show each element's `prov:label` (falling back to its
+identifier) as the node text instead of always showing the identifier:
+
+```python
+document.entity("e1", {pm.PROV_LABEL: "Crime report"})
+dot_labelled = prov_to_dot(document, use_labels=True)
+```
+
+## Hide n-ary relation elements
+
+Relations with more than two formal attributes (e.g. a `wasDerivedFrom` recording an
+activity and usage/generation) render every element by default. Set `show_nary=False` to
+draw only the first two:
+
+```python
+dot_binary = prov_to_dot(document, show_nary=False)
+```
+
+## All together
+
+```python
+dot = prov_to_dot(
+    document,
+    show_nary=True,
+    use_labels=False,
+    direction="BT",
+    show_element_attributes=True,
+    show_relation_attributes=True,
+)
+```
+
+See {py:func}`prov.dot.prov_to_dot` for the full parameter reference.

--- a/docs/howto/networkx.md
+++ b/docs/howto/networkx.md
@@ -1,0 +1,66 @@
+# Convert to/from a NetworkX graph
+
+`prov.graph` converts a document to and from a
+[NetworkX](https://networkx.org/) `MultiDiGraph`, useful for running graph algorithms
+(centrality, shortest paths, community detection, ...) that `prov` itself does not
+implement. `networkx` is a core dependency — no extra install needed.
+
+## Document to graph
+
+{py:func}`~prov.graph.prov_to_graph` returns one node per element (entity/activity/agent)
+and one edge per relation. It unifies the document first, so records describing the same
+identifier are merged into a single node:
+
+```python
+import prov.model as pm
+from prov.graph import prov_to_graph
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+e = document.entity("e1")
+a = document.activity("a1")
+document.wasGeneratedBy(e, a)
+
+g = prov_to_graph(document)
+
+print(list(g.nodes()))
+# [<ProvEntity: e1>, <ProvActivity: a1>]
+print(list(g.edges(data=True)))
+# [(<ProvEntity: e1>, <ProvActivity: a1>, {'relation': <ProvGeneration: (e1, a1)>})]
+```
+
+Each node *is* the `prov` element record (a {py:class}`~prov.model.ProvElement`); each edge
+carries the originating {py:class}`~prov.model.ProvRelation` under the `"relation"` key so
+you don't lose PROV-specific information (relation type, extra attributes) while using
+NetworkX.
+
+## Run a NetworkX algorithm
+
+Because nodes are hashable `prov` objects, any NetworkX algorithm works directly:
+
+```python
+import networkx as nx
+
+print(nx.is_directed_acyclic_graph(g))
+```
+
+## Graph back to document
+
+{py:func}`~prov.graph.graph_to_prov` reverses the conversion for a graph previously
+produced by `prov_to_graph` (or built to match its shape — nodes are `ProvRecord`
+instances with a bundle, edges carry a `"relation"` record in their data):
+
+```python
+from prov.graph import graph_to_prov
+
+reloaded = graph_to_prov(g)
+assert reloaded == document
+```
+
+## Round trip
+
+```python
+g = prov_to_graph(document)
+reloaded = graph_to_prov(g)
+assert reloaded == document
+```

--- a/docs/howto/provjson.md
+++ b/docs/howto/provjson.md
@@ -1,0 +1,90 @@
+# Work with PROV-JSON
+
+[PROV-JSON](https://openprovenance.org/prov-json/) is the default format used by
+{py:meth}`~prov.model.ProvDocument.serialize`/{py:meth}`~prov.model.ProvDocument.deserialize`.
+It needs no extra dependency — the serializer is always available.
+
+## Serialize to a file
+
+```python
+import prov.model as pm
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+document.entity("e1")
+
+document.serialize("document.json")  # format="json" is the default
+```
+
+## Serialize to a string
+
+Omit `destination` (or pass `None`) to get the serialization back as a string:
+
+```python
+json_str = document.serialize()
+print(json_str)
+```
+
+## Deserialize from a file or stream
+
+```python
+loaded = pm.ProvDocument.deserialize("document.json")
+assert loaded == document
+```
+
+`source` also accepts an open stream:
+
+```python
+with open("document.json") as f:
+    loaded = pm.ProvDocument.deserialize(f)
+```
+
+## Deserialize from a string
+
+Use the `content` keyword instead of `source`:
+
+```python
+loaded = pm.ProvDocument.deserialize(content=json_str, format="json")
+```
+
+## Auto-detect the format with `prov.read()`
+
+{py:func}`prov.read` tries every registered deserializer in turn — PROV-JSON, then
+PROV-O/RDF, then PROV-N, then PROV-XML — until one succeeds, so it works without knowing
+the format up front. PROV-JSON is tried first, so valid PROV-JSON content always
+auto-detects correctly:
+
+```python
+import prov
+
+loaded = prov.read("document.json")
+assert loaded == document
+```
+
+Passing `format="json"` explicitly skips the trial-and-error and gives a proper traceback
+if the content is not valid JSON.
+
+## Common errors
+
+Malformed JSON raises the standard library's decoder error, not a `prov`-specific
+exception:
+
+```python
+try:
+    pm.ProvDocument.deserialize(content="not json", format="json")
+except Exception as e:
+    print(f"{type(e).__name__}: {e}")
+```
+
+```text
+JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+```
+
+Calling `prov.read()` without `format` on content that matches none of the registered
+formats only raises the documented fallback `TypeError` ("Could not read from the
+source...") if every deserializer it tries fails with one of `TypeError`, `ValueError`,
+`AttributeError`, or `KeyError` — those are the only exceptions `read()` catches while it
+tries formats in turn. In practice the RDF deserializer (tried before PROV-XML) usually
+raises an `rdflib` parser error first, which is *not* in that list, so it propagates
+immediately instead. Either way: pass `format=` explicitly if you want a predictable,
+format-specific error.

--- a/docs/howto/provn.md
+++ b/docs/howto/provn.md
@@ -1,0 +1,56 @@
+# Work with PROV-N
+
+```{important}
+**PROV-N is write-only.** `prov` can produce [PROV-N](https://www.w3.org/TR/prov-n/) text,
+but there is no parser: deserializing PROV-N raises `NotImplementedError`. If you need to
+read a document back, save it in PROV-JSON, PROV-XML, or PROV-O/RDF instead.
+```
+
+PROV-N needs no extra dependency.
+
+## Get the PROV-N text directly
+
+{py:meth}`~prov.model.ProvBundle.get_provn` returns the notation as a string without going
+through the serializer registry at all — this is the simplest way to print or inspect it:
+
+```python
+import prov.model as pm
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+e = document.entity("e1")
+a = document.activity("a1")
+document.wasGeneratedBy(e, a)
+
+print(document.get_provn())
+```
+
+## Serialize to a file
+
+`format="provn"` goes through the same {py:meth}`~prov.model.ProvDocument.serialize` API
+as the other formats, for consistency with tooling that dispatches on `format`:
+
+```python
+document.serialize("document.provn", format="provn")
+```
+
+## Serialize to a string
+
+```python
+provn_str = document.serialize(format="provn")
+assert provn_str == document.get_provn()
+```
+
+## Deserializing raises `NotImplementedError`
+
+There is no PROV-N reader, in the library or via `prov.read()`'s auto-detection:
+
+```python
+try:
+    pm.ProvDocument.deserialize("document.provn", format="provn")
+except NotImplementedError:
+    print("PROV-N has no deserializer")
+```
+
+If your workflow needs a round trip, keep a PROV-JSON (or PROV-XML/RDF) copy alongside any
+PROV-N output — see {doc}`provjson`.

--- a/docs/howto/provo-rdf.md
+++ b/docs/howto/provo-rdf.md
@@ -1,0 +1,94 @@
+# Work with PROV-O (RDF)
+
+[PROV-O](https://www.w3.org/TR/prov-o/) support needs the optional `rdflib` dependency:
+
+```bash
+python -m pip install "prov[rdf]"
+```
+
+The serialization format is selected with `format="rdf"`. A second, RDF-specific keyword,
+`rdf_format`, chooses the concrete RDF syntax (`"trig"` by default) — do not confuse the
+two.
+
+## Serialize to a file
+
+```python
+import prov.model as pm
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+e = document.entity("e1")
+a = document.activity("a1")
+document.wasGeneratedBy(e, a)
+
+document.serialize("document.trig", format="rdf")  # rdf_format="trig" is the default
+```
+
+## Choose a different RDF syntax
+
+`rdf_format` accepts anything `rdflib` can serialize to, e.g. `"turtle"`, `"xml"`
+(RDF/XML), `"nt"`, `"nquads"`:
+
+```python
+turtle_str = document.serialize(format="rdf", rdf_format="turtle")
+print(turtle_str)
+```
+
+```{important}
+Only quad-based syntaxes (`"trig"` — the default — and `"nquads"`) preserve **bundles** as
+separate named graphs. Triple-based syntaxes such as `"turtle"` or `"xml"` flatten every
+bundle's statements into a single graph, discarding which bundle each statement came from.
+Stick with the default TriG if your document has bundles.
+```
+
+## Serialize to a string
+
+```python
+trig_str = document.serialize(format="rdf")
+```
+
+## Deserialize from a file or stream
+
+```python
+loaded = pm.ProvDocument.deserialize("document.trig", format="rdf")
+assert loaded == document
+```
+
+Pass the matching `rdf_format` if the input is not TriG:
+
+```python
+loaded = pm.ProvDocument.deserialize(content=turtle_str, format="rdf", rdf_format="turtle")
+```
+
+## Deserialize from a string
+
+```python
+loaded = pm.ProvDocument.deserialize(content=trig_str, format="rdf")
+```
+
+## Auto-detect the format with `prov.read()`
+
+PROV-O/RDF is the second format `prov.read()` tries (after PROV-JSON), so genuine RDF
+content auto-detects reliably:
+
+```python
+import prov
+
+loaded = prov.read("document.trig")
+assert loaded == document
+```
+
+## Common errors
+
+Malformed RDF raises `rdflib`'s own parser error:
+
+```python
+try:
+    pm.ProvDocument.deserialize(content="not rdf", format="rdf")
+except Exception as e:
+    print(f"{type(e).__name__}")
+```
+
+```text
+BadSyntax
+```

--- a/docs/howto/provxml.md
+++ b/docs/howto/provxml.md
@@ -1,0 +1,88 @@
+# Work with PROV-XML
+
+[PROV-XML](https://www.w3.org/TR/prov-xml/) support needs the optional `lxml` dependency:
+
+```bash
+python -m pip install "prov[xml]"
+```
+
+## Serialize to a file
+
+```python
+import prov.model as pm
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+document.entity("e1")
+
+document.serialize("document.xml", format="xml")
+```
+
+## Serialize to a string
+
+```python
+xml_str = document.serialize(format="xml")
+print(xml_str)
+```
+
+## Force xsd:type attributes
+
+By default `xsi:type` is only written for `prov:type`, `prov:location`, and `prov:value`,
+matching the PROV-XML spec examples. Pass `force_types=True` to write it for every
+non-`prov:` attribute too:
+
+```python
+xml_str_typed = document.serialize(format="xml", force_types=True)
+```
+
+## Deserialize from a file or stream
+
+```python
+loaded = pm.ProvDocument.deserialize("document.xml", format="xml")
+assert loaded == document
+```
+
+## Deserialize from a string
+
+```python
+loaded = pm.ProvDocument.deserialize(content=xml_str, format="xml")
+```
+
+## Auto-detect the format with `prov.read()`
+
+`prov.read()` tries PROV-JSON, then PROV-O/RDF, then PROV-N, then PROV-XML, stopping at the
+first deserializer that succeeds. In practice this means **plain PROV-XML content almost
+never auto-detects**: the RDF (TriG) parser is tried before the XML one, and on real
+PROV-XML input it fails with an `rdflib` syntax error rather than one of the exception
+types `read()` catches (`TypeError`, `ValueError`, `AttributeError`, `KeyError`) — so that
+error propagates before PROV-XML ever gets a turn:
+
+```python
+import prov
+
+try:
+    prov.read("document.xml")  # no format given
+except Exception as e:
+    print(f"{type(e).__name__}: autodetect did not reach the XML deserializer")
+
+loaded = prov.read("document.xml", format="xml")  # works
+assert loaded == document
+```
+
+Always pass `format="xml"` explicitly when reading PROV-XML; do not rely on autodetection
+for this format.
+
+## Common errors
+
+Malformed XML raises `lxml`'s own syntax error, not a `prov`-specific exception:
+
+```python
+try:
+    pm.ProvDocument.deserialize(content="not xml", format="xml")
+except Exception as e:
+    print(f"{type(e).__name__}: {e}")
+```
+
+```text
+XMLSyntaxError: Start tag expected, '<' not found, line 1, column 1 (<string>, line 1)
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,18 @@ Prov Python package's documentation
 
 .. toctree::
    :maxdepth: 1
+   :caption: How-to guides
+
+   howto/provjson
+   howto/provxml
+   howto/provo-rdf
+   howto/provn
+   howto/graphics
+   howto/cli
+   howto/networkx
+
+.. toctree::
+   :maxdepth: 1
    :caption: Reference
 
    modules


### PR DESCRIPTION
Phase 3, Task 4 (spec step 22, How-to quadrant).

Seven task-oriented how-to pages: one per serialization format, graphics export, the CLI tools, and NetworkX interop. Every code block and CLI example verified by real execution.

Three accuracy points documented as *current behaviour* (surfaced while verifying):
- `ProvDocument.serialize`/`deserialize` do not do file-extension dispatch; `format=` must be explicit. Documented accordingly.
- `prov.read()` autodetect order is JSON → RDF → PROV-N → XML; valid PROV-XML rarely auto-detects because the RDF/TriG parser raises `BadSyntax` (not one of the caught exceptions) before XML is tried. Flagged prominently in the PROV-XML page. (A behaviour fix belongs in 3.0.)
- PROV-N is write-only (deserialize raises `NotImplementedError`) — stated prominently.

Build: 0 warnings (baseline held). Suite unchanged.

Closes #141, closes #83.