### PR TITLE
docs: correct and normalise docstrings to Google style (non-model modules)

### DIFF
--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -22,17 +22,31 @@ class Error(Exception):
 def read(
     source: str | bytes | os.PathLike[str], format: str | None = None
 ) -> ProvDocument | None:
-    """
-    Convenience function returning a ProvDocument instance.
+    """Read a :class:`~prov.model.ProvDocument` from a file, path, or string.
 
-    It does a lazy format detection by simply using try/except for all known
-    formats. The deserializers should fail fairly early when data of the
-    wrong type is passed to them thus the try/except is likely cheap. One
+    If ``format`` is not given, the format is detected lazily by trying each
+    registered serializer's ``deserialize()`` in turn and returning the first
+    one that succeeds. The deserializers should fail fairly early when data of
+    the wrong type is passed to them thus the try/except is likely cheap. One
     could of course also do some more advanced format auto-detection but I am
     not sure that is necessary.
 
-    The downside is that no proper error messages will be produced, use the
-    format parameter to get the actual traceback.
+    The downside of auto-detection is that no proper error messages will be
+    produced; pass the ``format`` parameter explicitly to get the actual
+    traceback from the matching deserializer.
+
+    Args:
+        source: File-like stream, path, or raw content to deserialize.
+        format: Serialization format to use (e.g. ``"json"``, ``"xml"``,
+            ``"rdf"``, ``"provn"``). If ``None``, every registered format is
+            tried in turn.
+
+    Returns:
+        The deserialized :class:`~prov.model.ProvDocument`.
+
+    Raises:
+        TypeError: If ``format`` is ``None`` and none of the registered
+            serializers could deserialize ``source``.
     """
     # Lazy imports to not globber the namespace.
     from prov.model import ProvDocument

--- a/src/prov/constants.py
+++ b/src/prov/constants.py
@@ -1,3 +1,14 @@
+"""The PROV-DM/PROV-O vocabulary as module-level data.
+
+Defines one :class:`~prov.identifier.QualifiedName` constant per PROV record
+type and per formal attribute (``PROV_ENTITY``, ``PROV_ACTIVITY``,
+``PROV_ATTR_TIME``, ...), plus the lookup tables used to translate between
+those constants, PROV-N keywords, and the Python model classes:
+``PROV_N_MAP`` (record type to PROV-N keyword), ``PROV_BASE_CLS`` (record
+type to base record type), and the various ``PROV_ATTRIBUTE*``/
+``PROV_RECORD*`` sets and dicts consulted while parsing and serializing.
+"""
+
 from prov.identifier import Namespace
 
 __author__ = "Trung Dong Huynh"
@@ -57,6 +68,7 @@ PROV_N_MAP = {
     PROV_MEMBERSHIP: "hadMember",
     PROV_BUNDLE: "bundle",
 }
+"""Maps each top-level PROV record type QualifiedName to its PROV-N keyword."""
 
 # Records defined as subtypes in PROV-N but top level types in for example
 # PROV XML also need a mapping.
@@ -71,6 +83,8 @@ ADDITIONAL_N_MAP = {
     PROV["Collection"]: "collection",
     PROV["EmptyCollection"]: "emptyCollection",
 }
+"""Maps PROV-N subtype QualifiedNames (top-level types in e.g. PROV-XML) to
+their PROV-N keyword; not included in :data:`PROV_N_MAP` itself."""
 
 # Maps qualified names from the PROV namespace to their base class. If it
 # has no baseclass it maps to itsself. This is needed for example for PROV
@@ -105,6 +119,8 @@ PROV_BASE_CLS = {
     PROV_MEMBERSHIP: PROV_MEMBERSHIP,
     PROV_BUNDLE: PROV_ENTITY,
 }
+"""Maps each PROV record/subtype QualifiedName to its base record type
+QualifiedName (mapping to itself if it has no base type)."""
 
 # Identifiers for PROV's attributes
 PROV_ATTR_ENTITY = PROV["entity"]
@@ -162,20 +178,29 @@ PROV_ATTRIBUTE_QNAMES = {
     PROV_ATTR_INFLUENCER,
     PROV_ATTR_COLLECTION,
 }
+"""Set of QualifiedName-valued formal attributes of PROV records."""
 PROV_ATTRIBUTE_LITERALS = {PROV_ATTR_TIME, PROV_ATTR_STARTTIME, PROV_ATTR_ENDTIME}
+"""Set of literal-valued (non-QualifiedName) formal attributes of PROV records."""
 
 # Set of formal attributes of PROV records
 PROV_ATTRIBUTES = PROV_ATTRIBUTE_QNAMES | PROV_ATTRIBUTE_LITERALS
+"""All formal attributes of PROV records, QualifiedName- and literal-valued."""
 PROV_RECORD_ATTRIBUTES = [(attr, str(attr)) for attr in PROV_ATTRIBUTES]
+"""``(QualifiedName, str)`` pairs for every entry in :data:`PROV_ATTRIBUTES`."""
 
 PROV_RECORD_IDS_MAP = {
     PROV_N_MAP[rec_type_id]: rec_type_id for rec_type_id in PROV_N_MAP
 }
+"""Inverse of :data:`PROV_N_MAP`: maps each PROV-N keyword back to its record
+type QualifiedName."""
 PROV_ID_ATTRIBUTES_MAP = dict(PROV_RECORD_ATTRIBUTES)
+"""Maps each formal attribute QualifiedName to its string form."""
 # inverse of PROV_ID_ATTRIBUTES_MAP: maps each attribute name back to its QName
 PROV_ATTRIBUTES_ID_MAP = {
     attribute: prov_id for (prov_id, attribute) in PROV_RECORD_ATTRIBUTES
 }
+"""Inverse of :data:`PROV_ID_ATTRIBUTES_MAP`: maps each attribute's string
+form back to its QualifiedName."""
 
 # Extra definition for convenience
 PROV_TYPE = PROV["type"]

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -1,6 +1,6 @@
 """Graphical visualisation support for prov.model.
 
-This module produces graphical visualisation for provenanve graphs.
+This module produces graphical visualisation for provenance graphs.
 Requires pydot module and Graphviz.
 
 References:
@@ -180,6 +180,17 @@ ANNOTATION_END_ROW = "    </TABLE>>"
 
 
 def htlm_link_if_uri(value: Any) -> str:
+    """Render an attribute value as an HTML anchor if it has a ``uri``, else as plain text.
+
+    Args:
+        value: Attribute value to render; typically an
+            :class:`~prov.identifier.Identifier`/:class:`~prov.identifier.QualifiedName`
+            (which have a ``uri`` attribute) or a plain literal.
+
+    Returns:
+        An ``<a href="...">`` HTML fragment linking to ``value.uri`` if
+        ``value`` has a ``uri`` attribute, otherwise ``str(value)``.
+    """
     try:
         uri = value.uri
         return f'<a href="{uri}">{value!s}</a>'
@@ -195,21 +206,29 @@ def prov_to_dot(
     show_element_attributes: bool = True,
     show_relation_attributes: bool = True,
 ) -> pydot.Dot:
-    """
-    Convert a provenance bundle/document into a DOT graphical representation.
+    """Convert a provenance bundle/document into a DOT graphical representation.
 
-    :param bundle: The provenance bundle/document to be converted.
-    :type bundle: :class:`ProvBundle`
-    :param show_nary: shows all elements in n-ary relations.
-    :type show_nary: bool
-    :param use_labels: uses the prov:label property of an element as its name (instead of its identifier).
-    :type use_labels: bool
-    :param direction: specifies the direction of the graph. Valid values are "BT" (default), "TB", "LR", "RL".
-    :param show_element_attributes: shows attributes of elements.
-    :type show_element_attributes: bool
-    :param show_relation_attributes: shows attributes of relations.
-    :type show_relation_attributes: bool
-    :returns:  :class:`pydot.Dot` -- the Dot object.
+    The bundle is first :meth:`~prov.model.ProvBundle.unified`; if that
+    raises :class:`~prov.model.ProvException` (the bundle cannot be
+    unified), the original, non-unified bundle is rendered instead.
+
+    Args:
+        bundle: The provenance bundle/document to be converted.
+        show_nary: Show all elements of n-ary relations (i.e. relations with
+            more than two formal attributes), not just the first two.
+        use_labels: Use the ``prov:label`` property of an element as its
+            displayed name (instead of its identifier), where available.
+        direction: Direction of the graph, passed to Graphviz as
+            ``rankdir``. Valid values are ``"BT"`` (default), ``"TB"``,
+            ``"LR"``, ``"RL"``; any other value is silently replaced with
+            ``"BT"``.
+        show_element_attributes: Show attributes of elements as annotation
+            nodes.
+        show_relation_attributes: Show attributes of relations as annotation
+            nodes.
+
+    Returns:
+        The :class:`pydot.Dot` graph object.
     """
     if direction not in {"BT", "TB", "LR", "RL"}:
         # Invalid direction is provided

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -60,15 +60,34 @@ INFERRED_ELEMENT_CLASS = {
     PROV_ATTR_ENDER: ProvEntity,
     PROV_ATTR_STARTER: ProvEntity,
 }
+"""Maps a relation's first/second formal attribute (e.g. ``PROV_ATTR_ENTITY``)
+to the :class:`~prov.model.ProvElement` subclass used to create a bare node
+for an element referenced by a relation but not otherwise declared."""
 
 
 def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
-    """
-    Convert a :class:`~prov.model.ProvDocument` to a `MultiDiGraph
+    """Convert a :class:`~prov.model.ProvDocument` to a `MultiDiGraph
     <https://networkx.github.io/documentation/stable/reference/classes/multidigraph.html>`_
     instance of the `NetworkX <https://networkx.github.io/>`_ library.
 
-    :param prov_document: The :class:`~prov.model.ProvDocument` instance to convert.
+    The document is first :meth:`~prov.model.ProvBundle.unified` so that
+    records referring to the same real-world thing are merged before the
+    graph is built. Every PROV element becomes a graph node. Each relation
+    becomes an edge between the elements named in its first two formal
+    attributes, with the relation record stored under the edge's
+    ``"relation"`` attribute; if either of those two elements was not
+    already added as a node, a bare node is created for it using
+    :data:`INFERRED_ELEMENT_CLASS`. Relations whose first two formal
+    attributes are not both populated, or whose attribute type is not in
+    :data:`INFERRED_ELEMENT_CLASS`, are silently skipped.
+
+    Args:
+        prov_document: The :class:`~prov.model.ProvDocument` instance to
+            convert.
+
+    Returns:
+        A NetworkX ``MultiDiGraph`` with PROV elements as nodes and PROV
+        relations as edges.
     """
     g: nx.MultiDiGraph[Any] = nx.MultiDiGraph()
     unified = prov_document.unified()
@@ -96,13 +115,23 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
 
 
 def graph_to_prov(g: nx.MultiDiGraph[Any]) -> ProvDocument:
-    """
-    Convert a `MultiDiGraph
+    """Convert a `MultiDiGraph
     <https://networkx.github.io/documentation/stable/reference/classes/multidigraph.html>`_
     that was previously produced by :func:`prov_to_graph` back to a
     :class:`~prov.model.ProvDocument`.
 
-    :param g: The graph instance to convert.
+    Every node that is a :class:`~prov.model.ProvRecord` already attached to
+    a bundle is added to the new document; nodes without a bundle (e.g. bare
+    nodes inferred by :func:`prov_to_graph`) are skipped. Every edge whose
+    ``"relation"`` data is a :class:`~prov.model.ProvRecord` is likewise
+    added; edges without relation data are skipped.
+
+    Args:
+        g: The graph instance to convert.
+
+    Returns:
+        A new :class:`~prov.model.ProvDocument` containing the elements and
+        relations recovered from ``g``.
     """
     prov_doc = ProvDocument()
     for n in g.nodes():

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -13,21 +13,17 @@ class Identifier:
     # into a subclass
 
     def __init__(self, uri: str):
-        """
-        Constructor.
+        """Create an identifier for the given URI.
 
-        :param uri: URI string for the long namespace identifier.
+        Args:
+            uri: URI string for the identifier. Converted to ``str`` if not
+                already one.
         """
         self._uri: str = str(uri)  # Ensure this is a unicode string
 
     @property
     def uri(self) -> str:
-        """
-        Returns the URI associated with the current identifier.
-
-        Returns:
-            str: The URI representing the resource identifier.
-        """
+        """The URI associated with the current identifier."""
         return self._uri
 
     def __str__(self) -> str:
@@ -43,12 +39,7 @@ class Identifier:
         return f"<{self.__class__.__name__}: {self._uri}>"
 
     def provn_representation(self) -> str:
-        """
-        Returns the PROV-N representation of the URI.
-
-        Returns:
-            str: The PROV-N representation of the URI.
-        """
+        """Return the PROV-N representation of this identifier as an xsd:anyURI literal."""
         return f'"{self._uri}" %% xsd:anyURI'
 
 
@@ -101,7 +92,7 @@ class QualifiedName(Identifier):
         return hash(self.uri)
 
     def provn_representation(self) -> str:
-        """PROV-N representation of qualified name in a string."""
+        """Return the PROV-N representation of this qualified name as a quoted string."""
         return f"'{self._str}'"
 
 
@@ -109,11 +100,14 @@ class Namespace:
     """PROV Namespace."""
 
     def __init__(self, prefix: str, uri: str):
-        """
-        Constructor.
+        """Create a namespace with the given prefix and URI.
 
-        :param prefix: String short hand prefix for the namespace.
-        :param uri: URI string for the long namespace identifier (cannot be blank).
+        Args:
+            prefix: Short-hand prefix for the namespace.
+            uri: URI string for the namespace (cannot be blank).
+
+        Raises:
+            ValueError: If ``uri`` is empty or contains only whitespace.
         """
         if not uri or uri.isspace():
             raise ValueError("Not a valid URI to create a namespace.")
@@ -132,11 +126,14 @@ class Namespace:
         return self._prefix
 
     def contains(self, identifier: Identifier) -> bool:
-        """
-        Indicates whether the identifier provided is contained in this namespace.
+        """Check whether the given identifier's URI is contained in this namespace.
 
-        :param identifier: Identifier to check.
-        :return: bool
+        Args:
+            identifier: Identifier (or URI string) to check.
+
+        Returns:
+            ``True`` if the identifier's URI starts with this namespace's URI,
+            ``False`` otherwise (including when the URI cannot be determined).
         """
         uri = (
             identifier
@@ -146,12 +143,14 @@ class Namespace:
         return uri.startswith(self._uri) if uri else False
 
     def qname(self, identifier: str | Identifier) -> QualifiedName | None:
-        """
-        Returns the qualified name of the identifier given using the namespace
-        prefix.
+        """Resolve an identifier to a :class:`QualifiedName` in this namespace.
 
-        :param identifier: Identifier to resolve to a qualified name.
-        :return: :py:class:`QualifiedName`
+        Args:
+            identifier: Identifier (or URI string) to resolve.
+
+        Returns:
+            A new :class:`QualifiedName` in this namespace if ``identifier``'s
+            URI starts with this namespace's URI, otherwise ``None``.
         """
         uri = (
             identifier

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -46,7 +46,26 @@ class CLIError(Exception):
 
 
 def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
-    """Command line options."""
+    """Run the ``prov-compare`` command-line tool.
+
+    Parses two positional file arguments plus ``-f/--format1`` and
+    ``-F/--format2`` (each defaulting to ``"json"``), deserializes both
+    files, and compares the resulting documents for equality.
+
+    Args:
+        argv: Extra command-line arguments. If not ``None``, they are
+            appended to ``sys.argv`` (which is *not* replaced) before
+            argument parsing, so ``sys.argv[0]`` is still used as the
+            program name.
+
+    Returns:
+        ``0`` if the two documents are equal, ``1`` if they differ (the
+        truthiness of ``doc1 != doc2``), or ``2`` if an exception was raised
+        while parsing arguments or deserializing a file (unless
+        ``DEBUG``/``TESTRUN`` is set, in which case the exception propagates
+        instead). Unlike ``prov-convert``, ``KeyboardInterrupt`` is not
+        caught here and will propagate.
+    """
 
     if argv is None:
         argv = sys.argv

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -71,6 +71,8 @@ GRAPHVIZ_SUPPORTED_FORMATS = {
     "xdot",
     "xlib",
 }
+"""Graphviz output format names accepted by :func:`convert_file` in addition
+to the formats registered in :class:`~prov.serializers.Registry`."""
 
 
 class CLIError(Exception):
@@ -85,6 +87,28 @@ class CLIError(Exception):
 
 
 def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> None:
+    """Read a PROV document from ``infile`` and write it to ``outfile`` in ``output_format``.
+
+    ``infile`` is auto-detected across all registered deserialization
+    formats (see :meth:`~prov.model.ProvDocument.deserialize`). For
+    ``output_format``, ``"provn"`` is written directly via
+    :meth:`~prov.model.ProvDocument.get_provn`, a name in
+    :data:`GRAPHVIZ_SUPPORTED_FORMATS` is rendered through
+    :func:`~prov.dot.prov_to_dot` and Graphviz, and any other format is
+    delegated to :meth:`~prov.model.ProvDocument.serialize`.
+
+    Args:
+        infile: File-like object to read the source document from.
+        outfile: File-like object (opened in binary mode) to write the
+            converted output to.
+        output_format: Target format name (e.g. ``"json"``, ``"xml"``,
+            ``"rdf"``, ``"provn"``, or a Graphviz output format such as
+            ``"svg"``/``"pdf"``/``"png"``).
+
+    Raises:
+        CLIError: If ``output_format`` is not ``"provn"``, not a Graphviz
+            format, and not a registered serializer format.
+    """
     prov_doc = ProvDocument.deserialize(infile)
 
     # Formats not supported by prov.serializers
@@ -108,7 +132,24 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
 
 
 def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
-    """Command line options."""
+    """Run the ``prov-convert`` command-line tool.
+
+    Parses ``-f/--format``, an optional input file (default stdin), and an
+    optional output file (default stdout), then converts between them via
+    :func:`convert_file`.
+
+    Args:
+        argv: Extra command-line arguments. If not ``None``, they are
+            appended to ``sys.argv`` (which is *not* replaced) before
+            argument parsing, so ``sys.argv[0]`` is still used as the
+            program name.
+
+    Returns:
+        ``0`` on success or on ``KeyboardInterrupt``; ``2`` if an exception
+        was raised while parsing arguments or converting the file (unless
+        ``DEBUG``/``TESTRUN`` is set, in which case the exception
+        propagates instead).
+    """
 
     if argv is None:
         argv = sys.argv

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -22,28 +22,43 @@ class Serializer(ABC):
     """PROV document to serialise."""
 
     def __init__(self, document: ProvDocument | None = None):
-        """
-        Constructor.
+        """Create a serializer bound to a document.
 
-        :param document: Document to serialize.
+        Args:
+            document: Document this serializer will serialize, or
+                deserialize into. May be ``None`` when only deserialization
+                (which produces its own new document) is needed.
         """
         self.document = document
 
     @abstractmethod
     def serialize(self, stream: io.IOBase, **args: Any) -> None:
-        """
-        Abstract method for serializing.
+        """Serialize ``self.document`` and write it to a stream.
 
-        :param stream: Stream object to serialize the document into.
+        Subclasses implement this to encode the bound document and write the
+        result to ``stream``.
+
+        Args:
+            stream: Stream to write the serialized document into.
+            **args: Format-specific serialization options, passed through by
+                subclasses.
         """
         pass  # pragma: no cover -- abstract body, never executed directly
 
     @abstractmethod
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:
-        """
-        Abstract method for deserializing.
+        """Read and parse a document from a stream.
 
-        :param stream: Stream object to deserialize the document from.
+        Subclasses implement this to parse ``stream`` and build a new
+        :class:`~prov.model.ProvDocument` from it.
+
+        Args:
+            stream: Stream to deserialize the document from.
+            **args: Format-specific deserialization options, passed through
+                by subclasses.
+
+        Returns:
+            The deserialized :class:`~prov.model.ProvDocument`.
         """
         pass  # pragma: no cover -- abstract body, never executed directly
 
@@ -62,7 +77,13 @@ class Registry:
 
     @staticmethod
     def load_serializers() -> None:
-        """Loads all available serializers into the registry."""
+        """Populate :attr:`serializers` with the four built-in serializer classes.
+
+        Imports the ``json``, ``rdf``, ``provn``, and ``xml`` serializer
+        modules lazily (to avoid import cycles) and (re-)registers them in
+        :attr:`serializers`, unconditionally overwriting any previous
+        contents.
+        """
         from prov.serializers.provjson import ProvJSONSerializer
         from prov.serializers.provn import ProvNSerializer
         from prov.serializers.provrdf import ProvRDFSerializer
@@ -77,8 +98,17 @@ class Registry:
 
 
 def get(format_name: str) -> type[Serializer]:
-    """
-    Returns the serializer class for the specified format. Raises a DoNotExist
+    """Return the serializer class registered for a format.
+
+    Args:
+        format_name: Registry key, e.g. ``"json"``, ``"xml"``, ``"rdf"``,
+            ``"provn"``.
+
+    Returns:
+        The :class:`Serializer` subclass for the format.
+
+    Raises:
+        DoNotExist: If no serializer is registered under ``format_name``.
     """
     # Lazily initialize the list of serializers to avoid cyclic imports
     if Registry.serializers is None:

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -1,3 +1,5 @@
+"""PROV-JSON serializer for ProvDocument."""
+
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
 import datetime
@@ -31,15 +33,32 @@ ProvJSONDict = dict[str, dict[str, Any]]
 
 
 class ProvJSONException(Error):
+    """Raised when a PROV-JSON document contains a construct this package cannot decode."""
+
     pass
 
 
 class AnonymousIDGenerator:
+    """Assigns and caches stable blank-node identifiers for unidentified records."""
+
     def __init__(self) -> None:
         self._cache = {}  # type: dict[ProvRecord, Identifier]
         self._count = 0  # type: int
 
     def get_anon_id(self, obj: ProvRecord, local_prefix: str = "id") -> Identifier:
+        """Return a blank-node :class:`~prov.identifier.Identifier` for a record.
+
+        The same object always gets the same identifier back; a new one
+        (``_:<local_prefix><n>``) is minted and cached the first time a given
+        record is seen.
+
+        Args:
+            obj: Record needing an anonymous identifier.
+            local_prefix: Prefix used when minting a new identifier.
+
+        Returns:
+            The cached or newly minted blank-node identifier for ``obj``.
+        """
         if obj not in self._cache:
             self._count += 1
             self._cache[obj] = Identifier(f"_:{local_prefix}{self._count}")
@@ -53,19 +72,22 @@ LITERAL_XSDTYPE_MAP = {
     # boolean, string values are supported natively by PROV-JSON
     # datetime values are converted separately
 }
+"""Maps Python literal types to their PROV-JSON ``xsd:*`` type name, for
+types not natively supported by PROV-JSON."""
 
 
 class ProvJSONSerializer(Serializer):
-    """
-    PROV-JSON serializer for :class:`~prov.model.ProvDocument`
-    """
+    """PROV-JSON serializer for :class:`~prov.model.ProvDocument`."""
 
     def serialize(self, stream: io.IOBase, **args: Any) -> None:
-        """
-        Serializes a :class:`~prov.model.ProvDocument` instance to
-        `PROV-JSON <https://openprovenance.org/prov-json/>`_.
+        """Serialize ``self.document`` to `PROV-JSON <https://openprovenance.org/prov-json/>`_.
 
-        :param stream: Where to save the output.
+        Args:
+            stream: Stream to write the output to. Text streams receive the
+                JSON text directly; other (binary) streams receive it
+                UTF-8-encoded.
+            **args: Extra keyword arguments passed through to
+                :func:`json.dump`.
         """
         buf = io.StringIO()
         try:
@@ -82,12 +104,16 @@ class ProvJSONSerializer(Serializer):
             buf.close()
 
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:
-        """
-        Deserialize from the `PROV JSON
-        <https://openprovenance.org/prov-json/>`_ representation to a
-        :class:`~prov.model.ProvDocument` instance.
+        """Deserialize a `PROV-JSON <https://openprovenance.org/prov-json/>`_
+        stream into a :class:`~prov.model.ProvDocument`.
 
-        :param stream: Input data.
+        Args:
+            stream: Input data; binary streams are decoded as UTF-8 first.
+            **args: Extra keyword arguments passed through to
+                :func:`json.load`.
+
+        Returns:
+            The deserialized :class:`~prov.model.ProvDocument`.
         """
         if not isinstance(stream, io.TextIOBase):
             buf = io.StringIO(stream.read().decode("utf-8"))
@@ -96,7 +122,19 @@ class ProvJSONSerializer(Serializer):
 
 
 class ProvJSONEncoder(json.JSONEncoder):
+    """``json.JSONEncoder`` that knows how to encode a :class:`~prov.model.ProvDocument`."""
+
     def default(self, o: Any) -> Any:
+        """Return the PROV-JSON container dict for a :class:`~prov.model.ProvDocument`.
+
+        Args:
+            o: Object being encoded.
+
+        Returns:
+            The result of :func:`encode_json_document` if ``o`` is a
+            :class:`~prov.model.ProvDocument`, otherwise the superclass's
+            default handling.
+        """
         if isinstance(o, ProvDocument):
             return encode_json_document(o)
         else:
@@ -104,7 +142,22 @@ class ProvJSONEncoder(json.JSONEncoder):
 
 
 class ProvJSONDecoder(json.JSONDecoder):
+    """``json.JSONDecoder`` that decodes PROV-JSON into a :class:`~prov.model.ProvDocument`."""
+
     def decode(self, s: str, *args: Any, **kwargs: Any) -> Any:
+        """Parse a PROV-JSON string into a new :class:`~prov.model.ProvDocument`.
+
+        Args:
+            s: PROV-JSON text to parse.
+            *args: Extra positional arguments passed to the superclass's
+                ``decode()``.
+            **kwargs: Extra keyword arguments passed to the superclass's
+                ``decode()``.
+
+        Returns:
+            A new :class:`~prov.model.ProvDocument` populated via
+            :func:`decode_json_document`.
+        """
         container = super().decode(s, *args, **kwargs)
         document = ProvDocument()
         decode_json_document(container, document)
@@ -115,6 +168,17 @@ class ProvJSONDecoder(json.JSONDecoder):
 def valid_qualified_name(
     bundle: ProvBundle, value: QualifiedNameCandidate | None
 ) -> QualifiedName | None:
+    """Resolve a candidate value to a :class:`~prov.identifier.QualifiedName` in a bundle.
+
+    Args:
+        bundle: Bundle whose namespaces are used to resolve ``value``.
+        value: Candidate qualified name (string, :class:`QualifiedName`, or
+            other supported representation), or ``None``.
+
+    Returns:
+        The resolved :class:`~prov.identifier.QualifiedName`, or ``None`` if
+        ``value`` is ``None`` or cannot be resolved.
+    """
     if value is None:
         return None
     qualified_name = bundle.valid_qualified_name(value)
@@ -122,6 +186,16 @@ def valid_qualified_name(
 
 
 def encode_json_document(document: ProvDocument) -> ProvJSONDict:
+    """Encode a whole :class:`~prov.model.ProvDocument`, including its named bundles.
+
+    Args:
+        document: Document to encode.
+
+    Returns:
+        The PROV-JSON container dict for ``document``, with each named
+        bundle's own encoded container nested under ``container["bundle"]``
+        keyed by the bundle's identifier string.
+    """
     container = encode_json_container(document)
     for bundle in document.bundles:
         #  encoding the sub-bundle
@@ -131,6 +205,20 @@ def encode_json_document(document: ProvDocument) -> ProvJSONDict:
 
 
 def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
+    """Encode a single bundle's namespaces and records to a PROV-JSON container dict.
+
+    Does not recurse into ``bundle``'s own named bundles; see
+    :func:`encode_json_document` for encoding a whole document.
+
+    Args:
+        bundle: Bundle (or document, treated as its top-level bundle) to
+            encode.
+
+    Returns:
+        A dict with an optional ``"prefix"`` entry for registered namespaces
+        and one entry per PROV-N record-type keyword, each mapping record
+        identifiers (real or anonymous) to their encoded attributes.
+    """
     container = defaultdict(dict)  # type: dict[str, dict[str, Any]]
     prefixes = {}  # type: dict[str, str]
     for namespace in bundle._namespaces.get_registered_namespaces():
@@ -190,6 +278,18 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
 
 
 def decode_json_document(content: ProvJSONDict, document: ProvDocument) -> None:
+    """Decode a whole PROV-JSON container, including named bundles, into a document.
+
+    Mutates ``content`` in place, removing the top-level ``"bundle"`` key (if
+    present) before decoding the rest as the document's own records; mutates
+    ``document`` in place by adding the decoded records and named bundles to
+    it.
+
+    Args:
+        content: PROV-JSON container dict, as produced by
+            :func:`encode_json_document` (or parsed JSON in that shape).
+        document: Document to populate.
+    """
     bundles = {}
     if "bundle" in content:
         bundles = content["bundle"]
@@ -204,6 +304,23 @@ def decode_json_document(content: ProvJSONDict, document: ProvDocument) -> None:
 
 
 def decode_json_container(jc: ProvJSONDict, bundle: ProvBundle) -> None:
+    """Decode one PROV-JSON container's namespaces and records into a bundle.
+
+    Mutates ``jc`` in place, removing the ``"prefix"`` key (if present) once
+    its namespaces have been registered on ``bundle``; mutates ``bundle`` in
+    place by adding the decoded records to it. Does not handle a nested
+    ``"bundle"`` key; see :func:`decode_json_document` for a whole document.
+
+    Args:
+        jc: PROV-JSON container dict for a single bundle (no ``"bundle"``
+            key), as produced by :func:`encode_json_container`.
+        bundle: Bundle to populate.
+
+    Raises:
+        ProvJSONException: If a formal (QualifiedName- or literal-valued)
+            attribute has more than one value, other than the documented
+            multi-entity ``hadMember`` (membership) hack.
+    """
     if "prefix" in jc:
         prefixes = jc["prefix"]
         for prefix, uri in prefixes.items():
@@ -289,6 +406,20 @@ def decode_json_container(jc: ProvJSONDict, bundle: ProvBundle) -> None:
 
 
 def encode_json_representation(value: Any) -> Any:
+    """Encode a single non-formal attribute value to its PROV-JSON representation.
+
+    Args:
+        value: Attribute value to encode: a :class:`~prov.model.Literal`,
+            a :class:`datetime.datetime`, a
+            :class:`~prov.identifier.QualifiedName`, another
+            :class:`~prov.identifier.Identifier`, a type listed in
+            :data:`LITERAL_XSDTYPE_MAP`, or a plain JSON-native value.
+
+    Returns:
+        A ``{"$": ..., "type": ...}`` (optionally ``"lang"``) dict for typed
+        values, or ``value`` unchanged if it is already natively
+        JSON-representable (e.g. plain ``str``/``bool``).
+    """
     if isinstance(value, Literal):
         return literal_json_representation(value)
     elif isinstance(value, datetime.datetime):
@@ -306,6 +437,22 @@ def encode_json_representation(value: Any) -> Any:
 
 
 def decode_json_representation(literal: Any, bundle: ProvBundle) -> Any:
+    """Decode a single non-formal attribute value from its PROV-JSON representation.
+
+    Args:
+        literal: Either a ``{"$": ..., "type": ..., "lang": ...}`` dict (the
+            complex/typed representation) or a plain JSON-native value.
+        bundle: Bundle used to resolve any ``"type"``/value that is a
+            qualified name.
+
+    Returns:
+        An :class:`~prov.identifier.Identifier` for ``xsd:anyURI`` values, a
+        resolved :class:`~prov.identifier.QualifiedName` for
+        ``prov:QUALIFIED_NAME`` values, a :class:`~prov.model.Literal` for
+        other typed values, or ``literal`` unchanged if it was not a dict
+        (conversion of plain Python types happens later, when the value is
+        added to a record).
+    """
     if isinstance(literal, dict):
         # complex type
         value = literal["$"]
@@ -327,6 +474,15 @@ def decode_json_representation(literal: Any, bundle: ProvBundle) -> Any:
 
 
 def literal_json_representation(literal: Literal) -> dict[str, str]:
+    """Encode a :class:`~prov.model.Literal` to its PROV-JSON dict representation.
+
+    Args:
+        literal: Literal to encode.
+
+    Returns:
+        ``{"$": value, "lang": langtag}`` if the literal has a language tag,
+        otherwise ``{"$": value, "type": str(datatype)}``.
+    """
     # TODO: QName export
     value, datatype, langtag = literal.value, literal.datatype, literal.langtag
     if langtag:

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -9,14 +9,24 @@ from prov.serializers import Serializer
 
 
 class ProvNSerializer(Serializer):
-    """PROV-N serializer for ProvDocument"""
+    """PROV-N serializer for ProvDocument.
+
+    Write-only: PROV-N has no deserializer in this package (see
+    :meth:`deserialize`).
+    """
 
     def serialize(self, stream: io.IOBase, **args: Any) -> None:
-        """
-        Serializes a :class:`prov.model.ProvDocument` instance to a
-        `PROV-N <http://www.w3.org/TR/prov-n/>`_.
+        """Serialize ``self.document`` to `PROV-N <http://www.w3.org/TR/prov-n/>`_.
 
-        :param stream: Where to save the output.
+        Args:
+            stream: Stream to write the output to. Text streams receive the
+                PROV-N text directly; other (binary) streams receive it
+                UTF-8-encoded.
+            **args: Unused; accepted for interface compatibility with
+                :meth:`Serializer.serialize`.
+
+        Raises:
+            Exception: If ``self.document`` is ``None``.
         """
         if self.document is None:
             raise Exception("No document to serialize")
@@ -29,4 +39,9 @@ class ProvNSerializer(Serializer):
         )
 
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:
+        """Not implemented: PROV-N has no parser in this package.
+
+        Raises:
+            NotImplementedError: Always.
+        """
         raise NotImplementedError

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -55,15 +55,32 @@ __email__ = "satra@mit.edu"
 
 
 class ProvRDFException(Error):
+    """Raised when a PROV-RDF/PROV-O graph cannot be decoded by this package."""
+
     pass
 
 
 class AnonymousIDGenerator:
+    """Assigns and caches stable blank-node identifier strings for unidentified records."""
+
     def __init__(self) -> None:
         self._cache = {}  # type: dict[Any, str]
         self._count = 0  # type: int
 
     def get_anon_id(self, obj: pm.ProvRecord, local_prefix: str = "id") -> str:
+        """Return a blank-node identifier string (``"_:<local_prefix><n>"``) for a record.
+
+        The same object always gets the same identifier string back; a new
+        one is minted and cached the first time a given record is seen.
+
+        Args:
+            obj: Record needing an anonymous identifier.
+            local_prefix: Prefix used when minting a new identifier.
+
+        Returns:
+            The cached or newly minted blank-node identifier string for
+            ``obj``.
+        """
         if obj not in self._cache:
             self._count += 1
             self._cache[obj] = f"_:{local_prefix}{self._count}"
@@ -78,6 +95,8 @@ LITERAL_XSDTYPE_MAP = {
     # boolean, string values are supported natively by PROV-RDF
     # datetime values are converted separately
 }
+"""Maps Python literal types to their RDF ``xsd:*`` datatype URIRef, for
+types not natively/simply representable in PROV-RDF."""
 
 RELATION_MAP = {
     URIRef(PROV["alternateOf"].uri): "alternate",
@@ -96,6 +115,10 @@ RELATION_MAP = {
     URIRef(PROV["hadMember"].uri): "membership",
     URIRef(PROV["used"].uri): "usage",
 }
+"""Default ``relation_mapper`` for :meth:`ProvRDFSerializer.deserialize`/
+:meth:`~ProvRDFSerializer.decode_container`: maps each PROV-O relation
+predicate URIRef to the name of the :class:`~prov.model.ProvBundle` factory
+method used to recreate it (e.g. ``bundle.derivation(...)``)."""
 PREDICATE_MAP = {
     RDFS.label: pm.PROV["label"],
     URIRef(PROV["atLocation"].uri): PROV_LOCATION,
@@ -108,16 +131,28 @@ PREDICATE_MAP = {
     URIRef(PROV["hadGeneration"].uri): pm.PROV_ATTR_GENERATION,
     URIRef(PROV["hadActivity"].uri): pm.PROV_ATTR_ACTIVITY,
 }
+"""Default ``predicate_mapper`` for :meth:`ProvRDFSerializer.deserialize`/
+:meth:`~ProvRDFSerializer.decode_container`: maps PROV-O predicate URIRefs
+that don't already match a PROV formal-attribute QualifiedName to the
+QualifiedName of the formal attribute they represent."""
 
 
 def attr2rdf(attr: QualifiedName) -> URIRef:
+    """Return the PROV-O predicate URIRef for a PROV formal attribute.
+
+    Args:
+        attr: A formal attribute QualifiedName, e.g. ``PROV_ATTR_ENTITY``.
+
+    Returns:
+        The corresponding ``prov:*`` predicate URIRef (e.g.
+        ``prov:entity``), derived from
+        :data:`~prov.constants.PROV_ID_ATTRIBUTES_MAP`.
+    """
     return URIRef(PROV[PROV_ID_ATTRIBUTES_MAP[attr].split("prov:")[1]].uri)
 
 
 class ProvRDFSerializer(Serializer):
-    """
-    PROV-O serializer for :class:`~prov.model.ProvDocument`
-    """
+    """PROV-O serializer for :class:`~prov.model.ProvDocument`."""
 
     def serialize(
         self,
@@ -126,12 +161,22 @@ class ProvRDFSerializer(Serializer):
         PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
         **kwargs: Any,
     ) -> None:
-        """
-        Serializes a :class:`~prov.model.ProvDocument` instance to
-        `PROV-O <https://www.w3.org/TR/prov-o/>`_.
+        """Serialize ``self.document`` to `PROV-O <https://www.w3.org/TR/prov-o/>`_.
 
-        :param stream: Where to save the output.
-        :param rdf_format: The RDF format of the output, default to TRiG.
+        Args:
+            stream: Stream to write the output to. Text streams receive the
+                serialized text directly; other (binary) streams receive it
+                UTF-8-encoded.
+            rdf_format: The rdflib RDF format name for the output (e.g.
+                ``"trig"``, ``"xml"``, ``"turtle"``, ``"nquads"``).
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword,
+                used when building the relation predicates; defaults to
+                :data:`~prov.constants.PROV_N_MAP`.
+            **kwargs: Extra keyword arguments passed through to rdflib's
+                ``Graph.serialize()``.
+
+        Raises:
+            ProvRDFException: If ``self.document`` is ``None``.
         """
         if self.document is None:
             raise ProvRDFException("No document to serialize.")
@@ -162,12 +207,27 @@ class ProvRDFSerializer(Serializer):
         predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
         **kwargs: Any,
     ) -> pm.ProvDocument:
-        """
-        Deserialize from the `PROV-O <https://www.w3.org/TR/prov-o/>`_
-        representation to a :class:`~prov.model.ProvDocument` instance.
+        """Deserialize a `PROV-O <https://www.w3.org/TR/prov-o/>`_ graph
+        into a :class:`~prov.model.ProvDocument`.
 
-        :param stream: Input data.
-        :param rdf_format: The RDF format of the input data, default: TRiG.
+        Also sets ``self.document`` to the returned document as a side
+        effect.
+
+        Args:
+            stream: Input data, parsed by rdflib.
+            rdf_format: The rdflib RDF format name of the input data (e.g.
+                ``"trig"``, ``"xml"``, ``"turtle"``, ``"nquads"``).
+            relation_mapper: Maps PROV-O relation predicate URIRefs to
+                :class:`~prov.model.ProvBundle` factory method names;
+                defaults to :data:`RELATION_MAP`.
+            predicate_mapper: Maps PROV-O predicate URIRefs to formal
+                attribute QualifiedNames; defaults to :data:`PREDICATE_MAP`.
+            **kwargs: Extra keyword arguments passed through to rdflib's
+                ``Graph.parse()``.
+
+        Returns:
+            The deserialized :class:`~prov.model.ProvDocument` (also stored
+            in ``self.document``).
         """
         newargs = kwargs.copy()
         newargs["format"] = rdf_format
@@ -187,11 +247,34 @@ class ProvRDFSerializer(Serializer):
     def valid_identifier(
         self, value: pm.QualifiedNameCandidate | None
     ) -> pm.QualifiedName | None:
+        """Resolve a candidate value to a :class:`~prov.identifier.QualifiedName`.
+
+        Args:
+            value: Candidate qualified name, or ``None``.
+
+        Returns:
+            The resolved :class:`~prov.identifier.QualifiedName`, or ``None``
+            if ``value`` is ``None``/falsy or cannot be resolved against
+            ``self.document``'s namespaces.
+        """
         # valid_qualified_name returns None for falsy inputs, so passing None
         # through is safe despite its declared parameter type.
         return self.document.valid_qualified_name(value)  # type: ignore[union-attr, arg-type]
 
     def encode_rdf_representation(self, value: Any) -> RDFLiteral | URIRef:
+        """Encode a single attribute value to its RDF term representation.
+
+        Args:
+            value: Attribute value to encode: a ``URIRef`` (returned as-is),
+                a :class:`~prov.model.Literal`, a :class:`datetime.datetime`,
+                a :class:`~prov.identifier.QualifiedName`, another
+                :class:`~prov.identifier.Identifier`, a type listed in
+                :data:`LITERAL_XSDTYPE_MAP`, or another value passed straight
+                to ``rdflib.Literal``.
+
+        Returns:
+            The RDF term (``URIRef`` or ``rdflib.Literal``) for ``value``.
+        """
         if isinstance(value, URIRef):
             return value
         elif isinstance(value, pm.Literal):
@@ -208,6 +291,25 @@ class ProvRDFSerializer(Serializer):
             return RDFLiteral(value)
 
     def decode_rdf_representation(self, literal: Any, graph: Graph) -> Any:
+        """Decode a single RDF term back to its PROV attribute value representation.
+
+        If ``literal`` is a ``URIRef`` that cannot be resolved to a
+        QualifiedName in ``self.document``'s existing namespaces, a new
+        namespace is minted (via ``graph``'s namespace manager) and
+        registered on ``self.document`` as a side effect.
+
+        Args:
+            literal: RDF term to decode: an ``rdflib.Literal`` or a
+                ``URIRef``, or already a plain value to return unchanged.
+            graph: Graph ``literal`` came from, used to compute a QName/mint
+                a namespace for unresolved ``URIRef`` values.
+
+        Returns:
+            A :class:`datetime.datetime` for ``xsd:dateTime`` literals, a
+            :class:`~prov.model.Literal` for other typed/tagged literals, a
+            resolved (or newly minted) :class:`~prov.identifier.QualifiedName`
+            for ``URIRef`` values, or ``literal`` unchanged otherwise.
+        """
         if isinstance(literal, RDFLiteral):
             value = literal.value if literal.value is not None else literal
             datatype = literal.datatype
@@ -253,6 +355,17 @@ class ProvRDFSerializer(Serializer):
         document: pm.ProvDocument,
         PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
     ) -> ConjunctiveGraph:
+        """Encode a whole :class:`~prov.model.ProvDocument`, including its named bundles.
+
+        Args:
+            document: Document to encode.
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword;
+                defaults to :data:`~prov.constants.PROV_N_MAP`.
+
+        Returns:
+            A ``ConjunctiveGraph`` containing the document's own triples plus
+            one named subgraph per bundle in ``document.bundles``.
+        """
         container = self.encode_container(document)
         for item in document.bundles:
             #  encoding the sub-bundle
@@ -275,6 +388,32 @@ class ProvRDFSerializer(Serializer):
         container: ConjunctiveGraph | None = None,
         identifier: str | None = None,
     ) -> ConjunctiveGraph:
+        """Encode a single bundle's namespaces and records into an RDF graph.
+
+        Does not recurse into named bundles; see :meth:`encode_document` for
+        a whole document. Elements are encoded directly as PROV-O triples;
+        relations are encoded per the PROV-O qualification pattern (a
+        subject-predicate-object triple for the two main formal attributes,
+        plus a ``prov:qualified*`` blank/identified node carrying any
+        remaining formal and extra attributes), following the mappings from
+        PROV-N attribute names to PROV-O predicates defined by the PROV-O
+        specification.
+
+        Args:
+            bundle: Bundle (or document, treated as its top-level bundle) to
+                encode.
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword;
+                defaults to :data:`~prov.constants.PROV_N_MAP`.
+            container: Graph to add triples to. If ``None``, a new
+                ``ConjunctiveGraph`` is created (with ``identifier``, and
+                with the ``prov`` namespace pre-bound).
+            identifier: Identifier for the new graph, used only when
+                ``container`` is ``None``.
+
+        Returns:
+            The graph that was passed in as ``container``, or the newly
+            created one.
+        """
         if container is None:
             container = ConjunctiveGraph(identifier=identifier)
             nm = container.namespace_manager
@@ -525,6 +664,26 @@ class ProvRDFSerializer(Serializer):
         relation_mapper: dict[URIRef, str] = RELATION_MAP,
         predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
     ) -> None:
+        """Decode a whole RDF graph, including named subgraphs, into a document.
+
+        Mutates ``document`` in place: registers ``content``'s namespaces on
+        it, then decodes each subgraph (bnode-identified subgraphs as the
+        document's own records; IRI-identified subgraphs as named bundles
+        added via :meth:`~prov.model.ProvBundle.bundle`) via
+        :meth:`decode_container`. If ``content`` has no ``contexts()`` (i.e.
+        it is a plain ``Graph``, not conjunctive), it is decoded directly as
+        the document's own records.
+
+        Args:
+            content: RDF graph (typically a ``ConjunctiveGraph``, as produced
+                by :meth:`encode_document`) to decode.
+            document: Document to populate.
+            relation_mapper: Maps PROV-O relation predicate URIRefs to
+                :class:`~prov.model.ProvBundle` factory method names;
+                defaults to :data:`RELATION_MAP`.
+            predicate_mapper: Maps PROV-O predicate URIRefs to formal
+                attribute QualifiedNames; defaults to :data:`PREDICATE_MAP`.
+        """
         for prefix, url in content.namespaces():
             document.add_namespace(prefix, str(url))
         if hasattr(content, "contexts"):
@@ -566,6 +725,37 @@ class ProvRDFSerializer(Serializer):
         relation_mapper: dict[URIRef, str] = RELATION_MAP,
         predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
     ) -> None:
+        """Decode a single RDF (sub)graph's triples into records added to a bundle.
+
+        Reconstructs each subject's record type from its ``rdf:type``
+        triple(s), then walks every triple in the graph to fill in that
+        record's formal and non-formal attributes (mapping PROV-O relation
+        predicates back to :class:`~prov.model.ProvBundle` factory calls via
+        ``relation_mapper``, and other predicates back to formal attributes
+        via ``predicate_mapper`` and PROV-O's qualification pattern), adding
+        each reconstructed record to ``bundle`` via
+        :meth:`~prov.model.ProvBundle.new_record`. Mutates ``bundle`` (and,
+        for unresolvable subject IRIs, ``self.document``'s namespaces) in
+        place.
+
+        Args:
+            graph: The RDF (sub)graph to decode, e.g. one context of a
+                ``ConjunctiveGraph``.
+            bundle: Bundle (or document) to add the decoded records to.
+            relation_mapper: Maps PROV-O relation predicate URIRefs to
+                :class:`~prov.model.ProvBundle` factory method names;
+                defaults to :data:`RELATION_MAP`.
+            predicate_mapper: Maps PROV-O predicate URIRefs to formal
+                attribute QualifiedNames; defaults to :data:`PREDICATE_MAP`.
+
+        Raises:
+            ValueError: If a relation's object term cannot be decoded to a
+                usable attribute value.
+
+        Warns:
+            UserWarning: If, after decoding, some attributes could not be
+                matched to any formal attribute or converted.
+        """
         record_types = {}  # type: dict[str, pm.QualifiedName]
         PROV_CLS_MAP = {}  # type: dict[str, pm.QualifiedName]
         formal_attributes = {}  # type: dict[str, dict[pm.QualifiedName, pm.QualifiedNameCandidate | datetime.datetime | None]]
@@ -747,14 +937,28 @@ def walk(
 ) -> Generator[dict[Any, Any]]:
     """Generate all the full paths in a tree, as a dict.
 
-    :Example:
+    Args:
+        children: ``(name, iterable)`` pairs; each is one level of the tree,
+            enumerated in order. Each ``iterable`` must be an iterable of
+            values (not a callable) -- it is iterated directly.
+        level: Current recursion depth; only used as the dict key when
+            ``usename`` is ``False``.
+        path: Path accumulated so far; ``None`` (the default) starts a fresh
+            path at the top-level call.
+        usename: If ``True``, key each path dict by the level's ``name``;
+            if ``False``, key it by the level's integer depth instead.
 
-    >>> from prov.serializers.provrdf import walk
-    >>> iterables = [('a', lambda: [1, 2]), ('b', lambda: [3, 4])]
-    >>> [val['a'] for val in walk(iterables)]
-    [1, 1, 2, 2]
-    >>> [val['b'] for val in walk(iterables)]
-    [3, 4, 3, 4]
+    Yields:
+        One dict per full path through ``children``, mapping each level's
+        key to the value chosen at that level.
+
+    Example:
+        >>> from prov.serializers.provrdf import walk
+        >>> iterables = [('a', [1, 2]), ('b', [3, 4])]
+        >>> [val['a'] for val in walk(iterables)]
+        [1, 1, 2, 2]
+        >>> [val['b'] for val in walk(iterables)]
+        [3, 4, 3, 4]
     """
     # Entry point
     if path is None:
@@ -778,6 +982,20 @@ def walk(
 
 
 def literal_rdf_representation(literal: pm.Literal) -> RDFLiteral:
+    """Encode a :class:`~prov.model.Literal` to an ``rdflib.Literal``.
+
+    Args:
+        literal: Literal to encode.
+
+    Returns:
+        A language-tagged ``rdflib.Literal`` if ``literal`` has a language
+        tag, otherwise a datatype-tagged one (base64-encoding the value
+        first for ``xsd:base64Binary``).
+
+    Raises:
+        ValueError: If ``literal`` has neither a language tag nor a
+            datatype.
+    """
     if literal.langtag:
         #  a language tag can only go with prov:InternationalizedString
         return RDFLiteral(literal.value, lang=literal.langtag)

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -1,3 +1,5 @@
+"""PROV-XML serializer for ProvDocument."""
+
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
 import datetime
@@ -23,15 +25,22 @@ logger = logging.getLogger(__name__)
 # mapping.
 FULL_NAMES_MAP = dict(PROV_N_MAP)
 FULL_NAMES_MAP.update(ADDITIONAL_N_MAP)
+"""Maps every PROV record/subtype QualifiedName (including PROV-XML's
+top-level subtypes from :data:`~prov.constants.ADDITIONAL_N_MAP`) to its
+PROV-XML element name."""
 # Inverse mapping.
 FULL_PROV_RECORD_IDS_MAP = {
     FULL_NAMES_MAP[rec_type_id]: rec_type_id for rec_type_id in FULL_NAMES_MAP
 }
+"""Inverse of :data:`FULL_NAMES_MAP`: maps each PROV-XML element name back to
+its record/subtype QualifiedName."""
 
 XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 
 
 class ProvXMLException(prov.Error):
+    """Raised when a PROV-XML document cannot be serialized or parsed by this package."""
+
     pass
 
 
@@ -41,19 +50,25 @@ class ProvXMLSerializer(Serializer):
     def serialize(
         self, stream: io.IOBase, force_types: bool = False, **kwargs: Any
     ) -> None:
-        """
-        Serializes a :class:`~prov.model.ProvDocument` instance to `PROV-XML
-        <http://www.w3.org/TR/prov-xml/>`_.
+        """Serialize ``self.document`` to `PROV-XML <http://www.w3.org/TR/prov-xml/>`_.
 
-        :param stream: Where to save the output.
-        :type force_types: boolean, optional
-        :param force_types: Will force xsd:types to be written for most
-            attributes mainly PROV-"attributes", e.g. tags not in the
-            PROV namespace. Off by default meaning xsd:type attributes will
-            only be set for prov:type, prov:location, and prov:value as is
-            done in the official PROV-XML specification. Furthermore the
-            types will always be set if the Python type requires it. False
-            is a good default and it should rarely require changing.
+        Args:
+            stream: Stream to write the output to. Text streams receive the
+                XML text directly; other (binary) streams are written to via
+                ``lxml``'s own UTF-8 encoding.
+            force_types: If ``True``, force ``xsi:type`` to be written for
+                most attributes, including non-PROV-namespaced ones. Off by
+                default, meaning ``xsi:type`` attributes are only set for
+                ``prov:type``, ``prov:location``, and ``prov:value`` as done
+                in the official PROV-XML specification. Regardless of this
+                flag, the type is always set if the Python type of the value
+                requires it (e.g. ``bool``, ``float``, ``datetime``). A good
+                default; it should rarely require changing.
+            **kwargs: Unused; accepted for interface compatibility with
+                :meth:`~prov.serializers.Serializer.serialize`.
+
+        Raises:
+            ProvXMLException: If ``self.document`` is ``None``.
         """
         if self.document is None:
             raise ProvXMLException("No document to serialize.")
@@ -82,19 +97,23 @@ class ProvXMLSerializer(Serializer):
         element: etree._Element | None = None,
         force_types: bool = False,
     ) -> etree._Element:
-        """
-        Serializes a bundle or document to PROV XML.
+        """Serialize a bundle or document to a PROV-XML etree element.
 
-        :param bundle: The bundle or document.
-        :param element: The XML element to write to. Will be created if None.
-        :type force_types: boolean, optional
-        :param force_types: Will force xsd:types to be written for most
-            attributes mainly PROV-"attributes", e.g. tags not in the
-            PROV namespace. Off by default meaning xsd:type attributes will
-            only be set for prov:type, prov:location, and prov:value as is
-            done in the official PROV-XML specification. Furthermore the
-            types will always be set if the Python type requires it. False
-            is a good default and it should rarely require changing.
+        Namespaces are collected from ``self.document`` (the top-level
+        document being serialized) plus ``bundle``'s own namespaces and the
+        package's default namespaces.
+
+        Args:
+            bundle: The bundle or document to serialize.
+            element: Parent XML element to attach a ``<prov:bundleContent>``
+                child to. If ``None``, a new top-level ``<prov:document>``
+                element is created and returned instead.
+            force_types: See :meth:`serialize`.
+
+        Returns:
+            The XML element created for ``bundle``: a new
+            ``<prov:document>`` element if ``element`` was ``None``, or the
+            ``<prov:bundleContent>`` child added to ``element`` otherwise.
         """
         # Build the namespace map for lxml and attach it to the root XML
         # element.
@@ -229,11 +248,19 @@ class ProvXMLSerializer(Serializer):
         return xml_bundle_root
 
     def deserialize(self, stream: io.IOBase, **kwargs: Any) -> prov.model.ProvDocument:
-        """
-        Deserialize from `PROV-XML <http://www.w3.org/TR/prov-xml/>`_
-        representation to a :class:`~prov.model.ProvDocument` instance.
+        """Deserialize a `PROV-XML <http://www.w3.org/TR/prov-xml/>`_
+        stream into a :class:`~prov.model.ProvDocument`.
 
-        :param stream: Input data.
+        XML comments in the input are discarded before parsing.
+
+        Args:
+            stream: Input data; text streams are UTF-8-encoded before
+                parsing.
+            **kwargs: Unused; accepted for interface compatibility with
+                :meth:`~prov.serializers.Serializer.deserialize`.
+
+        Returns:
+            The deserialized :class:`~prov.model.ProvDocument`.
         """
         if isinstance(stream, io.TextIOBase):
             with io.BytesIO() as buf:
@@ -257,12 +284,28 @@ class ProvXMLSerializer(Serializer):
         xml_doc: etree._Element,
         bundle: prov.model.ProvDocument | prov.model.ProvBundle,
     ) -> prov.model.ProvDocument | prov.model.ProvBundle:
-        """
-        Deserialize an etree element containing a PROV document or a bundle
-        and write it to the provided internal object.
+        """Deserialize an etree element containing a PROV document or bundle.
 
-        :param xml_doc: An etree element containing the information to read.
-        :param bundle: The bundle object to write to.
+        Mutates ``bundle`` in place, adding one record per child element of
+        ``xml_doc``; ``<prov:bundleContent>`` children are recursively
+        deserialized into new named bundles added to ``bundle`` (which must
+        then be a :class:`~prov.model.ProvDocument`). A ``<prov:other>``
+        child (non-PROV information) is skipped with a warning.
+
+        Args:
+            xml_doc: The etree element (document or bundle content) to read.
+            bundle: The document or bundle object to populate.
+
+        Returns:
+            ``bundle``, mutated in place.
+
+        Raises:
+            ProvXMLException: If a child element is not in the PROV
+                namespace.
+
+        Warns:
+            UserWarning: For each ``<prov:other>`` child, which is otherwise
+                ignored.
         """
 
         for element in xml_doc:
@@ -323,13 +366,22 @@ class ProvXMLSerializer(Serializer):
         rec_type: prov.identifier.QualifiedName,
         attributes: list[tuple[prov.identifier.QualifiedName, Any]],
     ) -> str:
-        """
-        Helper function trying to derive the record label taking care of
-        subtypes and what not. It will also remove the type declaration for
-        the attributes if it was used to specialize the type.
+        """Derive the PROV-XML element name for a record, honouring subtypes.
 
-        :param rec_type: The type of records.
-        :param attributes: The attributes of the record.
+        If a ``prov:type`` attribute's value names a subtype of ``rec_type``
+        (per :data:`~prov.constants.PROV_BASE_CLS`), that subtype's element
+        name is used instead of ``rec_type``'s, and the matching
+        ``(PROV_TYPE, value)`` entry is removed from ``attributes`` in place
+        (it is then encoded as the element name rather than duplicated as a
+        ``prov:type`` attribute).
+
+        Args:
+            rec_type: The record's (base) type.
+            attributes: The record's attributes; mutated in place if a
+                subtype is found.
+
+        Returns:
+            The PROV-XML element name to use for the record.
         """
         rec_label = FULL_NAMES_MAP[rec_type]
 
@@ -348,10 +400,26 @@ class ProvXMLSerializer(Serializer):
 def _extract_attributes(
     element: etree._Element,
 ) -> list[tuple[prov.identifier.QualifiedName, Any]]:
-    """
-    Extract the PROV attributes from an etree element.
+    """Extract a record's attributes from its PROV-XML etree element.
 
-    :param element: The lxml.etree.Element instance.
+    Each child of ``element`` becomes one ``(QualifiedName, value)`` pair:
+    a ``prov:ref`` attribute yields a :class:`~prov.identifier.QualifiedName`
+    value, an ``xsi:type`` attribute yields a typed
+    :class:`~prov.model.Literal` (or, for ``xsd:QName``, a
+    :class:`~prov.identifier.QualifiedName`), an ``xml:lang`` attribute
+    yields a language-tagged :class:`~prov.model.Literal`, and a child with
+    no attributes yields its plain text content.
+
+    Args:
+        element: The PROV-XML record element whose children are its
+            attributes.
+
+    Returns:
+        The extracted ``(QualifiedName, value)`` pairs, in document order.
+
+    Warns:
+        UserWarning: For any child attribute that is none of ``prov:ref``,
+            ``xsi:type``, or ``xml:lang``; such attributes are ignored.
     """
     attributes = []  # type: list[tuple[prov.identifier.QualifiedName, Any]]
     for subel in element:
@@ -393,6 +461,25 @@ def _extract_attributes(
 def xml_qname_to_QualifiedName(
     element: etree._Element, qname_str: str
 ) -> prov.identifier.QualifiedName:
+    """Resolve an XML QName-like string to a :class:`~prov.identifier.QualifiedName`.
+
+    Args:
+        element: The etree element ``qname_str`` was read from; its
+            ``nsmap`` (in scope at that point in the document) is used to
+            resolve the prefix.
+        qname_str: A ``"prefix:localpart"`` string, or a bare local name to
+            be resolved against the default namespace.
+
+    Returns:
+        The resolved qualified name. The XSD and PROV namespaces are mapped
+        to this package's canonical :data:`~prov.constants.XSD`/
+        :data:`~prov.constants.PROV` namespace objects; any other namespace
+        URI becomes a new :class:`~prov.identifier.Namespace`.
+
+    Raises:
+        ProvXMLException: If ``qname_str`` has no recognized prefix and
+            ``element`` has no default namespace in scope.
+    """
     if ":" in qname_str:
         prefix, localpart = qname_str.split(":", 1)
         if prefix in element.nsmap:


### PR DESCRIPTION
Phase 3, Task 7 (spec step 23, first half). Accuracy-first docstring pass over every module except `model.py` (Task 8), then Google/napoleon style. Docstrings and comments only — zero executable-code changes (mypy strict + full suite identical to baseline).

Notable factual corrections found while verifying against the now-strict annotations:
- `prov.read()`: documented that it raises `TypeError` when no serializer matches (never returns None) and the format-detection order.
- `provrdf.walk()`: fixed a broken doctest — the example passed lambdas the function never calls, so it raised `TypeError`; corrected to plain lists (verified with `python -m doctest`).
- Documented previously-silent side effects: `prov_to_graph`/`graph_to_prov` skipping malformed relations; `prov_to_dot` silently resetting an invalid `direction`; JSON/XML/RDF decoders mutating their argument in place; RDF decoder minting namespaces on `self.document`.
- `constants.py` had no docstrings; added module + lookup-table docs.
- CLI `main()` exit-code behaviour documented accurately.

Build: 0 warnings; ruff/mypy/pytest all green.