### PR TITLE
test: migrate XML + RDF tests to pytest matrix; per-param skip/xfail marks (Phase 3, step 24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,43 +145,58 @@ extras in `pyproject.toml`); JSON and PROV-N have no extra dependencies.
 The suite is **mid-migration** from a plain-`unittest` multiple-inheritance design to a
 pytest-native shared matrix (Phase 3 test-suite redesign — authority:
 `docs/superpowers/specs/2026-07-06-test-suite-redesign.md`). The runner is `pytest`, which
-collects both styles natively (`expectedFailure` surfaces as `xfailed`). **JSON and the `model`
-target have been migrated; XML, RDF, and dot still ride the legacy scaffolding.** Expect the two
-styles to coexist until that migration completes.
+collects both styles natively (`expectedFailure` surfaces as `xfailed`). **JSON, XML, RDF, and
+the `model` target have been migrated; only `test_dot.py` still rides the legacy scaffolding.**
+Expect the two styles to coexist until that last migration completes.
 
 **Pytest-native shared matrix (current target):**
 
-- `conftest.py` — the shared scaffolding. Defines `ROUNDTRIP_FORMATS` (currently `("json",)`;
-  xml/rdf join later) and `SHARED_TARGETS = ("model", *ROUNDTRIP_FORMATS)`. The `fmt` fixture is
-  parametrized over `SHARED_TARGETS`, so every shared test runs once per serialization format
-  **and** once under a non-serializing `model` target (which forces `get_provn()` + a
-  self-equality check instead of a round trip). The `roundtrip` fixture returns a `_check(doc)`
-  callable that tests call as `roundtrip(doc)`. A `pytest_assertrepr_compare` hook renders the
-  record-level symmetric difference when two `ProvDocument`s compare unequal under `assert`, so
-  round-trip failures show *which record* differs.
+- `conftest.py` — the shared scaffolding. Defines `ROUNDTRIP_FORMATS = ("json", "xml", "rdf")`
+  and `SHARED_TARGETS = ("model", *ROUNDTRIP_FORMATS)`. The `fmt` fixture is parametrized over
+  `SHARED_TARGETS`, so every shared test runs once per serialization format **and** once under a
+  non-serializing `model` target (which forces `get_provn()` + a self-equality check instead of a
+  round trip). The `roundtrip` fixture returns a `_check(doc)` callable that tests call as
+  `roundtrip(doc)`. A `pytest_assertrepr_compare` hook renders the record-level symmetric
+  difference when two `ProvDocument`s compare unequal under `assert`, so round-trip failures show
+  *which record* differs.
 - `test_statements.py`, `test_attributes.py`, `test_qnames.py`, `test_examples.py` — the shared
   body as plain module-level functions taking the `roundtrip` fixture (one node per case × per
   target in `SHARED_TARGETS`). `test_attributes.py` parametrizes the single-type-attribute case
   over `ATTRIBUTE_VALUES`.
+- **Per-param skip/xfail marks on the `rdf` target** (design doc §2/§3): 14 "scruffy" cases in
+  `test_statements.py` (two same-identifier relations differing by `prov:time`, which PROV-O
+  cannot represent) are `pytest.mark.skip`-ped referencing issue #217; 3 datatype-fidelity cases —
+  `test_entity_with_one_type_attribute_decimal` (#77) and
+  `test_entity_with_multiple_attribute`/`test_entity_with_multiple_value_attribute` (#218) in
+  `test_attributes.py` — are strict `xfail`s. Each affected function opts out of the module-wide
+  `fmt` fixture with its own explicit `@pytest.mark.parametrize("fmt", [...])` so the mark attaches
+  only to the `rdf` param; `model`/`json`/`xml` still run normally. `test_examples.py` skips the
+  `datatypes` example under `fmt == "rdf"` only (same #218 root cause), matching the pre-migration
+  behavior.
 - `attribute_values.py` — the importable `ATTRIBUTE_VALUES` datatype corpus (order is
-  significant: later RDF datatype-fidelity xfails key off individual indices), shared by the new
-  `test_attributes.py` and the legacy `attributes.py` mixin.
+  significant: the RDF datatype-fidelity xfails key off individual indices, e.g. index 8 is the
+  `xsd:decimal` case), shared by the new `test_attributes.py` and the legacy `attributes.py` mixin.
 - `examples.py` — canonical example PROV documents (built programmatically), consumed by both the
   new `test_examples.py` and the legacy mixins.
 - `json/`, `xml/`, `rdf/`, `unification/` — fixture data directories consumed by the
   corresponding test modules (e.g. `TestLoadingProvToolboxJSON` in `test_model.py` round-trips
   every file under `tests/json/`).
+- `test_xml.py`, `test_rdf.py` — keep only the genuinely format-specific tests (c14n comparison,
+  example serialization/deserialization edge cases, serializer error paths, `find_diff`,
+  `test_json_to_ttl_match`, etc.); the shared round-trip coverage now lives in the pytest-native
+  modules above. `test_xml.py`'s `ProvXMLRoundTripFromFileTestCase` file-glob scaffold is
+  intentionally disabled (no test methods attached) per design doc §4 Decision 3.
 
 **Legacy-during-migration scaffolding (still live, retired in a later step):**
 
 - `utility.py` — `RoundTripTestCase` base (serialize → deserialize → `assertEqual`, keyed off a
-  `FORMAT` class attribute). Still subclassed by `test_xml.py`/`test_rdf.py`/`test_dot.py`.
+  `FORMAT` class attribute). Still subclassed by `test_dot.py`.
 - `attributes.py`, `statements.py`, `qnames.py` — the `TestAttributesBase` / `TestStatementsBase`
   / `TestQualifiedNamesBase` mixins, and `AllTestsBase`/`TestExamplesBase` in `test_model.py`,
-  composed into the xml/rdf/dot round-trip suites. These duplicate the coverage now also provided
-  by the new pytest-native modules for the model/json targets; the duplication is expected and
-  intentional until xml/rdf/dot migrate.
+  composed into the dot round-trip suite. These duplicate the coverage now also provided by the
+  new pytest-native modules for the model/json/xml/rdf targets; the duplication is expected and
+  intentional until dot migrates.
 
 When adding a new shared record type, attribute, or serializer behavior, add it to the
-pytest-native shared modules (and, while xml/rdf/dot remain on the mixins, to the corresponding
-mixin) so every target is exercised, rather than writing per-format tests from scratch.
+pytest-native shared modules (and, while dot remains on the mixins, to the corresponding mixin) so
+every target is exercised, rather than writing per-format tests from scratch.

--- a/src/prov/tests/conftest.py
+++ b/src/prov/tests/conftest.py
@@ -8,7 +8,7 @@ and hands it to the ``roundtrip`` fixture, which is parametrized over
 under the non-serializing ``model`` target.
 
 The legacy ``utility.py``/``statements.py``/``attributes.py``/``qnames.py``
-mixins remain in place for the not-yet-migrated xml/rdf/dot modules; they are
+mixins remain in place for the not-yet-migrated ``test_dot.py``; they are
 retired in a later migration step.
 """
 
@@ -19,8 +19,7 @@ import pytest
 from prov.model import ProvDocument
 
 # Formats that support a full serialize -> deserialize -> compare round trip.
-# xml and rdf join in the next migration step.
-ROUNDTRIP_FORMATS = ("json",)
+ROUNDTRIP_FORMATS = ("json", "xml", "rdf")
 # The full target axis: the round-trip formats PLUS a "model" target that
 # constructs the document, exercises PROV-N generation, and checks the
 # self-equality invariant WITHOUT serialization. The model axis preserves the

--- a/src/prov/tests/test_attributes.py
+++ b/src/prov/tests/test_attributes.py
@@ -2,10 +2,11 @@
 
 Migrated from the ``TestAttributesBase`` mixin (``attributes.py``): the 28
 single-type-attribute cases collapse into one parametrized function (node ids
-``attr-0``..``attr-27``), plus the multi-attribute and multi-value-attribute
-cases. Each runs once per target in ``SHARED_TARGETS``. The legacy mixin
-remains for the not-yet-migrated xml/rdf/dot modules; both share
-``ATTRIBUTE_VALUES``.
+``attr-0``..``attr-7``, ``attr-9``..``attr-27`` -- ``attr-8``, the
+``xsd:decimal`` case, is isolated below), plus the multi-attribute and
+multi-value-attribute cases. Each runs once per target in
+``SHARED_TARGETS``. The legacy mixin remains for the not-yet-migrated
+``test_dot.py``; both share ``ATTRIBUTE_VALUES``.
 """
 
 import pytest
@@ -13,10 +14,36 @@ import pytest
 from prov.model import ProvDocument
 from prov.tests.attribute_values import ATTRIBUTE_VALUES, EX_NS
 
+# Fixable RDF datatype-fidelity bugs slated for 3.0: strict xfails so an
+# accidental fix flips XFAIL->XPASS and fails the run (design doc §2/§3).
+RDF_DECIMAL_XFAIL = pytest.mark.xfail(
+    reason="Literal(10, XSD_DECIMAL) round-trips to 10.0, losing xsd:decimal "
+    "-- issue #77",
+    strict=True,
+    raises=AssertionError,
+)
+RDF_DATATYPE_XFAIL = pytest.mark.xfail(
+    reason="RDF loses XSD datatype fidelity across a mixed attribute set -- issue #218",
+    strict=True,
+    raises=AssertionError,
+)
+
+# These functions opt out of the module-wide `fmt` fixture (see conftest.py)
+# with their own explicit parametrization so the xfail mark attaches only to
+# the rdf param; model/json/xml still run normally.
+decimal_fmt = pytest.mark.parametrize(
+    "fmt",
+    ["model", "json", "xml", pytest.param("rdf", marks=RDF_DECIMAL_XFAIL)],
+)
+datatype_fmt = pytest.mark.parametrize(
+    "fmt",
+    ["model", "json", "xml", pytest.param("rdf", marks=RDF_DATATYPE_XFAIL)],
+)
+
 
 @pytest.mark.parametrize(
     "value",
-    [pytest.param(v, id=f"attr-{i}") for i, v in enumerate(ATTRIBUTE_VALUES)],
+    [pytest.param(v, id=f"attr-{i}") for i, v in enumerate(ATTRIBUTE_VALUES) if i != 8],
 )
 def test_entity_with_one_type_attribute(roundtrip, value):
     document = ProvDocument()
@@ -24,6 +51,14 @@ def test_entity_with_one_type_attribute(roundtrip, value):
     roundtrip(document)
 
 
+@decimal_fmt
+def test_entity_with_one_type_attribute_decimal(roundtrip):
+    document = ProvDocument()
+    document.entity(EX_NS["et"], {"prov:type": ATTRIBUTE_VALUES[8]})
+    roundtrip(document)
+
+
+@datatype_fmt
 def test_entity_with_multiple_attribute(roundtrip):
     document = ProvDocument()
     attributes = [(EX_NS[f"v_{i}"], value) for i, value in enumerate(ATTRIBUTE_VALUES)]
@@ -31,6 +66,7 @@ def test_entity_with_multiple_attribute(roundtrip):
     roundtrip(document)
 
 
+@datatype_fmt
 def test_entity_with_multiple_value_attribute(roundtrip):
     document = ProvDocument()
     attributes = [("prov:value", value) for value in ATTRIBUTE_VALUES]

--- a/src/prov/tests/test_examples.py
+++ b/src/prov/tests/test_examples.py
@@ -5,12 +5,20 @@ function loops over the canonical ``examples.tests`` documents and round-trips
 each, run once per target in ``SHARED_TARGETS``. It is kept as one looping node
 per target (not expanded per example) to preserve the collected-count parity
 baseline; per-example isolation is a deferred improvement. The legacy mixin
-remains for the not-yet-migrated xml/rdf/dot modules.
+remains for the not-yet-migrated ``test_dot.py``.
 """
 
 from prov.tests import examples
 
 
-def test_all_examples(roundtrip):
-    for _name, build in examples.tests:
+def test_all_examples(roundtrip, fmt):
+    for name, build in examples.tests:
+        # The "datatypes" example packs a mixed-XSD-datatype attribute set
+        # onto one entity, the same shape that loses fidelity across an RDF
+        # round trip as issue #218 (see test_attributes.py's
+        # RDF_DATATYPE_XFAIL); the pre-migration test_rdf.py loop skipped
+        # this example outright (`if name in ["datatypes"]: continue`).
+        # Preserved here, scoped to the rdf target only.
+        if fmt == "rdf" and name == "datatypes":
+            continue
         roundtrip(build())

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -1,3 +1,11 @@
+"""RDF serializer-specific tests.
+
+The shared statement/attribute/qname/example round-trips run through the
+pytest-native ``fmt`` matrix (see ``conftest.py`` and the ``test_statements``/
+``test_attributes``/``test_qnames``/``test_examples`` modules); this file keeps
+only the genuinely RDF-specific cases.
+"""
+
 import logging
 import os
 import unittest
@@ -5,17 +13,17 @@ from glob import glob
 from io import BytesIO, StringIO
 
 import rdflib as rl
+from rdflib import RDF, URIRef
 from rdflib.compare import graph_diff
+from rdflib.graph import ConjunctiveGraph, Graph
 
 import prov.model as pm
 from prov.model import ProvDocument
-from prov.tests import examples
-from prov.tests.test_model import (
-    TestAttributesBase,
-    TestQualifiedNamesBase,
-    TestStatementsBase,
+from prov.serializers.provrdf import (
+    ProvRDFException,
+    ProvRDFSerializer,
+    literal_rdf_representation,
 )
-from prov.tests.utility import RoundTripTestCase
 
 logger = logging.getLogger(__name__)
 
@@ -62,124 +70,6 @@ def find_diff(g_rdf, g0_rdf):
     return graphs_equal, in_both, in_first2, in_second2
 
 
-class TestExamplesBase:
-    """This is the base class for testing support for all the examples provided
-    in prov.tests.examples.
-    It is not runnable and needs to be included in a subclass of
-    RoundTripTestCase.
-    """
-
-    def test_all_examples(self):
-        counter = 0
-        for name, graph in examples.tests:
-            if name in ["datatypes"]:
-                logger.info("%d. Skipping the %s example", counter, name)
-                continue
-            counter += 1
-            logger.info("%d. Testing the %s example", counter, name)
-            g = graph()
-            self.do_tests(g)
-
-
-class TestJSONExamplesBase:
-    """This is the base class for testing support for all the examples provided
-    in prov.tests.examples.
-    It is not runnable and needs to be included in a subclass of
-    RoundTripTestCase.
-    """
-
-    def test_all_examples(self):
-        counter = 0
-        for name, graph in examples.tests:
-            if name in ["datatypes"]:
-                logger.info("%d. Skipping the %s example", counter, name)
-                continue
-            counter += 1
-            logger.info("%d. Testing the %s example", counter, name)
-            g = graph()
-            self.do_tests(g)
-
-
-class TestStatementsBase2(TestStatementsBase):
-    @unittest.expectedFailure
-    def test_scruffy_end_1(self):
-        TestStatementsBase.test_scruffy_end_1(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_end_2(self):
-        TestStatementsBase.test_scruffy_end_2(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_end_3(self):
-        TestStatementsBase.test_scruffy_end_3(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_end_4(self):
-        TestStatementsBase.test_scruffy_end_4(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_generation_1(self):
-        TestStatementsBase.test_scruffy_generation_1(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_generation_2(self):
-        TestStatementsBase.test_scruffy_generation_2(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_invalidation_1(self):
-        TestStatementsBase.test_scruffy_invalidation_1(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_invalidation_2(self):
-        TestStatementsBase.test_scruffy_invalidation_2(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_start_1(self):
-        TestStatementsBase.test_scruffy_start_1(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_start_2(self):
-        TestStatementsBase.test_scruffy_start_2(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_start_3(self):
-        TestStatementsBase.test_scruffy_start_3(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_start_4(self):
-        TestStatementsBase.test_scruffy_start_4(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_usage_1(self):
-        TestStatementsBase.test_scruffy_usage_1(self)
-
-    @unittest.expectedFailure
-    def test_scruffy_usage_2(self):
-        TestStatementsBase.test_scruffy_usage_2(self)
-
-
-class TestAttributesBase2(TestAttributesBase):
-    @unittest.expectedFailure
-    def test_entity_with_multiple_attribute(self):
-        TestAttributesBase.test_entity_with_multiple_attribute(self)
-
-    @unittest.expectedFailure
-    def test_entity_with_multiple_value_attribute(self):
-        TestAttributesBase.test_entity_with_multiple_value_attribute(self)
-
-    @unittest.expectedFailure
-    def test_entity_with_one_type_attribute_8(self):
-        TestAttributesBase.test_entity_with_one_type_attribute_8(self)
-
-
-class AllTestsBase(
-    TestExamplesBase, TestStatementsBase2, TestQualifiedNamesBase, TestAttributesBase2
-):
-    """This is a test to include all available tests."""
-
-    pass
-
-
 class TestRDFSerializer(unittest.TestCase):
     def test_decoding_unicode_value(self):
         unicode_char = "\u2019"
@@ -201,31 +91,23 @@ class TestRDFSerializer(unittest.TestCase):
         self.assertIn(unicode_char, e1.get_attribute("prov:label"))
 
     def test_serialize_without_a_document_raises(self):
-        from prov.serializers.provrdf import ProvRDFException, ProvRDFSerializer
-
         serializer = ProvRDFSerializer(document=None)
         with self.assertRaises(ProvRDFException) as ctx:
             serializer.serialize(BytesIO())
         self.assertIn("No document to serialize", str(ctx.exception))
 
     def test_literal_rdf_representation_langtag(self):
-        from prov.serializers.provrdf import literal_rdf_representation
-
         literal = pm.Literal("bonjour", langtag="fr")
         rdf_literal = literal_rdf_representation(literal)
         self.assertEqual(str(rdf_literal), "bonjour")
         self.assertEqual(rdf_literal.language, "fr")
 
     def test_literal_rdf_representation_base64binary(self):
-        from prov.serializers.provrdf import literal_rdf_representation
-
         literal = pm.Literal("aGVsbG8=", datatype=pm.XSD["base64Binary"])
         rdf_literal = literal_rdf_representation(literal)
         self.assertEqual(str(rdf_literal), "aGVsbG8=")
 
     def test_literal_rdf_representation_without_datatype_raises(self):
-        from prov.serializers.provrdf import literal_rdf_representation
-
         with self.assertRaises(ValueError):
             literal_rdf_representation(pm.Literal("no datatype, no langtag"))
 
@@ -258,10 +140,6 @@ class TestRDFSerializer(unittest.TestCase):
         # everywhere it is called internally; passing one explicitly (as an
         # external caller might) must reuse it rather than creating a new
         # ConjunctiveGraph.
-        from rdflib.graph import ConjunctiveGraph
-
-        from prov.serializers.provrdf import ProvRDFSerializer
-
         doc = ProvDocument()
         doc.add_namespace("ex", "http://example.org/")
         doc.entity("ex:e1")
@@ -277,11 +155,6 @@ class TestRDFSerializer(unittest.TestCase):
         # decode_document()'s `hasattr(content, "contexts")` branch is False
         # for a plain rdflib Graph (as opposed to a ConjunctiveGraph), which
         # every other test in this module parses into.
-        from rdflib import RDF, URIRef
-        from rdflib.graph import Graph
-
-        from prov.serializers.provrdf import ProvRDFSerializer
-
         graph = Graph()
         graph.add(
             (
@@ -303,11 +176,6 @@ class TestRDFSerializer(unittest.TestCase):
         # TriG output, so a re-parsed document may name a bundle context by
         # an IRI matching no registered namespace; decode_document() must
         # fall back to compute_qname instead of raising ProvException.
-        from rdflib import RDF, URIRef
-        from rdflib.graph import ConjunctiveGraph
-
-        from prov.serializers.provrdf import ProvRDFSerializer
-
         content = ConjunctiveGraph()
         bundle_graph = content.get_context(URIRef("http://example.org/bundle1"))
         bundle_graph.add(
@@ -445,10 +313,6 @@ class TestRDFSerializer(unittest.TestCase):
                 raise e
                 # errors.append((e, idx, fname, in_first, in_second))
         self.assertFalse(errors)
-
-
-class RoundTripRDFTests(RoundTripTestCase, AllTestsBase):
-    FORMAT = "rdf"
 
 
 if __name__ == "__main__":

--- a/src/prov/tests/test_statements.py
+++ b/src/prov/tests/test_statements.py
@@ -2,14 +2,38 @@
 
 Migrated from the ``TestStatementsBase`` mixin (``statements.py``): each test
 method becomes a module-level function taking the ``roundtrip`` fixture, which
-runs it once per target in ``SHARED_TARGETS`` (model + json this step). The
-legacy mixin remains for the not-yet-migrated xml/rdf/dot modules.
+runs it once per target in ``SHARED_TARGETS`` (model/json/xml/rdf). The 14
+"scruffy" cases opt out of the shared ``fmt`` fixture with their own explicit
+parametrization so the rdf param can be skipped (issue #217; see the
+``scruffy_fmt`` decorator below). The legacy mixin remains for the
+not-yet-migrated ``test_dot.py``.
 """
+
+import pytest
 
 from prov.model import *
 
 EX_NS = Namespace("ex", "http://example.org/")
 EX2_NS = Namespace("ex2", "http://example2.org/")
+
+# The 14 "scruffy" documents below add two relations sharing one identifier
+# but differing prov:time; PROV-O cannot represent this (both times serialize
+# onto the one qualified IRI, and deserialization then raises ProvException:
+# "Cannot have more than one value for attribute prov:time"). This is an
+# accepted PROV-O representational limitation, not a bug on a fix path, so the
+# rdf param is skipped rather than xfailed (design doc §2/§3, issue #217).
+RDF_SCRUFFY_SKIP = pytest.mark.skip(
+    reason="PROV-O cannot represent same-identifier relations differing by "
+    "prov:time — accepted limitation, issue #217",
+)
+
+# These functions opt out of the module-wide `fmt` fixture (see conftest.py)
+# with their own explicit parametrization so the skip mark attaches only to
+# the rdf param; model/json/xml still run normally.
+scruffy_fmt = pytest.mark.parametrize(
+    "fmt",
+    ["model", "json", "xml", pytest.param("rdf", marks=RDF_SCRUFFY_SKIP)],
+)
 
 
 def new_document():
@@ -1316,6 +1340,7 @@ def test_membership_3(roundtrip):
 
 
 # SCRUFFY
+@scruffy_fmt
 def test_scruffy_generation_1(roundtrip):
     document = new_document()
     document.generation(
@@ -1335,6 +1360,7 @@ def test_scruffy_generation_1(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_generation_2(roundtrip):
     document = new_document()
     gen1 = document.generation(
@@ -1356,6 +1382,7 @@ def test_scruffy_generation_2(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_invalidation_1(roundtrip):
     document = new_document()
     document.invalidation(
@@ -1375,6 +1402,7 @@ def test_scruffy_invalidation_1(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_invalidation_2(roundtrip):
     document = new_document()
     inv1 = document.invalidation(
@@ -1396,6 +1424,7 @@ def test_scruffy_invalidation_2(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_usage_1(roundtrip):
     document = new_document()
     document.usage(
@@ -1415,6 +1444,7 @@ def test_scruffy_usage_1(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_usage_2(roundtrip):
     document = new_document()
     use1 = document.usage(
@@ -1436,6 +1466,7 @@ def test_scruffy_usage_2(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_start_1(roundtrip):
     document = new_document()
     document.start(
@@ -1455,6 +1486,7 @@ def test_scruffy_start_1(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_start_2(roundtrip):
     document = new_document()
     start1 = document.start(
@@ -1476,6 +1508,7 @@ def test_scruffy_start_2(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_start_3(roundtrip):
     document = new_document()
     start1 = document.start(
@@ -1501,6 +1534,7 @@ def test_scruffy_start_3(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_start_4(roundtrip):
     document = new_document()
     start1 = document.start(
@@ -1527,6 +1561,7 @@ def test_scruffy_start_4(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_end_1(roundtrip):
     document = new_document()
     document.end(
@@ -1546,6 +1581,7 @@ def test_scruffy_end_1(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_end_2(roundtrip):
     document = new_document()
     end1 = document.end(
@@ -1567,6 +1603,7 @@ def test_scruffy_end_2(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_end_3(roundtrip):
     document = new_document()
     end1 = document.end(
@@ -1592,6 +1629,7 @@ def test_scruffy_end_3(roundtrip):
     roundtrip(document)
 
 
+@scruffy_fmt
 def test_scruffy_end_4(roundtrip):
     document = new_document()
     end1 = document.end(

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -1,6 +1,5 @@
 import contextlib
 import difflib
-import glob
 import inspect
 import io
 import os
@@ -12,8 +11,11 @@ from lxml import etree
 import prov.model as prov
 from prov.constants import PROV
 from prov.identifier import Namespace, QualifiedName
-from prov.tests.test_model import AllTestsBase
-from prov.tests.utility import RoundTripTestCase
+from prov.serializers.provxml import (
+    ProvXMLException,
+    ProvXMLSerializer,
+    xml_qname_to_QualifiedName,
+)
 
 EX_NS = ("ex", "http://example.com/ns/ex#")
 EX_TR = ("tr", "http://example.com/ns/tr#")
@@ -397,16 +399,12 @@ class ProvXMLSerializerErrorsTestCase(unittest.TestCase):
     serializers/provxml.py)."""
 
     def test_serialize_without_a_document_raises(self):
-        from prov.serializers.provxml import ProvXMLException, ProvXMLSerializer
-
         serializer = ProvXMLSerializer(document=None)
         with self.assertRaises(ProvXMLException) as ctx:
             serializer.serialize(io.BytesIO())
         self.assertIn("No document to serialize", str(ctx.exception))
 
     def test_non_prov_top_level_element_raises(self):
-        from prov.serializers.provxml import ProvXMLException
-
         xml_string = """<?xml version="1.0" encoding="UTF-8"?>
         <prov:document
             xmlns:prov="http://www.w3.org/ns/prov#"
@@ -452,11 +450,6 @@ class ProvXMLSerializerErrorsTestCase(unittest.TestCase):
         self.assertEqual(list(e1.get_attribute("ex:version")), ["2"])
 
     def test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises(self):
-        from prov.serializers.provxml import (
-            ProvXMLException,
-            xml_qname_to_QualifiedName,
-        )
-
         element = etree.fromstring(
             '<root xmlns:ex="http://example.com/ns/ex#"><child/></root>'
         )
@@ -467,6 +460,17 @@ class ProvXMLSerializerErrorsTestCase(unittest.TestCase):
 
 
 class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
+    """Scaffolding for a per-file XML round-trip glob, left disabled.
+
+    Deserializing then re-serializing PROV-XML does not maintain XML
+    equivalence (e.g. prov:entity elements with type prov:Plan become
+    prov:plan elements), so no test methods are attached to this class.
+    Re-enabling it is a possible future coverage chore (2.4.0 window /
+    conformance phase), explicitly out of scope for the pytest-matrix
+    migration -- see design doc §4 Decision 3
+    (docs/superpowers/specs/2026-07-06-test-suite-redesign.md).
+    """
+
     def _perform_round_trip(self, filename, force_types=False):
         document = prov.ProvDocument.deserialize(source=filename, format="xml")
 
@@ -475,52 +479,6 @@ class ProvXMLRoundTripFromFileTestCase(unittest.TestCase):
                 format="xml", destination=new_xml, force_types=force_types
             )
             compare_xml(filename, new_xml)
-
-
-# Add one test for each found file. Lazy way to do metaprogramming...
-# I think parametrized tests are justified in this case as the test
-# function names make it clear what is going on.
-for filename in glob.iglob(os.path.join(DATA_PATH, "*" + os.path.extsep + "xml")):
-    name = os.path.splitext(os.path.basename(filename))[0]
-    test_name = f"test_roundtrip_from_xml_{name}"
-
-    # Cannot round trip this one as the namespace in the PROV data model are
-    # always defined per bundle and not per element.
-    if name in (
-        "nested_default_namespace",
-        "nested_changing_default_namespace",
-        "namespace_redefined_but_does_not_change",
-        "namespace_redefined",
-    ):
-        continue
-
-    # Python creates closures on function calls...
-    def get_fct(f):
-        # `name` is the outer loop variable, but it is only read here,
-        # synchronously, on the same iteration it was set -- not from the
-        # returned `fct` closure below, so late-binding is not an issue.
-        force_types = name in ["pc1"]  # noqa: B023
-
-        def fct(self):
-            self._perform_round_trip(f, force_types=force_types)
-
-        # `fct` here is this function's own name (defined two lines above),
-        # not the outer loop's `fct` variable assigned below.
-        return fct  # noqa: B023
-
-    fct = get_fct(filename)
-    fct.__name__ = str(test_name)
-
-    # Disabled round-trip XML comparisons since deserializing then serializing
-    # PROV-XML does not maintain XML equivalence. (For example, prov:entity
-    # elements with type prov:Plan become prov:plan elements)
-    # TODO: Revisit these tests
-
-    # setattr(ProvXMLRoundTripFromFileTestCase, test_name, fct)
-
-
-class RoundTripXMLTests(RoundTripTestCase, AllTestsBase):
-    FORMAT = "xml"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends the pytest-native shared matrix (from #220) to the XML and RDF formats, retires the legacy per-format round-trip classes, and moves the 17 `expectedFailure` markers to per-param `skip`/`xfail` marks per the approved design doc (`docs/superpowers/specs/2026-07-06-test-suite-redesign.md` §2–§4). Only `test_dot.py` now remains on the legacy mixins (Task 12).

## What changed

- **`conftest.py`** — `ROUNDTRIP_FORMATS = ("json", "xml", "rdf")`, so `SHARED_TARGETS = ("model", "json", "xml", "rdf")`. Every shared statement/attribute/qname/example case now runs across all four targets.
- **17 markers moved into the shared modules** as per-param marks on the `rdf` axis (design §2/§3):
  - **14 scruffy** (`test_statements.py`) → `pytest.mark.skip` ref **#217** (PROV-O can't represent same-identifier relations differing by `prov:time`; running them raises `ProvException`, so skip not xfail).
  - **decimal** — `attr-8` extracted into its own `test_entity_with_one_type_attribute_decimal` → strict `xfail` ref **#77**.
  - **2 multi-datatype** (`test_entity_with_multiple_attribute`, `..._value_attribute`) → strict `xfail` ref **#218**.
  - Affected functions opt out of the auto `fmt` fixture via explicit `@pytest.mark.parametrize("fmt", [..., pytest.param("rdf", marks=...)])` so the mark stays local to the rdf case; model/json/xml still run normally.
- **`test_xml.py`** — `RoundTripXMLTests` deleted; the 15 XML-specific tests (`ProvXMLTestCase` + `ProvXMLSerializerErrorsTestCase`) kept, `compare_xml`/`remove_empty_tags` as module helpers, 3 function-local imports normalised to module level. The disabled file-glob round-trip block stays disabled (design §4 Decision 3); the dead commented metaprogramming loop removed with a pointer comment.
- **`test_rdf.py`** — `RoundTripRDFTests`, the rdf-local `AllTestsBase`, `TestStatementsBase2`/`TestAttributesBase2` (the xfail wrappers), and the two example-loop base classes deleted; the 11 RDF-specific `TestRDFSerializer` tests + `find_diff` kept; ~12 function-local imports normalised. `test_json_to_ttl_match` ported faithfully (position-indexed skip lists preserved; filename re-keying deferred, not risked for parity).
- **`test_examples.py`** — the `datatypes` example is skipped on the `rdf` target only (mixed-XSD-datatype attribute set, same #218 root cause), preserving pre-migration `continue` behaviour with a documented comment.
- **CLAUDE.md** — Tests section updated (JSON/XML/RDF/model migrated; only dot legacy; the mark mechanism documented).

## Parity (user-gate evidence)

Collected total constant at **1102**; the run tally shifts exactly as the design doc §4 authorises (14 scruffy `expectedFailure`→`skip`, 3 fidelity stay `xfail`):

| | baseline | migrated |
|---|---|---|
| `pytest --collect-only` | 1102 | **1102** |
| `pytest` | 1085 passed / 17 xfailed / 0 skipped | **1085 passed / 3 xfailed / 14 skipped** |
| coverage | 97%+ | **98%** |

`grep -c expectedFailure test_rdf.py` → 0. No XPASS (strict xfails confirm the bugs are still open). Gates (`ruff`, `ruff format`, `mypy`, full suite) all green.

Shared-module collect after enabling xml/rdf: `test_statements` 588, `test_attributes` 120, `test_qnames` 28, `test_examples` 4 (= 185 × 4 targets = 740); `test_xml` 15, `test_rdf` 11, `test_dot` 191 (unchanged), plus model/json/other = 1102.