### PR TITLE
test: pytest-native shared matrix + JSON migration (Phase 3, step 24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,23 +142,46 @@ extras in `pyproject.toml`); JSON and PROV-N have no extra dependencies.
 
 ### Tests (`src/prov/tests/`)
 
-Test code is plain `unittest` (`TestCase` classes/`assert*` methods, `expectedFailure`, etc.),
-not pytest-specific; the runner is `pytest`, which collects and runs unittest-style classes
-natively (`expectedFailure` surfaces as `xfailed`). Shared test scaffolding lives in a few
-base-class modules rather than being duplicated per format:
+The suite is **mid-migration** from a plain-`unittest` multiple-inheritance design to a
+pytest-native shared matrix (Phase 3 test-suite redesign — authority:
+`docs/superpowers/specs/2026-07-06-test-suite-redesign.md`). The runner is `pytest`, which
+collects both styles natively (`expectedFailure` surfaces as `xfailed`). **JSON and the `model`
+target have been migrated; XML, RDF, and dot still ride the legacy scaffolding.** Expect the two
+styles to coexist until that migration completes.
 
-- `examples.py` — canonical example PROV documents (built programmatically) reused across
-  serializer/model tests.
-- `utility.py` — `RoundTripTestCase` base: serializes a document in a format and deserializes
-  it back, asserting equivalence. Format-specific test files (`test_json.py`, `test_xml.py`,
-  `test_rdf.py`) subclass this together with the shared mixins below.
-- `attributes.py`, `statements.py`, `qnames.py` — shared `TestAttributesBase` /
-  `TestStatementsBase` / `TestQualifiedNamesBase` mixins exercising attribute/statement/qname
-  behavior identically across formats.
+**Pytest-native shared matrix (current target):**
+
+- `conftest.py` — the shared scaffolding. Defines `ROUNDTRIP_FORMATS` (currently `("json",)`;
+  xml/rdf join later) and `SHARED_TARGETS = ("model", *ROUNDTRIP_FORMATS)`. The `fmt` fixture is
+  parametrized over `SHARED_TARGETS`, so every shared test runs once per serialization format
+  **and** once under a non-serializing `model` target (which forces `get_provn()` + a
+  self-equality check instead of a round trip). The `roundtrip` fixture returns a `_check(doc)`
+  callable that tests call as `roundtrip(doc)`. A `pytest_assertrepr_compare` hook renders the
+  record-level symmetric difference when two `ProvDocument`s compare unequal under `assert`, so
+  round-trip failures show *which record* differs.
+- `test_statements.py`, `test_attributes.py`, `test_qnames.py`, `test_examples.py` — the shared
+  body as plain module-level functions taking the `roundtrip` fixture (one node per case × per
+  target in `SHARED_TARGETS`). `test_attributes.py` parametrizes the single-type-attribute case
+  over `ATTRIBUTE_VALUES`.
+- `attribute_values.py` — the importable `ATTRIBUTE_VALUES` datatype corpus (order is
+  significant: later RDF datatype-fidelity xfails key off individual indices), shared by the new
+  `test_attributes.py` and the legacy `attributes.py` mixin.
+- `examples.py` — canonical example PROV documents (built programmatically), consumed by both the
+  new `test_examples.py` and the legacy mixins.
 - `json/`, `xml/`, `rdf/`, `unification/` — fixture data directories consumed by the
   corresponding test modules (e.g. `TestLoadingProvToolboxJSON` in `test_model.py` round-trips
   every file under `tests/json/`).
 
-When adding a new record type, attribute, or serializer behavior, the common pattern is to add
-it once to `examples.py`/the shared mixins so all format serializers are exercised against it,
-rather than writing per-format tests from scratch.
+**Legacy-during-migration scaffolding (still live, retired in a later step):**
+
+- `utility.py` — `RoundTripTestCase` base (serialize → deserialize → `assertEqual`, keyed off a
+  `FORMAT` class attribute). Still subclassed by `test_xml.py`/`test_rdf.py`/`test_dot.py`.
+- `attributes.py`, `statements.py`, `qnames.py` — the `TestAttributesBase` / `TestStatementsBase`
+  / `TestQualifiedNamesBase` mixins, and `AllTestsBase`/`TestExamplesBase` in `test_model.py`,
+  composed into the xml/rdf/dot round-trip suites. These duplicate the coverage now also provided
+  by the new pytest-native modules for the model/json targets; the duplication is expected and
+  intentional until xml/rdf/dot migrate.
+
+When adding a new shared record type, attribute, or serializer behavior, add it to the
+pytest-native shared modules (and, while xml/rdf/dot remain on the mixins, to the corresponding
+mixin) so every target is exercised, rather than writing per-format tests from scratch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ combine-as-imports = true  # keep multi-name `X as X` re-export blocks compact
 "src/prov/serializers/provxml.py" = ["F403", "F405"]
 "src/prov/tests/attributes.py" = ["F403", "F405"]
 "src/prov/tests/statements.py" = ["F403", "F405"]
+"src/prov/tests/test_statements.py" = ["F403", "F405"]
 "src/prov/tests/test_extras.py" = ["F403", "F405"]
 
 [tool.pytest.ini_options]

--- a/src/prov/tests/attribute_values.py
+++ b/src/prov/tests/attribute_values.py
@@ -1,0 +1,67 @@
+"""Shared attribute-value corpus for the attribute round-trip tests.
+
+`ATTRIBUTE_VALUES` is the canonical list of datatypes exercised by
+``test_attributes.py`` (pytest-native) and by the legacy
+``TestAttributesBase`` mixin (still consumed by the not-yet-migrated
+xml/rdf/dot modules). Keep the entries and their order stable: the RDF
+datatype-fidelity xfails introduced in a later migration step key off the
+index of individual values (e.g. index 8 is the ``xsd:decimal`` case).
+"""
+
+import datetime
+
+from prov.identifier import Identifier, Namespace
+from prov.model import (
+    XSD_ANYURI,
+    XSD_BYTE,
+    XSD_DATETIME,
+    XSD_DECIMAL,
+    XSD_DOUBLE,
+    XSD_FLOAT,
+    XSD_INT,
+    XSD_INTEGER,
+    XSD_LONG,
+    XSD_NONNEGATIVEINTEGER,
+    XSD_NONPOSITIVEINTEGER,
+    XSD_POSITIVEINTEGER,
+    XSD_SHORT,
+    XSD_UNSIGNEDBYTE,
+    XSD_UNSIGNEDINT,
+    XSD_UNSIGNEDLONG,
+    XSD_UNSIGNEDSHORT,
+    Literal,
+)
+
+EX_NS = Namespace("ex", "http://example.org/")
+EX_OTHER_NS = Namespace("other", "http://example.org/")
+
+ATTRIBUTE_VALUES = [
+    "un lieu",
+    Literal("un lieu", langtag="fr"),
+    Literal("a place", langtag="en"),
+    Literal(1, XSD_INT),
+    Literal(1, XSD_LONG),
+    Literal(1, XSD_SHORT),
+    Literal(2.0, XSD_DOUBLE),
+    Literal(1.0, XSD_FLOAT),
+    Literal(10, XSD_DECIMAL),
+    True,
+    False,
+    Literal(10, XSD_BYTE),
+    Literal(10, XSD_UNSIGNEDINT),
+    Literal(10, XSD_UNSIGNEDLONG),
+    Literal(10, XSD_INTEGER),
+    Literal(10, XSD_UNSIGNEDSHORT),
+    Literal(10, XSD_NONNEGATIVEINTEGER),
+    Literal(-10, XSD_NONPOSITIVEINTEGER),
+    Literal(10, XSD_POSITIVEINTEGER),
+    Literal(10, XSD_UNSIGNEDBYTE),
+    Identifier("http://example.org"),
+    Literal("http://example.org", XSD_ANYURI),
+    EX_NS["abc"],
+    EX_OTHER_NS["abcd"],
+    Namespace("ex", "http://example4.org/")["zabc"],
+    Namespace("other", "http://example4.org/")["zabcd"],
+    datetime.datetime.now(),
+    Literal(datetime.datetime.now().isoformat(), XSD_DATETIME),
+]

--- a/src/prov/tests/attributes.py
+++ b/src/prov/tests/attributes.py
@@ -1,47 +1,24 @@
 from typing import Any, ClassVar
 
 from prov.model import *
-
-EX_NS = Namespace("ex", "http://example.org/")
-EX_OTHER_NS = Namespace("other", "http://example.org/")
+from prov.tests.attribute_values import (  # noqa: F401
+    ATTRIBUTE_VALUES,
+    EX_NS,
+    EX_OTHER_NS,
+)
 
 
 class TestAttributesBase:
     """This is the base class for testing support for various datatypes.
     It is not runnable and needs to be included in a subclass of
     RoundTripTestCase.
+
+    Legacy-during-migration: this mixin is still consumed by the not-yet-migrated
+    xml/rdf/dot round-trip modules. The pytest-native replacement lives in
+    ``test_attributes.py``; both share ``ATTRIBUTE_VALUES``.
     """
 
-    attribute_values: ClassVar[list[Any]] = [
-        "un lieu",
-        Literal("un lieu", langtag="fr"),
-        Literal("a place", langtag="en"),
-        Literal(1, XSD_INT),
-        Literal(1, XSD_LONG),
-        Literal(1, XSD_SHORT),
-        Literal(2.0, XSD_DOUBLE),
-        Literal(1.0, XSD_FLOAT),
-        Literal(10, XSD_DECIMAL),
-        True,
-        False,
-        Literal(10, XSD_BYTE),
-        Literal(10, XSD_UNSIGNEDINT),
-        Literal(10, XSD_UNSIGNEDLONG),
-        Literal(10, XSD_INTEGER),
-        Literal(10, XSD_UNSIGNEDSHORT),
-        Literal(10, XSD_NONNEGATIVEINTEGER),
-        Literal(-10, XSD_NONPOSITIVEINTEGER),
-        Literal(10, XSD_POSITIVEINTEGER),
-        Literal(10, XSD_UNSIGNEDBYTE),
-        Identifier("http://example.org"),
-        Literal("http://example.org", XSD_ANYURI),
-        EX_NS["abc"],
-        EX_OTHER_NS["abcd"],
-        Namespace("ex", "http://example4.org/")["zabc"],
-        Namespace("other", "http://example4.org/")["zabcd"],
-        datetime.datetime.now(),
-        Literal(datetime.datetime.now().isoformat(), XSD_DATETIME),
-    ]
+    attribute_values: ClassVar[list[Any]] = ATTRIBUTE_VALUES
 
     def new_document(self):
         return ProvDocument()

--- a/src/prov/tests/conftest.py
+++ b/src/prov/tests/conftest.py
@@ -69,14 +69,32 @@ def roundtrip(fmt):
     return _check
 
 
+def _document_record_strings(doc: ProvDocument) -> set[str]:
+    """All record strings in ``doc``, including those inside named sub-bundles.
+
+    ``ProvBundle.get_records()`` returns only the bundle's own records, but
+    ``ProvDocument.__eq__`` also compares nested bundles, so a diff built from
+    the top-level records alone is blind to bundle contents (it would render an
+    empty diff for a document whose only records live in a sub-bundle). Fold
+    each sub-bundle's records in, prefixed with the bundle identifier so records
+    from different bundles cannot collide as equal strings. Documents nest
+    bundles only one level, so no recursion is needed.
+    """
+    records = {str(r) for r in doc.get_records()}
+    if doc.has_bundles():
+        for bundle in doc.bundles:
+            records.update(f"{bundle.identifier} | {r}" for r in bundle.get_records())
+    return records
+
+
 def pytest_assertrepr_compare(config, op, left, right):
     """Readable diff for ``assert doc == reloaded`` on two ProvDocuments."""
     if op != "==" or not (
         isinstance(left, ProvDocument) and isinstance(right, ProvDocument)
     ):
         return None
-    left_recs = {str(r) for r in left.get_records()}
-    right_recs = {str(r) for r in right.get_records()}
+    left_recs = _document_record_strings(left)
+    right_recs = _document_record_strings(right)
     only_left = sorted(left_recs - right_recs)
     only_right = sorted(right_recs - left_recs)
     return [

--- a/src/prov/tests/conftest.py
+++ b/src/prov/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Pytest-native shared scaffolding for the round-trip test matrix.
+
+This replaces the ``RoundTripTestCase``/``do_tests`` inheritance machinery for
+the migrated shared modules (``test_statements.py``, ``test_attributes.py``,
+``test_qnames.py``, ``test_examples.py``). Each shared test builds a document
+and hands it to the ``roundtrip`` fixture, which is parametrized over
+``SHARED_TARGETS`` so every case runs once per serialization format AND once
+under the non-serializing ``model`` target.
+
+The legacy ``utility.py``/``statements.py``/``attributes.py``/``qnames.py``
+mixins remain in place for the not-yet-migrated xml/rdf/dot modules; they are
+retired in a later migration step.
+"""
+
+import io
+
+import pytest
+
+from prov.model import ProvDocument
+
+# Formats that support a full serialize -> deserialize -> compare round trip.
+# xml and rdf join in the next migration step.
+ROUNDTRIP_FORMATS = ("json",)
+# The full target axis: the round-trip formats PLUS a "model" target that
+# constructs the document, exercises PROV-N generation, and checks the
+# self-equality invariant WITHOUT serialization. The model axis preserves the
+# coverage the old RoundTripModelTest provided.
+SHARED_TARGETS = ("model", *ROUNDTRIP_FORMATS)
+
+
+def roundtrip_document(doc: ProvDocument, fmt: str) -> ProvDocument:
+    """Serialize ``doc`` to ``fmt`` and read it back."""
+    with io.BytesIO() as stream:
+        doc.serialize(destination=stream, format=fmt, indent=4)
+        stream.seek(0)
+        return ProvDocument.deserialize(source=stream, format=fmt)
+
+
+@pytest.fixture(params=SHARED_TARGETS)
+def fmt(request):
+    """The target under test — "model" or a serialization format.
+
+    Parametrizes every shared statement/attribute/qname/example case, so each
+    runs once per round-trip format AND once under the non-serializing model
+    target.
+    """
+    return request.param
+
+
+@pytest.fixture
+def roundtrip(fmt):
+    """Return a ``_check(doc)`` callable that asserts ``doc`` survives its target.
+
+    For a serialization format: serialize -> deserialize -> ``doc == reloaded``.
+    For the "model" target: no serialization — force PROV-N generation (proving
+    model support for the statement) and assert self-equality. On inequality the
+    ``pytest_assertrepr_compare`` hook below renders which records differ.
+    """
+
+    def _check(doc: ProvDocument) -> ProvDocument:
+        if fmt == "model":
+            doc.get_provn()  # exercises PROV-N generation
+            assert doc == doc  # self-equality invariant, no serialization
+            return doc
+        reloaded = roundtrip_document(doc, fmt)
+        assert doc == reloaded  # readable diff via the hook below
+        return reloaded
+
+    return _check
+
+
+def pytest_assertrepr_compare(config, op, left, right):
+    """Readable diff for ``assert doc == reloaded`` on two ProvDocuments."""
+    if op != "==" or not (
+        isinstance(left, ProvDocument) and isinstance(right, ProvDocument)
+    ):
+        return None
+    left_recs = {str(r) for r in left.get_records()}
+    right_recs = {str(r) for r in right.get_records()}
+    only_left = sorted(left_recs - right_recs)
+    only_right = sorted(right_recs - left_recs)
+    return [
+        "ProvDocument == ProvDocument failed:",
+        f"  records: {len(left_recs)} left, {len(right_recs)} right",
+        f"  in left only  ({len(only_left)}):",
+        *(f"    - {r}" for r in only_left),
+        f"  in right only ({len(only_right)}):",
+        *(f"    + {r}" for r in only_right),
+    ]

--- a/src/prov/tests/test_attributes.py
+++ b/src/prov/tests/test_attributes.py
@@ -1,0 +1,38 @@
+"""Pytest-native shared attribute round-trip tests.
+
+Migrated from the ``TestAttributesBase`` mixin (``attributes.py``): the 28
+single-type-attribute cases collapse into one parametrized function (node ids
+``attr-0``..``attr-27``), plus the multi-attribute and multi-value-attribute
+cases. Each runs once per target in ``SHARED_TARGETS``. The legacy mixin
+remains for the not-yet-migrated xml/rdf/dot modules; both share
+``ATTRIBUTE_VALUES``.
+"""
+
+import pytest
+
+from prov.model import ProvDocument
+from prov.tests.attribute_values import ATTRIBUTE_VALUES, EX_NS
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(v, id=f"attr-{i}") for i, v in enumerate(ATTRIBUTE_VALUES)],
+)
+def test_entity_with_one_type_attribute(roundtrip, value):
+    document = ProvDocument()
+    document.entity(EX_NS["et"], {"prov:type": value})
+    roundtrip(document)
+
+
+def test_entity_with_multiple_attribute(roundtrip):
+    document = ProvDocument()
+    attributes = [(EX_NS[f"v_{i}"], value) for i, value in enumerate(ATTRIBUTE_VALUES)]
+    document.entity(EX_NS["emov"], attributes)
+    roundtrip(document)
+
+
+def test_entity_with_multiple_value_attribute(roundtrip):
+    document = ProvDocument()
+    attributes = [("prov:value", value) for value in ATTRIBUTE_VALUES]
+    document.entity(EX_NS["emv"], attributes)
+    roundtrip(document)

--- a/src/prov/tests/test_examples.py
+++ b/src/prov/tests/test_examples.py
@@ -1,0 +1,16 @@
+"""Pytest-native shared example round-trip test.
+
+Migrated from the ``TestExamplesBase`` mixin (in ``test_model.py``): a single
+function loops over the canonical ``examples.tests`` documents and round-trips
+each, run once per target in ``SHARED_TARGETS``. It is kept as one looping node
+per target (not expanded per example) to preserve the collected-count parity
+baseline; per-example isolation is a deferred improvement. The legacy mixin
+remains for the not-yet-migrated xml/rdf/dot modules.
+"""
+
+from prov.tests import examples
+
+
+def test_all_examples(roundtrip):
+    for _name, build in examples.tests:
+        roundtrip(build())

--- a/src/prov/tests/test_json.py
+++ b/src/prov/tests/test_json.py
@@ -1,18 +1,20 @@
-import logging
-import unittest
+"""JSON serializer-specific tests.
+
+The shared statement/attribute/qname/example round-trips run through the
+pytest-native ``fmt`` matrix (see ``conftest.py`` and the ``test_statements``/
+``test_attributes``/``test_qnames``/``test_examples`` modules); this file keeps
+only the genuinely JSON-specific cases.
+"""
+
+import pytest
 
 from prov.model import ProvDocument
 from prov.serializers.provjson import ProvJSONEncoder, ProvJSONException
-from prov.tests.test_model import AllTestsBase
-from prov.tests.utility import RoundTripTestCase
-
-logger = logging.getLogger(__name__)
 
 
-class TestJSONSerializer(unittest.TestCase):
-    def test_decoding_unicode_value(self):
-        unicode_char = "\u2019"
-        json_content = f"""{{
+def test_decoding_unicode_value():
+    unicode_char = "\u2019"
+    json_content = f"""{{
     "prefix": {{
         "ex": "http://www.example.org"
     }},
@@ -23,15 +25,16 @@ class TestJSONSerializer(unittest.TestCase):
     }}
 }}"""
 
-        prov_doc = ProvDocument.deserialize(content=json_content, format="json")
-        e1 = prov_doc.get_record("ex:unicode_char")[0]
-        self.assertIn(unicode_char, e1.get_attribute("prov:label"))
+    prov_doc = ProvDocument.deserialize(content=json_content, format="json")
+    e1 = prov_doc.get_record("ex:unicode_char")[0]
+    assert unicode_char in e1.get_attribute("prov:label")
 
-    def test_multi_valued_prov_attribute_raises(self):
-        # PROV attributes (e.g. usage's prov:entity) must be single-valued;
-        # a JSON list of more than one value is rejected (docs/test-gap-
-        # checklist.md, T13 item under serializers/provjson.py).
-        json_content = """{
+
+def test_multi_valued_prov_attribute_raises():
+    # PROV attributes (e.g. usage's prov:entity) must be single-valued;
+    # a JSON list of more than one value is rejected (docs/test-gap-
+    # checklist.md, T13 item under serializers/provjson.py).
+    json_content = """{
     "prefix": {"ex": "http://example.org/"},
     "used": {
         "ex:u1": {
@@ -40,51 +43,46 @@ class TestJSONSerializer(unittest.TestCase):
         }
     }
 }"""
-        self.assertRaises(
-            ProvJSONException,
-            ProvDocument.deserialize,
-            content=json_content,
-            format="json",
-        )
-
-    def test_encoder_default_fallback_for_non_document(self):
-        # Pins the isolated method's contract: for anything other than a
-        # ProvDocument, default() falls back to the base encoder. In the
-        # real serialize() path json.dump() only ever hands default() the
-        # top-level ProvDocument (everything nested is already plain
-        # dicts/strings), so this branch is not reachable end-to-end today.
-        encoder = ProvJSONEncoder()
-        self.assertEqual(encoder.default("plain string"), '"plain string"')
-
-    def test_attribute_touched_but_never_set_is_omitted_from_json(self):
-        # Accessing .label/.value auto-vivifies an empty set entry in the
-        # record's attribute dict (a plain defaultdict); the encoder must
-        # skip empty attribute value sets rather than emitting them.
-        doc = ProvDocument()
-        doc.add_namespace("ex", "http://example.org/")
-        e1 = doc.entity("ex:e1")
-        _ = e1.label  # touches (and auto-vivifies) the "prov:label" entry
-
-        json_str = doc.serialize(format="json")
-
-        self.assertNotIn("prov:label", json_str)
-
-    def test_third_record_with_same_identifier_appends_to_existing_list(self):
-        # The first duplicate-identifier record turns the container entry
-        # into a singleton list; a third (or later) record with the same
-        # identifier must append directly to that list without re-wrapping
-        # it (docs/test-gap-checklist.md, T13 item under provjson.py).
-        doc = ProvDocument()
-        doc.add_namespace("ex", "http://example.org/")
-        doc.activity("ex:a1", other_attributes={"ex:tag": "one"})
-        doc.activity("ex:a1", other_attributes={"ex:tag": "two"})
-        doc.activity("ex:a1", other_attributes={"ex:tag": "three"})
-
-        json_str = doc.serialize(format="json")
-        reloaded = ProvDocument.deserialize(content=json_str, format="json")
-
-        self.assertEqual(len(reloaded.get_record("ex:a1")), 3)
+    with pytest.raises(ProvJSONException):
+        ProvDocument.deserialize(content=json_content, format="json")
 
 
-class RoundTripJSONTests(RoundTripTestCase, AllTestsBase):
-    FORMAT = "json"
+def test_encoder_default_fallback_for_non_document():
+    # Pins the isolated method's contract: for anything other than a
+    # ProvDocument, default() falls back to the base encoder. In the
+    # real serialize() path json.dump() only ever hands default() the
+    # top-level ProvDocument (everything nested is already plain
+    # dicts/strings), so this branch is not reachable end-to-end today.
+    encoder = ProvJSONEncoder()
+    assert encoder.default("plain string") == '"plain string"'
+
+
+def test_attribute_touched_but_never_set_is_omitted_from_json():
+    # Accessing .label/.value auto-vivifies an empty set entry in the
+    # record's attribute dict (a plain defaultdict); the encoder must
+    # skip empty attribute value sets rather than emitting them.
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    e1 = doc.entity("ex:e1")
+    _ = e1.label  # touches (and auto-vivifies) the "prov:label" entry
+
+    json_str = doc.serialize(format="json")
+
+    assert "prov:label" not in json_str
+
+
+def test_third_record_with_same_identifier_appends_to_existing_list():
+    # The first duplicate-identifier record turns the container entry
+    # into a singleton list; a third (or later) record with the same
+    # identifier must append directly to that list without re-wrapping
+    # it (docs/test-gap-checklist.md, T13 item under provjson.py).
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.activity("ex:a1", other_attributes={"ex:tag": "one"})
+    doc.activity("ex:a1", other_attributes={"ex:tag": "two"})
+    doc.activity("ex:a1", other_attributes={"ex:tag": "three"})
+
+    json_str = doc.serialize(format="json")
+    reloaded = ProvDocument.deserialize(content=json_str, format="json")
+
+    assert len(reloaded.get_record("ex:a1")) == 3

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -29,7 +29,6 @@ from prov.tests import examples
 from prov.tests.attributes import TestAttributesBase
 from prov.tests.qnames import TestQualifiedNamesBase
 from prov.tests.statements import TestStatementsBase
-from prov.tests.utility import RoundTripTestCase
 
 logger = logging.getLogger(__name__)
 
@@ -753,21 +752,16 @@ class TestPlot(unittest.TestCase):
 class AllTestsBase(
     TestExamplesBase, TestStatementsBase, TestAttributesBase, TestQualifiedNamesBase
 ):
-    """This is a test to include all available tests."""
+    """This is a test to include all available tests.
+
+    Legacy-during-migration: still composed into the xml/rdf/dot round-trip
+    suites via ``RoundTripTestCase``. The "model" target's coverage (formerly
+    ``RoundTripModelTest``) now runs through the pytest-native ``fmt`` matrix in
+    the ``test_statements``/``test_attributes``/``test_qnames``/``test_examples``
+    modules. Retired once xml/rdf/dot migrate.
+    """
 
     pass
-
-
-class RoundTripModelTest(RoundTripTestCase, AllTestsBase):
-    def assertRoundTripEquivalence(self, prov_doc, msg=None):
-        """Exercises prov.model without the actual serialization and PROV-N
-        generation.
-        """
-        provn_content = prov_doc.get_provn()
-        # Checking for self-equality
-        self.assertEqual(
-            prov_doc, prov_doc, "The document is not self-equal:\n" + provn_content
-        )
 
 
 if __name__ == "__main__":

--- a/src/prov/tests/test_qnames.py
+++ b/src/prov/tests/test_qnames.py
@@ -1,0 +1,65 @@
+"""Pytest-native shared qualified-name / namespace round-trip tests.
+
+Migrated from the ``TestQualifiedNamesBase`` mixin (``qnames.py``): each test
+method becomes a module-level function taking the ``roundtrip`` fixture, run
+once per target in ``SHARED_TARGETS``. The legacy mixin remains for the
+not-yet-migrated xml/rdf/dot modules.
+"""
+
+from prov.model import ProvDocument
+
+
+def document_with_n_bundles_having_default_namespace(n):
+    prov_doc = ProvDocument()
+    prov_doc.add_namespace("ex", "http://www.example.org/")
+    for i in range(n):
+        x = str(i + 1)
+        bundle = prov_doc.bundle("ex:bundle/" + x)
+        bundle.set_default_namespace("http://www.example.org/default/" + x)
+        bundle.entity("e")
+    return prov_doc
+
+
+def test_namespace_inheritance(roundtrip):
+    prov_doc = ProvDocument()
+    prov_doc.add_namespace("ex", "http://www.example.org/")
+    bundle = prov_doc.bundle("ex:bundle")
+    e1 = bundle.entity("ex:e1")
+    assert e1.identifier is not None, "e1's identifier is None!"
+    roundtrip(prov_doc)
+
+
+def test_default_namespace_inheritance(roundtrip):
+    prov_doc = ProvDocument()
+    prov_doc.set_default_namespace("http://www.example.org/")
+    bundle = prov_doc.bundle("bundle")
+    e1 = bundle.entity("e1")
+    assert e1.identifier is not None, "e1's identifier is None!"
+    roundtrip(prov_doc)
+
+
+def test_flattening_1_bundle_with_default_namespace(roundtrip):
+    prov_doc = document_with_n_bundles_having_default_namespace(1)
+    roundtrip(prov_doc.flattened())
+
+
+def test_flattening_2_bundles_with_default_namespace(roundtrip):
+    prov_doc = document_with_n_bundles_having_default_namespace(2)
+    roundtrip(prov_doc.flattened())
+
+
+def test_flattening_3_bundles_with_default_namespace(roundtrip):
+    prov_doc = document_with_n_bundles_having_default_namespace(3)
+    roundtrip(prov_doc.flattened())
+
+
+def test_flattening_1_bundle_with_default_namespaces(roundtrip):
+    prov_doc = document_with_n_bundles_having_default_namespace(1)
+    prov_doc.set_default_namespace("http://www.example.org/default/0")
+    roundtrip(prov_doc.flattened())
+
+
+def test_flattening_2_bundle_with_default_namespaces(roundtrip):
+    prov_doc = document_with_n_bundles_having_default_namespace(2)
+    prov_doc.set_default_namespace("http://www.example.org/default/0")
+    roundtrip(prov_doc.flattened())

--- a/src/prov/tests/test_statements.py
+++ b/src/prov/tests/test_statements.py
@@ -1,0 +1,1696 @@
+"""Pytest-native shared statement round-trip tests.
+
+Migrated from the ``TestStatementsBase`` mixin (``statements.py``): each test
+method becomes a module-level function taking the ``roundtrip`` fixture, which
+runs it once per target in ``SHARED_TARGETS`` (model + json this step). The
+legacy mixin remains for the not-yet-migrated xml/rdf/dot modules.
+"""
+
+from prov.model import *
+
+EX_NS = Namespace("ex", "http://example.org/")
+EX2_NS = Namespace("ex2", "http://example2.org/")
+
+
+def new_document():
+    return ProvDocument()
+
+
+def add_label(record):
+    record.add_attributes([("prov:label", Literal("hello"))])
+
+
+def add_labels(record):
+    record.add_attributes(
+        [
+            ("prov:label", Literal("hello")),
+            ("prov:label", Literal("bye", langtag="en")),
+            ("prov:label", Literal("bonjour", langtag="fr")),
+        ]
+    )
+
+
+def add_types(record):
+    record.add_attributes(
+        [
+            ("prov:type", "a"),
+            ("prov:type", 1),
+            ("prov:type", 1.0),
+            ("prov:type", True),
+            ("prov:type", EX_NS["abc"]),
+            ("prov:type", datetime.datetime.now()),
+            (
+                "prov:type",
+                Literal("http://boiled-egg.example.com", datatype=XSD_ANYURI),
+            ),
+        ]
+    )
+
+
+def add_locations(record):
+    record.add_attributes(
+        [
+            ("prov:Location", "Southampton"),
+            ("prov:Location", 1),
+            ("prov:Location", 1.0),
+            ("prov:Location", True),
+            ("prov:Location", EX_NS["london"]),
+            ("prov:Location", datetime.datetime.now()),
+            ("prov:Location", EX_NS.uri + "london"),
+            ("prov:Location", Literal(2002, datatype=XSD["gYear"])),
+        ]
+    )
+
+
+def add_value(record):
+    record.add_attributes([("prov:value", EX_NS["avalue"])])
+
+
+def add_further_attributes(record):
+    record.add_attributes(
+        [
+            (EX_NS["tag1"], "hello"),
+            (EX_NS["tag2"], "bye"),
+            (EX2_NS["tag3"], "hi"),
+            (EX_NS["tag1"], "hello\nover\nmore\nlines"),
+        ]
+    )
+
+
+def add_further_attributes0(record):
+    record.add_attributes(
+        [
+            (EX_NS["tag1"], "hello"),
+            (EX_NS["tag2"], "bye"),
+            (EX_NS["tag2"], Literal("hola", langtag="es")),
+            (EX2_NS["tag3"], "hi"),
+            (EX_NS["tag"], 1),
+            (EX_NS["tag"], Literal(1, datatype=XSD_SHORT)),
+            (EX_NS["tag"], Literal(1, datatype=XSD_DOUBLE)),
+            (EX_NS["tag"], 1.0),
+            (EX_NS["tag"], True),
+            (EX_NS["tag"], EX_NS.uri + "southampton"),
+        ]
+    )
+
+    add_further_attributes_with_qnames(record)
+
+
+def add_further_attributes_with_qnames(record):
+    record.add_attributes(
+        [
+            (EX_NS["tag"], EX2_NS["newyork"]),
+            (EX_NS["tag"], EX_NS["london"]),
+        ]
+    )
+
+
+# TESTS
+
+
+# ENTITIES
+def test_entity_0(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e0"])
+    a.add_attributes(
+        [
+            (EX_NS["tag2"], Literal("guten tag", langtag="de")),
+            ("prov:Location", "un llieu"),
+            (PROV["Location"], 1),
+            (PROV["Location"], 2.0),
+            (PROV["Location"], EX_NS.uri + "london"),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_entity_1(roundtrip):
+    document = new_document()
+    document.entity(EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_entity_2(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e2"])
+    a.add_attributes([(PROV_LABEL, "entity2")])
+    roundtrip(document)
+
+
+def test_entity_3(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e3"])
+    a.add_attributes([(PROV_LABEL, "entity3")])
+    add_value(a)
+    roundtrip(document)
+
+
+def test_entity_4(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e4"])
+    a.add_attributes([(PROV_LABEL, "entity4")])
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_entity_5(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e5"])
+    a.add_attributes([(PROV_LABEL, "entity5")])
+    add_types(a)
+    roundtrip(document)
+
+
+def test_entity_6(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e6"])
+    a.add_attributes([(PROV_LABEL, "entity6")])
+    add_locations(a)
+    roundtrip(document)
+
+
+def test_entity_7(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e7"])
+    a.add_attributes([(PROV_LABEL, "entity7")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_entity_8(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e8"])
+    a.add_attributes([(PROV_LABEL, "entity8")])
+    add_types(a)
+    add_types(a)
+    add_locations(a)
+    add_locations(a)
+    add_labels(a)
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_entity_9(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e9"])
+    a.add_attributes([(PROV_LABEL, "entity9")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes(a)
+    roundtrip(document)
+
+
+def test_entity_10(roundtrip):
+    document = new_document()
+    a = document.entity(EX_NS["e10"])
+    a.add_attributes([(PROV_LABEL, "entity10")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes0(a)
+    roundtrip(document)
+
+
+# ACTIVITIES
+def test_activity_1(roundtrip):
+    document = new_document()
+    document.activity(EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_activity_2(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a2"])
+    a.add_attributes([(PROV_LABEL, "activity2")])
+    roundtrip(document)
+
+
+def test_activity_3(roundtrip):
+    document = new_document()
+    document.activity(
+        EX_NS["a3"],
+        startTime=datetime.datetime.now(),
+        endTime=datetime.datetime.now(),
+    )
+    roundtrip(document)
+
+
+def test_activity_4(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a4"])
+    a.add_attributes([(PROV_LABEL, "activity4")])
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_activity_5(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a5"])
+    a.add_attributes([(PROV_LABEL, "activity5")])
+    add_types(a)
+    roundtrip(document)
+
+
+def test_activity_6(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a6"])
+    a.add_attributes([(PROV_LABEL, "activity6")])
+    add_locations(a)
+    roundtrip(document)
+
+
+def test_activity_7(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a7"])
+    a.add_attributes([(PROV_LABEL, "activity7")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_activity_8(roundtrip):
+    document = new_document()
+    a = document.activity(
+        EX_NS["a8"],
+        startTime=datetime.datetime.now(),
+        endTime=datetime.datetime.now(),
+    )
+    a.add_attributes([(PROV_LABEL, "activity8")])
+    add_types(a)
+    add_types(a)
+    add_locations(a)
+    add_locations(a)
+    add_labels(a)
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_activity_9(roundtrip):
+    document = new_document()
+    a = document.activity(EX_NS["a9"])
+    a.add_attributes([(PROV_LABEL, "activity9")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes(a)
+    roundtrip(document)
+
+
+# AGENTS
+def test_agent_1(roundtrip):
+    document = new_document()
+    document.agent(EX_NS["ag1"])
+    roundtrip(document)
+
+
+def test_agent_2(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag2"])
+    a.add_attributes([(PROV_LABEL, "agent2")])
+    roundtrip(document)
+
+
+def test_agent_3(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag3"])
+    a.add_attributes(
+        [
+            (PROV_LABEL, "agent3"),
+            (PROV_LABEL, Literal("hello")),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_agent_4(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag4"])
+    a.add_attributes(
+        [
+            (PROV_LABEL, "agent4"),
+            (PROV_LABEL, Literal("hello")),
+            (PROV_LABEL, Literal("bye", langtag="en")),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_agent_5(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag5"])
+    a.add_attributes(
+        [
+            (PROV_LABEL, "agent5"),
+            (PROV_LABEL, Literal("hello")),
+            (PROV_LABEL, Literal("bye", langtag="en")),
+            (PROV_LABEL, Literal("bonjour", langtag="french")),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_agent_6(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag6"])
+    a.add_attributes([(PROV_LABEL, "agent6")])
+    add_types(a)
+    roundtrip(document)
+
+
+def test_agent_7(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag7"])
+    a.add_attributes([(PROV_LABEL, "agent7")])
+    add_locations(a)
+    add_labels(a)
+    roundtrip(document)
+
+
+def test_agent_8(roundtrip):
+    document = new_document()
+    a = document.agent(EX_NS["ag8"])
+    a.add_attributes([(PROV_LABEL, "agent8")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes(a)
+    roundtrip(document)
+
+
+# GENERATIONS
+def test_generation_1(roundtrip):
+    document = new_document()
+    document.generation(EX_NS["e1"], identifier=EX_NS["gen1"])
+    roundtrip(document)
+
+
+def test_generation_2(roundtrip):
+    document = new_document()
+    document.generation(EX_NS["e1"], identifier=EX_NS["gen2"], activity=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_generation_3(roundtrip):
+    document = new_document()
+    a = document.generation(EX_NS["e1"], identifier=EX_NS["gen3"], activity=EX_NS["a1"])
+    a.add_attributes(
+        [
+            (PROV_ROLE, "somerole"),
+            (PROV_ROLE, "otherRole"),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_generation_4(roundtrip):
+    document = new_document()
+    document.new_record(
+        PROV_GENERATION,
+        EX_NS["gen4"],
+        (
+            (PROV_ATTR_ENTITY, EX_NS["e1"]),
+            (PROV_ATTR_ACTIVITY, EX_NS["a1"]),
+            (PROV_ATTR_TIME, datetime.datetime.now()),
+        ),
+        {PROV_ROLE: "somerole"},
+    )
+    roundtrip(document)
+
+
+def test_generation_5(roundtrip):
+    document = new_document()
+    a = document.generation(
+        EX_NS["e1"],
+        identifier=EX_NS["gen5"],
+        activity=EX_NS["a1"],
+        time=datetime.datetime.now(),
+    )
+    a.add_attributes(
+        [
+            (PROV_ROLE, "somerole"),
+        ]
+    )
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes(a)
+    roundtrip(document)
+
+
+def test_generation_6(roundtrip):
+    document = new_document()
+    document.generation(EX_NS["e1"], activity=EX_NS["a1"], time=datetime.datetime.now())
+    roundtrip(document)
+
+
+def test_generation_7(roundtrip):
+    document = new_document()
+    a = document.generation(
+        EX_NS["e1"], activity=EX_NS["a1"], time=datetime.datetime.now()
+    )
+    a.add_attributes([(PROV_ROLE, "somerole")])
+    add_types(a)
+    add_locations(a)
+    add_labels(a)
+    add_further_attributes(a)
+    roundtrip(document)
+
+
+# USAGE
+def test_usage_1(roundtrip):
+    document = new_document()
+    document.usage(None, entity=EX_NS["e1"], identifier=EX_NS["use1"])
+    roundtrip(document)
+
+
+def test_usage_2(roundtrip):
+    document = new_document()
+    document.usage(EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use2"])
+    roundtrip(document)
+
+
+def test_usage_3(roundtrip):
+    document = new_document()
+    use = document.usage(EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use3"])
+    use.add_attributes([(PROV_ROLE, "somerole"), (PROV_ROLE, "otherRole")])
+    roundtrip(document)
+
+
+def test_usage_4(roundtrip):
+    document = new_document()
+    use = document.usage(
+        EX_NS["a1"],
+        entity=EX_NS["e1"],
+        identifier=EX_NS["use4"],
+        time=datetime.datetime.now(),
+    )
+    use.add_attributes([(PROV_ROLE, "somerole")])
+    roundtrip(document)
+
+
+def test_usage_5(roundtrip):
+    document = new_document()
+    use = document.usage(
+        EX_NS["a1"],
+        entity=EX_NS["e1"],
+        identifier=EX_NS["use5"],
+        time=datetime.datetime.now(),
+    )
+    use.add_attributes([(PROV_ROLE, "somerole")])
+    add_types(use)
+    add_locations(use)
+    add_labels(use)
+    add_further_attributes(use)
+    roundtrip(document)
+
+
+def test_usage_6(roundtrip):
+    document = new_document()
+    document.usage(EX_NS["a1"], entity=EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_usage_7(roundtrip):
+    document = new_document()
+    use = document.usage(EX_NS["a1"], entity=EX_NS["e1"], time=datetime.datetime.now())
+    use.add_attributes([(PROV_ROLE, "somerole")])
+    add_types(use)
+    add_locations(use)
+    add_labels(use)
+    add_further_attributes(use)
+    roundtrip(document)
+
+
+# INVALIDATIONS
+def test_invalidation_1(roundtrip):
+    document = new_document()
+    document.invalidation(EX_NS["e1"], identifier=EX_NS["inv1"])
+    roundtrip(document)
+
+
+def test_invalidation_2(roundtrip):
+    document = new_document()
+    document.invalidation(EX_NS["e1"], identifier=EX_NS["inv2"], activity=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_invalidation_3(roundtrip):
+    document = new_document()
+    inv = document.invalidation(
+        EX_NS["e1"], identifier=EX_NS["inv3"], activity=EX_NS["a1"]
+    )
+    inv.add_attributes(
+        [
+            (PROV_ROLE, "someRole"),
+            (PROV_ROLE, "otherRole"),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_invalidation_4(roundtrip):
+    document = new_document()
+    inv = document.invalidation(
+        EX_NS["e1"],
+        identifier=EX_NS["inv4"],
+        activity=EX_NS["a1"],
+        time=datetime.datetime.now(),
+    )
+    inv.add_attributes(
+        [
+            (PROV_ROLE, "someRole"),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_invalidation_5(roundtrip):
+    document = new_document()
+    inv = document.invalidation(
+        EX_NS["e1"],
+        identifier=EX_NS["inv5"],
+        activity=EX_NS["a1"],
+        time=datetime.datetime.now(),
+    )
+    inv.add_attributes(
+        [
+            (PROV_ROLE, "someRole"),
+        ]
+    )
+    add_types(inv)
+    add_locations(inv)
+    add_labels(inv)
+    add_further_attributes(inv)
+    roundtrip(document)
+
+
+def test_invalidation_6(roundtrip):
+    document = new_document()
+    document.invalidation(EX_NS["e1"], activity=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_invalidation_7(roundtrip):
+    document = new_document()
+    inv = document.invalidation(
+        EX_NS["e1"], activity=EX_NS["a1"], time=datetime.datetime.now()
+    )
+    inv.add_attributes(
+        [
+            (PROV_ROLE, "someRole"),
+        ]
+    )
+    add_types(inv)
+    add_locations(inv)
+    add_labels(inv)
+    add_further_attributes(inv)
+    roundtrip(document)
+
+
+# STARTS
+def test_start_1(roundtrip):
+    document = new_document()
+    document.start(None, trigger=EX_NS["e1"], identifier=EX_NS["start1"])
+    roundtrip(document)
+
+
+def test_start_2(roundtrip):
+    document = new_document()
+    document.start(EX_NS["a1"], trigger=EX_NS["e1"], identifier=EX_NS["start2"])
+    roundtrip(document)
+
+
+def test_start_3(roundtrip):
+    document = new_document()
+    document.start(EX_NS["a1"], identifier=EX_NS["start3"])
+    roundtrip(document)
+
+
+def test_start_4(roundtrip):
+    document = new_document()
+    document.start(
+        None, trigger=EX_NS["e1"], identifier=EX_NS["start4"], starter=EX_NS["a2"]
+    )
+    roundtrip(document)
+
+
+def test_start_5(roundtrip):
+    document = new_document()
+    document.start(
+        EX_NS["a1"],
+        trigger=EX_NS["e1"],
+        identifier=EX_NS["start5"],
+        starter=EX_NS["a2"],
+    )
+    roundtrip(document)
+
+
+def test_start_6(roundtrip):
+    document = new_document()
+    document.start(EX_NS["a1"], identifier=EX_NS["start6"], starter=EX_NS["a2"])
+    roundtrip(document)
+
+
+def test_start_7(roundtrip):
+    document = new_document()
+    document.start(
+        EX_NS["a1"],
+        identifier=EX_NS["start7"],
+        starter=EX_NS["a2"],
+        time=datetime.datetime.now(),
+    )
+    roundtrip(document)
+
+
+def test_start_8(roundtrip):
+    document = new_document()
+    start = document.start(
+        EX_NS["a1"],
+        identifier=EX_NS["start8"],
+        starter=EX_NS["a2"],
+        time=datetime.datetime.now(),
+    )
+    start.add_attributes(
+        [
+            (PROV_ROLE, "egg-cup"),
+            (PROV_ROLE, "boiling-water"),
+        ]
+    )
+    add_types(start)
+    add_locations(start)
+    add_labels(start)
+    add_further_attributes(start)
+    roundtrip(document)
+
+
+def test_start_9(roundtrip):
+    document = new_document()
+    document.start(EX_NS["a1"], trigger=EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_start_10(roundtrip):
+    document = new_document()
+    start = document.start(
+        EX_NS["a1"], starter=EX_NS["a2"], time=datetime.datetime.now()
+    )
+    start.add_attributes(
+        [
+            (PROV_ROLE, "egg-cup"),
+            (PROV_ROLE, "boiling-water"),
+        ]
+    )
+    add_types(start)
+    add_locations(start)
+    add_labels(start)
+    add_further_attributes(start)
+    roundtrip(document)
+
+
+# ENDS
+def test_end_1(roundtrip):
+    document = new_document()
+    document.end(None, trigger=EX_NS["e1"], identifier=EX_NS["end1"])
+    roundtrip(document)
+
+
+def test_end_2(roundtrip):
+    document = new_document()
+    document.end(EX_NS["a1"], trigger=EX_NS["e1"], identifier=EX_NS["end2"])
+    roundtrip(document)
+
+
+def test_end_3(roundtrip):
+    document = new_document()
+    document.end(EX_NS["a1"], identifier=EX_NS["end3"])
+    roundtrip(document)
+
+
+def test_end_4(roundtrip):
+    document = new_document()
+    document.end(None, trigger=EX_NS["e1"], identifier=EX_NS["end4"], ender=EX_NS["a2"])
+    roundtrip(document)
+
+
+def test_end_5(roundtrip):
+    document = new_document()
+    document.end(
+        EX_NS["a1"],
+        trigger=EX_NS["e1"],
+        identifier=EX_NS["end5"],
+        ender=EX_NS["a2"],
+    )
+    roundtrip(document)
+
+
+def test_end_6(roundtrip):
+    document = new_document()
+    document.end(EX_NS["a1"], identifier=EX_NS["end6"], ender=EX_NS["a2"])
+    roundtrip(document)
+
+
+def test_end_7(roundtrip):
+    document = new_document()
+    document.end(
+        EX_NS["a1"],
+        identifier=EX_NS["end7"],
+        ender=EX_NS["a2"],
+        time=datetime.datetime.now(),
+    )
+    roundtrip(document)
+
+
+def test_end_8(roundtrip):
+    document = new_document()
+    end = document.end(
+        EX_NS["a1"],
+        identifier=EX_NS["end8"],
+        ender=EX_NS["a2"],
+        time=datetime.datetime.now(),
+    )
+    end.add_attributes(
+        [
+            (PROV_ROLE, "egg-cup"),
+            (PROV_ROLE, "boiling-water"),
+        ]
+    )
+    add_types(end)
+    add_locations(end)
+    add_labels(end)
+    add_further_attributes(end)
+    roundtrip(document)
+
+
+def test_end_9(roundtrip):
+    document = new_document()
+    document.end(EX_NS["a1"], trigger=EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_end_10(roundtrip):
+    document = new_document()
+    end = document.end(EX_NS["a1"], ender=EX_NS["a2"], time=datetime.datetime.now())
+    end.add_attributes(
+        [
+            (PROV_ROLE, "yolk"),
+            (PROV_ROLE, "white"),
+        ]
+    )
+    add_types(end)
+    add_locations(end)
+    add_labels(end)
+    add_further_attributes(end)
+    roundtrip(document)
+
+
+# DERIVATIONS
+def test_derivation_1(roundtrip):
+    document = new_document()
+    document.derivation(None, usedEntity=EX_NS["e1"], identifier=EX_NS["der1"])
+    roundtrip(document)
+
+
+def test_derivation_2(roundtrip):
+    document = new_document()
+    document.derivation(EX_NS["e2"], usedEntity=None, identifier=EX_NS["der2"])
+    roundtrip(document)
+
+
+def test_derivation_3(roundtrip):
+    document = new_document()
+    document.derivation(EX_NS["e2"], usedEntity=EX_NS["e1"], identifier=EX_NS["der3"])
+    roundtrip(document)
+
+
+def test_derivation_4(roundtrip):
+    document = new_document()
+    der = document.derivation(
+        EX_NS["e2"], usedEntity=EX_NS["e1"], identifier=EX_NS["der4"]
+    )
+    add_label(der)
+    roundtrip(document)
+
+
+def test_derivation_5(roundtrip):
+    document = new_document()
+    document.derivation(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["der5"],
+        activity=EX_NS["a"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_6(roundtrip):
+    document = new_document()
+    document.derivation(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["der6"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_7(roundtrip):
+    document = new_document()
+    document.derivation(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["der7"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+        generation=EX_NS["g"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_8(roundtrip):
+    document = new_document()
+    der = document.derivation(
+        EX_NS["e2"], usedEntity=EX_NS["e1"], identifier=EX_NS["der8"]
+    )
+    add_label(der)
+    add_types(der)
+    add_further_attributes(der)
+    roundtrip(document)
+
+
+def test_derivation_9(roundtrip):
+    document = new_document()
+    der = document.derivation(EX_NS["e2"], usedEntity=None)
+    add_types(der)
+    roundtrip(document)
+
+
+def test_derivation_10(roundtrip):
+    document = new_document()
+    document.derivation(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+        generation=EX_NS["g"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_11(roundtrip):
+    document = new_document()
+    document.revision(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["rev1"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+        generation=EX_NS["g"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_12(roundtrip):
+    document = new_document()
+    document.quotation(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["quo1"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+        generation=EX_NS["g"],
+    )
+    roundtrip(document)
+
+
+def test_derivation_13(roundtrip):
+    document = new_document()
+    document.primary_source(
+        EX_NS["e2"],
+        usedEntity=EX_NS["e1"],
+        identifier=EX_NS["prim1"],
+        activity=EX_NS["a"],
+        usage=EX_NS["u"],
+        generation=EX_NS["g"],
+    )
+    roundtrip(document)
+
+
+# ASSOCIATIONS
+def test_association_1(roundtrip):
+    document = new_document()
+    document.association(EX_NS["a1"], identifier=EX_NS["assoc1"])
+    roundtrip(document)
+
+
+def test_association_2(roundtrip):
+    document = new_document()
+    document.association(None, agent=EX_NS["ag1"], identifier=EX_NS["assoc2"])
+    roundtrip(document)
+
+
+def test_association_3(roundtrip):
+    document = new_document()
+    document.association(EX_NS["a1"], agent=EX_NS["ag1"], identifier=EX_NS["assoc3"])
+    roundtrip(document)
+
+
+def test_association_4(roundtrip):
+    document = new_document()
+    document.association(
+        EX_NS["a1"],
+        agent=EX_NS["ag1"],
+        identifier=EX_NS["assoc4"],
+        plan=EX_NS["plan1"],
+    )
+    roundtrip(document)
+
+
+def test_association_5(roundtrip):
+    document = new_document()
+    document.association(EX_NS["a1"], agent=EX_NS["ag1"])
+    roundtrip(document)
+
+
+def test_association_6(roundtrip):
+    document = new_document()
+    assoc = document.association(
+        EX_NS["a1"],
+        agent=EX_NS["ag1"],
+        identifier=EX_NS["assoc6"],
+        plan=EX_NS["plan1"],
+    )
+    add_labels(assoc)
+    roundtrip(document)
+
+
+def test_association_7(roundtrip):
+    document = new_document()
+    assoc = document.association(
+        EX_NS["a1"],
+        agent=EX_NS["ag1"],
+        identifier=EX_NS["assoc7"],
+        plan=EX_NS["plan1"],
+    )
+    add_labels(assoc)
+    add_types(assoc)
+    roundtrip(document)
+
+
+def test_association_8(roundtrip):
+    document = new_document()
+    assoc = document.association(
+        EX_NS["a1"],
+        agent=EX_NS["ag1"],
+        identifier=EX_NS["assoc8"],
+        plan=EX_NS["plan1"],
+    )
+    assoc.add_attributes(
+        [
+            (PROV_ROLE, "figroll"),
+            (PROV_ROLE, "sausageroll"),
+        ]
+    )
+    roundtrip(document)
+
+
+def test_association_9(roundtrip):
+    document = new_document()
+    assoc = document.association(
+        EX_NS["a1"],
+        agent=EX_NS["ag1"],
+        identifier=EX_NS["assoc9"],
+        plan=EX_NS["plan1"],
+    )
+    add_labels(assoc)
+    add_types(assoc)
+    add_further_attributes(assoc)
+    roundtrip(document)
+
+
+def test_association_10(roundtrip):
+    document = new_document()
+    assoc1 = document.association(
+        EX_NS["a1"], agent=EX_NS["ag1"], identifier=EX_NS["assoc10a"]
+    )
+    assoc1.add_attributes(
+        [
+            (PROV_ROLE, "figroll"),
+        ]
+    )
+    assoc2 = document.association(
+        EX_NS["a1"], agent=EX_NS["ag2"], identifier=EX_NS["assoc10b"]
+    )
+    assoc2.add_attributes(
+        [
+            (PROV_ROLE, "sausageroll"),
+        ]
+    )
+    roundtrip(document)
+
+
+# ATTRIBUTIONS
+def test_attribution_1(roundtrip):
+    document = new_document()
+    document.attribution(EX_NS["e1"], None, identifier=EX_NS["attr1"])
+    roundtrip(document)
+
+
+def test_attribution_2(roundtrip):
+    document = new_document()
+    document.attribution(None, EX_NS["ag1"], identifier=EX_NS["attr2"])
+    roundtrip(document)
+
+
+def test_attribution_3(roundtrip):
+    document = new_document()
+    document.attribution(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["attr3"])
+    roundtrip(document)
+
+
+def test_attribution_4(roundtrip):
+    document = new_document()
+    document.attribution(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["attr4"])
+    roundtrip(document)
+
+
+def test_attribution_5(roundtrip):
+    document = new_document()
+    document.attribution(EX_NS["e1"], EX_NS["ag1"])
+    roundtrip(document)
+
+
+def test_attribution_6(roundtrip):
+    document = new_document()
+    attr = document.attribution(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["attr6"])
+    add_labels(attr)
+    roundtrip(document)
+
+
+def test_attribution_7(roundtrip):
+    document = new_document()
+    attr = document.attribution(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["attr7"])
+    add_labels(attr)
+    add_types(attr)
+    roundtrip(document)
+
+
+def test_attribution_8(roundtrip):
+    document = new_document()
+    attr = document.attribution(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["attr8"])
+    add_labels(attr)
+    add_types(attr)
+    add_further_attributes(attr)
+    roundtrip(document)
+
+
+# DELEGATIONS
+def test_delegation_1(roundtrip):
+    document = new_document()
+    document.delegation(EX_NS["e1"], None, identifier=EX_NS["dele1"])
+    roundtrip(document)
+
+
+def test_delegation_2(roundtrip):
+    document = new_document()
+    document.delegation(None, EX_NS["ag1"], identifier=EX_NS["dele2"])
+    roundtrip(document)
+
+
+def test_delegation_3(roundtrip):
+    document = new_document()
+    document.delegation(EX_NS["e1"], EX_NS["ag1"], identifier=EX_NS["dele3"])
+    roundtrip(document)
+
+
+def test_delegation_4(roundtrip):
+    document = new_document()
+    document.delegation(
+        EX_NS["e1"], EX_NS["ag1"], activity=EX_NS["a1"], identifier=EX_NS["dele4"]
+    )
+    roundtrip(document)
+
+
+def test_delegation_5(roundtrip):
+    document = new_document()
+    document.delegation(EX_NS["e1"], EX_NS["ag1"])
+    roundtrip(document)
+
+
+def test_delegation_6(roundtrip):
+    document = new_document()
+    dele = document.delegation(
+        EX_NS["e1"], EX_NS["ag1"], activity=EX_NS["a1"], identifier=EX_NS["dele6"]
+    )
+    add_labels(dele)
+    roundtrip(document)
+
+
+def test_delegation_7(roundtrip):
+    document = new_document()
+    dele = document.delegation(
+        EX_NS["e1"], EX_NS["ag1"], activity=EX_NS["a1"], identifier=EX_NS["dele7"]
+    )
+    add_labels(dele)
+    add_types(dele)
+    roundtrip(document)
+
+
+def test_delegation_8(roundtrip):
+    document = new_document()
+    dele = document.delegation(
+        EX_NS["e1"], EX_NS["ag1"], activity=EX_NS["a1"], identifier=EX_NS["dele8"]
+    )
+    add_labels(dele)
+    add_types(dele)
+    add_further_attributes(dele)
+    roundtrip(document)
+
+
+# COMMUNICATIONS
+def test_communication_1(roundtrip):
+    document = new_document()
+    document.communication(EX_NS["a2"], None, identifier=EX_NS["inf1"])
+    roundtrip(document)
+
+
+def test_communication_2(roundtrip):
+    document = new_document()
+    document.communication(None, EX_NS["a1"], identifier=EX_NS["inf2"])
+    roundtrip(document)
+
+
+def test_communication_3(roundtrip):
+    document = new_document()
+    document.communication(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf3"])
+    roundtrip(document)
+
+
+def test_communication_4(roundtrip):
+    document = new_document()
+    document.communication(EX_NS["a2"], EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_communication_5(roundtrip):
+    document = new_document()
+    inf = document.communication(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf5"])
+    add_labels(inf)
+    roundtrip(document)
+
+
+def test_communication_6(roundtrip):
+    document = new_document()
+    inf = document.communication(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf6"])
+    add_labels(inf)
+    add_types(inf)
+    roundtrip(document)
+
+
+def test_communication_7(roundtrip):
+    document = new_document()
+    inf = document.communication(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf7"])
+    add_labels(inf)
+    add_types(inf)
+    add_further_attributes(inf)
+    roundtrip(document)
+
+
+# INFLUENCES
+def test_influence_1(roundtrip):
+    document = new_document()
+    document.influence(EX_NS["a2"], None, identifier=EX_NS["inf1"])
+    roundtrip(document)
+
+
+def test_influence_2(roundtrip):
+    document = new_document()
+    document.influence(None, EX_NS["a1"], identifier=EX_NS["inf2"])
+    roundtrip(document)
+
+
+def test_influence_3(roundtrip):
+    document = new_document()
+    document.influence(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf3"])
+    roundtrip(document)
+
+
+def test_influence_4(roundtrip):
+    document = new_document()
+    document.influence(EX_NS["a2"], EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_influence_5(roundtrip):
+    document = new_document()
+    inf = document.influence(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf5"])
+    add_labels(inf)
+    roundtrip(document)
+
+
+def test_influence_6(roundtrip):
+    document = new_document()
+    inf = document.influence(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf6"])
+    add_labels(inf)
+    add_types(inf)
+    roundtrip(document)
+
+
+def test_influence_7(roundtrip):
+    document = new_document()
+    inf = document.influence(EX_NS["a2"], EX_NS["a1"], identifier=EX_NS["inf7"])
+    add_labels(inf)
+    add_types(inf)
+    add_further_attributes(inf)
+    roundtrip(document)
+
+
+# OTHERS
+def test_alternate_1(roundtrip):
+    document = new_document()
+    document.alternate(EX_NS["e2"], EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_specialization_1(roundtrip):
+    document = new_document()
+    document.specialization(EX_NS["e2"], EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_mention_1(roundtrip):
+    document = new_document()
+    document.mention(EX_NS["e2"], EX_NS["e1"], None)
+    roundtrip(document)
+
+
+def test_mention_2(roundtrip):
+    document = new_document()
+    document.mention(EX_NS["e2"], EX_NS["e1"], EX_NS["b"])
+    roundtrip(document)
+
+
+def test_membership_1(roundtrip):
+    document = new_document()
+    document.membership(EX_NS["c"], EX_NS["e1"])
+    roundtrip(document)
+
+
+def test_membership_2(roundtrip):
+    document = new_document()
+    document.membership(EX_NS["c"], EX_NS["e1"])
+    document.membership(EX_NS["c"], EX_NS["e2"])
+    roundtrip(document)
+
+
+def test_membership_3(roundtrip):
+    document = new_document()
+    document.membership(EX_NS["c"], EX_NS["e1"])
+    document.membership(EX_NS["c"], EX_NS["e2"])
+    document.membership(EX_NS["c"], EX_NS["e3"])
+    roundtrip(document)
+
+
+# SCRUFFY
+def test_scruffy_generation_1(roundtrip):
+    document = new_document()
+    document.generation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    document.generation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_generation_2(roundtrip):
+    document = new_document()
+    gen1 = document.generation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    gen2 = document.generation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    gen1.add_attributes([(EX_NS["tag2"], "hello-scruff-gen2")])
+    gen2.add_attributes([(EX_NS["tag2"], "hi-scruff-gen2")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_invalidation_1(roundtrip):
+    document = new_document()
+    document.invalidation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    document.invalidation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_invalidation_2(roundtrip):
+    document = new_document()
+    inv1 = document.invalidation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    inv2 = document.invalidation(
+        EX_NS["e1"],
+        EX_NS["a1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    inv1.add_attributes([(EX_NS["tag2"], "hello")])
+    inv2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_usage_1(roundtrip):
+    document = new_document()
+    document.usage(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    document.usage(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_usage_2(roundtrip):
+    document = new_document()
+    use1 = document.usage(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    use2 = document.usage(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    use1.add_attributes([(EX_NS["tag2"], "hello")])
+    use2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_start_1(roundtrip):
+    document = new_document()
+    document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_start_2(roundtrip):
+    document = new_document()
+    start1 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    start2 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    start1.add_attributes([(EX_NS["tag2"], "hello")])
+    start2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_start_3(roundtrip):
+    document = new_document()
+    start1 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+        starter=EX_NS["a1s"],
+    )
+    start2 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        starter=EX_NS["a2s"],
+    )
+    start1.add_attributes([(EX_NS["tag2"], "hello")])
+    start2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    document.activity(identifier=EX_NS["a2"])
+    document.activity(identifier=EX_NS["a2s"])
+    roundtrip(document)
+
+
+def test_scruffy_start_4(roundtrip):
+    document = new_document()
+    start1 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+        starter=EX_NS["a1s"],
+    )
+    start2 = document.start(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        starter=EX_NS["a2s"],
+    )
+    start1.add_attributes([(EX_NS["tag2"], "hello")])
+    start2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    document.activity(identifier=EX_NS["a1s"])
+    document.activity(identifier=EX_NS["a2"])
+    document.activity(identifier=EX_NS["a2s"])
+    roundtrip(document)
+
+
+def test_scruffy_end_1(roundtrip):
+    document = new_document()
+    document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_end_2(roundtrip):
+    document = new_document()
+    end1 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+    )
+    end2 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+    )
+    end1.add_attributes([(EX_NS["tag2"], "hello")])
+    end2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    roundtrip(document)
+
+
+def test_scruffy_end_3(roundtrip):
+    document = new_document()
+    end1 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+        ender=EX_NS["a1s"],
+    )
+    end2 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        ender=EX_NS["a2s"],
+    )
+    end1.add_attributes([(EX_NS["tag2"], "hello")])
+    end2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    document.activity(identifier=EX_NS["a2"])
+    document.activity(identifier=EX_NS["a2s"])
+    roundtrip(document)
+
+
+def test_scruffy_end_4(roundtrip):
+    document = new_document()
+    end1 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=datetime.datetime.now(),
+        ender=EX_NS["a1s"],
+    )
+    end2 = document.end(
+        EX_NS["a1"],
+        EX_NS["e1"],
+        identifier=EX_NS["gen1"],
+        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        ender=EX_NS["a2s"],
+    )
+    end1.add_attributes([(EX_NS["tag2"], "hello")])
+    end2.add_attributes([(EX_NS["tag2"], "hi")])
+    document.entity(identifier=EX_NS["e1"])
+    document.activity(identifier=EX_NS["a1"])
+    document.activity(identifier=EX_NS["a1s"])
+    document.activity(identifier=EX_NS["a2"])
+    document.activity(identifier=EX_NS["a2s"])
+    roundtrip(document)
+
+
+def test_bundle_1(roundtrip):
+    document = new_document()
+
+    bundle1 = ProvBundle(identifier=EX_NS["bundle1"])
+    bundle1.usage(activity=EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use1"])
+    bundle1.entity(identifier=EX_NS["e1"])
+    bundle1.activity(identifier=EX_NS["a1"])
+
+    bundle2 = ProvBundle(identifier=EX_NS["bundle2"])
+    bundle2.usage(activity=EX_NS["aa1"], entity=EX_NS["ee1"], identifier=EX_NS["use2"])
+    bundle2.entity(identifier=EX_NS["ee1"])
+    bundle2.activity(identifier=EX_NS["aa1"])
+
+    document.add_bundle(bundle1)
+    document.add_bundle(bundle2)
+
+    roundtrip(document)
+
+
+def test_bundle_2(roundtrip):
+    document = new_document()
+
+    bundle1 = ProvBundle(identifier=EX_NS["bundle1"])
+    bundle1.usage(activity=EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use1"])
+    bundle1.entity(identifier=EX_NS["e1"])
+    bundle1.activity(identifier=EX_NS["a1"])
+
+    bundle2 = ProvBundle(identifier=EX_NS["bundle2"])
+    bundle2.usage(activity=EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use2"])
+    bundle2.entity(identifier=EX_NS["e1"])
+    bundle2.activity(identifier=EX_NS["a1"])
+
+    document.add_bundle(bundle1)
+    document.add_bundle(bundle2)
+
+    roundtrip(document)
+
+
+def test_bundle_3(roundtrip):
+    document = new_document()
+
+    bundle1 = ProvBundle(identifier=EX_NS["bundle1"])
+    bundle1.usage(activity=EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use1"])
+    bundle1.entity(identifier=EX_NS["e1"])
+    bundle1.activity(identifier=EX_NS["a1"])
+
+    bundle2 = ProvBundle(identifier=EX_NS["bundle2"])
+    bundle2.usage(activity=EX_NS["aa1"], entity=EX_NS["ee1"], identifier=EX_NS["use2"])
+    bundle2.entity(identifier=EX_NS["ee1"])
+    bundle2.activity(identifier=EX_NS["aa1"])
+
+    document.add_bundle(bundle1)
+    document.add_bundle(bundle2)
+
+    roundtrip(document)
+
+
+def test_bundle_4(roundtrip):
+    document = new_document()
+
+    bundle1 = ProvBundle(identifier=EX_NS["bundle1"])
+    bundle1.usage(activity=EX_NS["a1"], entity=EX_NS["e1"], identifier=EX_NS["use1"])
+    bundle1.entity(identifier=EX_NS["e1"])
+    bundle1.activity(identifier=EX_NS["a1"])
+
+    bundle2 = ProvBundle(identifier=EX_NS["bundle2"])
+    bundle2.usage(
+        activity=EX2_NS["aa1"], entity=EX2_NS["ee1"], identifier=EX2_NS["use2"]
+    )
+    bundle2.entity(identifier=EX2_NS["ee1"])
+    bundle2.activity(identifier=EX2_NS["aa1"])
+
+    document.add_bundle(bundle1)
+    document.add_bundle(bundle2)
+
+    roundtrip(document)


### PR DESCRIPTION
Pattern-setter for the pytest-native test-suite redesign (Phase 3, spec step 24, second deliverable). Implements the shared infrastructure from the approved design doc (`docs/superpowers/specs/2026-07-06-test-suite-redesign.md`) and migrates the JSON format tests onto it. XML/RDF (Task 11) and the remaining modules (Task 12) follow.

## What changed

- **`conftest.py`** (new) — the shared matrix: `ROUNDTRIP_FORMATS = ("json",)` (xml/rdf join in Task 11) and `SHARED_TARGETS = ("model", *ROUNDTRIP_FORMATS)`. A `fmt` fixture parametrizes every shared test over `SHARED_TARGETS`, so each shared case runs once per serialization format **and** once under a non-serializing `model` target (forces `get_provn()` + self-equality). A `roundtrip` fixture returns a `_check(doc)` callable. A `pytest_assertrepr_compare` hook renders the record-level symmetric difference when two `ProvDocument`s compare unequal — including records inside named sub-bundles — so round-trip failures show *which record* differs instead of an opaque blob.
- **Shared body → parametrized modules** — `test_statements.py` (147 fns), `test_attributes.py` (28-param + 2), `test_qnames.py` (7), `test_examples.py` (1 looping) replace the multiply-inherited mixin bodies for the model/json targets.
- **`attribute_values.py`** (new) — `ATTRIBUTE_VALUES` extracted from the `attributes.py` mixin so both the new module and the legacy mixin share one corpus (order preserved — later RDF datatype xfails key off indices).
- **`test_json.py`** — `RoundTripJSONTests` dropped; the 5 `TestJSONSerializer` methods converted to plain pytest functions. No `unittest`/`RoundTripTestCase`.
- **`test_model.py`** — only `RoundTripModelTest` removed (its coverage is now the `model` axis). `AllTestsBase`/`TestExamplesBase` and the legacy mixins stay — `test_xml.py`/`test_rdf.py`/`test_dot.py` still ride them until Tasks 11–12.
- **CLAUDE.md** — Tests section rewritten to describe the half-migrated state; mixins marked legacy-during-migration.

## Parity (user-gate evidence)

Collected-test parity is exact — **1102 before and after**.

| | baseline (master) | migrated |
|---|---|---|
| `pytest --collect-only` | 1102 | **1102** |
| `pytest` | 1085 passed / 17 xfailed | **1085 passed / 17 xfailed** |
| coverage | 97%+ | **98%** |

Per-module decomposition proving 1102: new shared modules `test_statements` 294 + `test_attributes` 60 + `test_qnames` 14 + `test_examples` 2 = **370** (= 185 × {model, json}); `test_json` 5; `test_model` 67 (was 252, −185); `test_xml`/`test_rdf`/`test_dot` unchanged at 200/196/191; other modules 73. Net move: −185 (model) −185 (json shared) +370 (new) = 0.

**Deliberate deviation from the design doc's §3 sketch:** `test_examples.py` is a single looping node per target, not the 8-`param` expansion the sketch shows — the expansion would add +7 per target and break the 1102 invariant. Per-example isolation is deferred; the maintainer's parity rule wins.

## assertrepr hook demo

A deliberately-broken round trip (record only inside a sub-bundle) now renders:

```
assert ProvDocument == ProvDocument failed:
    records: 1 left, 1 right
    in left only  (1):
      - ex:bundle | entity(ex:e1)
    in right only (1):
      + ex:bundle | entity(ex:e2)
```

(Bundle-awareness added after code review — `get_records()` alone is blind to sub-bundle contents, which `ProvDocument.__eq__` compares separately.)

Gates: `ruff check`, `ruff format --check`, `mypy src`, full suite all green.