### PR TITLE
test: property-based round-trip tests with Hypothesis

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
+        env:
+          # Use the bounded, deterministic Hypothesis profile for the
+          # property-based round-trip tests (registered in conftest.py) so they
+          # add a small, predictable amount of time to the CI matrix.
+          HYPOTHESIS_PROFILE: ci
         run: |
           uv sync --locked --extra rdf --extra xml --group dev
           uv run coverage run -m pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,15 @@ once and parametrized over a format matrix rather than copy-pasted per serialize
   This replaced a pre-redesign scaffold that re-rendered all 185 shared statement/attribute
   documents through dot on every run — a real but disproportionate rendering cost for coverage
   duplicated by the `model`/`json`/`xml`/`rdf` targets above.
+- `strategies.py` / `test_property_roundtrip.py` — Hypothesis property-based round-trip tests.
+  `strategies.prov_documents` generates valid PROV documents (multiple namespaces, mixed-type
+  attributes, the full relation set, optionally a sub-bundle) and the property asserts
+  `deserialize(serialize(doc)) == doc` for each `ROUNDTRIP_FORMATS` target (json/xml/rdf; PROV-N
+  is write-only). Known-lossy constructs are excluded at generation time, each commented with its
+  issue (#77/#217/#218 plus the empty-string-through-XML and xsd:float RDF-precision losses this
+  work surfaced), keeping the property honest under the 2.x output freeze. Hypothesis profiles are
+  registered in `conftest.py` and selected via `HYPOTHESIS_PROFILE`; CI sets `HYPOTHESIS_PROFILE=ci`
+  (bounded `max_examples`, deterministic) while the local `default` profile is exploratory.
 
 When adding a new shared record type, attribute, or serializer behavior, add it to the
 pytest-native shared modules above so every target is exercised, rather than writing per-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ prov = ["py.typed"]
 [dependency-groups]
 dev = [
     "coverage>=7.6.10",
+    "hypothesis>=6.156.1",
     "lxml-stubs>=0.5.1",
     "mypy>=1.19.1",
     "pre-commit>=4.0.1",

--- a/src/prov/tests/conftest.py
+++ b/src/prov/tests/conftest.py
@@ -9,10 +9,22 @@ non-serializing ``model`` target.
 """
 
 import io
+import os
 
 import pytest
+from hypothesis import settings
 
 from prov.model import ProvDocument
+
+# Hypothesis profiles for the property-based round-trip tests
+# (``test_property_roundtrip.py``). The local ``default`` profile is
+# exploratory; the ``ci`` profile is bounded and deterministic so the property
+# tests add a predictable, small amount of wall-clock time to the CI matrix.
+# The active profile is chosen from the ``HYPOTHESIS_PROFILE`` env var (CI sets
+# it to ``ci``); it defaults to ``default`` when unset.
+settings.register_profile("default", max_examples=200, deadline=None)
+settings.register_profile("ci", max_examples=50, deadline=None, derandomize=True)
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))
 
 # Formats that support a full serialize -> deserialize -> compare round trip.
 ROUNDTRIP_FORMATS = ("json", "xml", "rdf")

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -1,0 +1,266 @@
+"""Hypothesis strategies that generate valid PROV documents.
+
+These feed ``test_property_roundtrip.py``: the composite ``prov_documents``
+strategy builds a :class:`~prov.model.ProvDocument` containing multiple
+namespaces, elements (entities/activities/agents) with mixed attribute types,
+the full relation set drawn over the generated identifiers, and — optionally —
+one named sub-bundle populated the same way.
+
+Every construct generated here is expected to survive a
+serialize -> deserialize round trip through *all* deserializable formats
+(json, xml, rdf). Known-lossy constructs are deliberately excluded, each with a
+comment linking the tracking issue, so that a property failure signals a *new*
+bug rather than a documented one. See the exclusions inline below.
+"""
+
+import string
+from datetime import datetime, timezone
+
+from hypothesis import strategies as st
+
+from prov.identifier import Namespace
+from prov.model import ProvBundle, ProvDocument
+
+# A small fixed set of namespaces registered on every generated document, so
+# documents exercise multi-namespace prefix handling (criterion 1).
+NAMESPACES = {
+    "ex": "http://example.org/",
+    "ex2": "http://example.com/ns2/",
+    "ex3": "http://example.net/ns3#",
+}
+# Reused to build QualifiedName *attribute values* below; equal (prefix + uri)
+# to the "ex" namespace registered on each document, so it resolves cleanly.
+EX_NS = Namespace("ex", NAMESPACES["ex"])
+
+# Local parts used for identifiers and prefixes are kept to a simple ascii
+# alphabet. #223: PROV-N does not escape qname metacharacters (' ) , ( : ; [ ] =)
+# in local parts. PROV-N is write-only and therefore out of the round-trip
+# property, but keeping identifier local parts simple avoids depending on that
+# behaviour at all. Non-ASCII deliberately lives in the string attribute
+# *values* below (criterion 1), never in identifiers.
+local_part = st.text(
+    alphabet=string.ascii_lowercase + string.digits, min_size=1, max_size=8
+)
+
+# Text attribute values may contain non-ASCII. Surrogates (Cs) cannot be encoded
+# to UTF-8, and control characters (Cc) make the XML writer raise
+# ``ValueError: All strings must be XML compatible...`` (an uncaught exception,
+# not a serializer behaviour we could round-trip; RDF handles every Cc codepoint
+# unchanged). Excluding both is a generation-validity narrowing (not a serializer
+# behaviour change) — the values that remain still cover the full non-ASCII range.
+# min_size=1: an *empty*-string attribute value is dropped entirely by the XML
+# serializer (the attribute vanishes on round trip), while JSON and RDF preserve
+# it — #224, a genuine XML round-trip bug deferred to 3.0, excluded here rather
+# than fixed under the 2.x output freeze.
+text_values = st.text(
+    alphabet=st.characters(exclude_categories=("Cs", "Cc")),
+    min_size=1,
+    max_size=30,
+)
+
+attr_values = st.one_of(
+    text_values,  # str, including non-ASCII
+    st.integers(min_value=-(2**31), max_value=2**31),
+    st.booleans(),
+    # Floats. PROV types a Python ``float`` as xsd:float (single precision), and
+    # RDF canonicalises xsd:float to a short decimal, so an arbitrary float does
+    # NOT survive the RDF round trip (e.g. 0.1 and large-magnitude values come
+    # back changed) even with width=32 — #225, a genuine RDF float-precision loss
+    # deferred to 3.0. JSON/XML keep the full repr and are unaffected. We
+    # therefore restrict generation to eighth-step dyadic rationals of modest
+    # magnitude (|v| <= 8192): exactly representable in float32 with a short
+    # exact decimal, empirically round-tripping cleanly through all three
+    # formats while still exercising the xsd:float datatype with fractional
+    # values. #77 (no Decimal values are generated) is covered for the same
+    # reason: xsd:decimal fidelity is lost through RDF.
+    st.integers(min_value=-(8192 * 8), max_value=8192 * 8).map(lambda n: n / 8.0),
+    # Timezone-aware UTC datetimes; PROV serialises these as xsd:dateTime.
+    st.datetimes(min_value=datetime(1900, 1, 1), max_value=datetime(2100, 1, 1)).map(
+        lambda dt: dt.replace(tzinfo=timezone.utc)
+    ),
+    # QualifiedName values, drawn from the registered "ex" namespace.
+    local_part.map(lambda s: EX_NS[s]),
+)
+
+
+def _attribute_dict(draw) -> dict:
+    """Draw a dict of ``ex:<key> -> value`` other-attributes.
+
+    #218: multiple values / mixed datatypes on a *single* attribute key lose
+    datatype fidelity through RDF. Using a dict guarantees unique keys, so no
+    key is ever emitted twice with differing datatypes.
+    """
+    keys = draw(st.lists(local_part, min_size=0, max_size=4, unique=True))
+    return {f"ex:k{key}": draw(attr_values) for key in keys}
+
+
+def _draw_ids(draw, tag: str) -> list[str]:
+    """Draw a list of unique element identifiers with a role-specific prefix.
+
+    Prefixing by role (``e``/``a``/``g``) keeps entity, activity and agent
+    identifiers disjoint even when their local parts collide, so no two
+    elements of different kinds ever share an identifier.
+    """
+    names = draw(st.lists(local_part, min_size=1, max_size=3, unique=True))
+    return [f"ex:{tag}{name}" for name in names]
+
+
+# Optional formal time on time-bearing relations, mirroring the datetime values.
+_rel_time = st.one_of(
+    st.none(),
+    st.datetimes(min_value=datetime(1900, 1, 1), max_value=datetime(2100, 1, 1)).map(
+        lambda dt: dt.replace(tzinfo=timezone.utc)
+    ),
+)
+
+
+def _populate(draw, container: ProvBundle) -> list[str]:
+    """Add elements and relations to ``container`` (a document or a bundle).
+
+    Returns the entity identifiers drawn for ``container`` so the caller can
+    wire up cross-bundle relations (mentionOf) that reference them.
+    """
+    entities = _draw_ids(draw, "e")
+    activities = _draw_ids(draw, "a")
+    agents = _draw_ids(draw, "g")
+    all_ids = entities + activities + agents
+
+    for eid in entities:
+        container.entity(eid, _attribute_dict(draw))
+    for aid in activities:
+        # Optional start/end times on the activity itself.
+        start = draw(_rel_time)
+        end = draw(_rel_time)
+        container.activity(aid, start, end, _attribute_dict(draw))
+    for gid in agents:
+        container.agent(gid, _attribute_dict(draw))
+
+    def pick(pool: list[str]) -> str:
+        return draw(st.sampled_from(pool))
+
+    def times() -> int:
+        return draw(st.integers(min_value=0, max_value=2))
+
+    # The full relation set, drawn over the generated identifiers, all created
+    # *without* an explicit relation identifier (anonymous). mentionOf is the one
+    # relation not created here: it is inherently cross-bundle (it references
+    # another bundle's identifier), so `prov_documents` emits it separately once
+    # a sub-bundle has been drawn.
+    #
+    # #217: PROV-O cannot represent two relations of the same kind between the
+    # same primary endpoints that differ only in a *qualifying* formal attribute
+    # (e.g. prov:time) — one collapses or loses an attribute on the RDF round
+    # trip. Anonymity alone does NOT avoid this. We therefore keep at most one
+    # relation of each kind per (endpoint1, endpoint2) pair (the `fresh` guard
+    # below), which is exactly the construct #217 tracks; excluding it is a
+    # generation-validity narrowing, not a serializer change. The guard is
+    # deliberately conservative — broader than #217's exact same-identifier
+    # shape — because it also forecloses #226-style collapse: it suppresses e.g.
+    # two `association`s sharing (activity, agent) but differing by `plan`.
+    # Those non-delegation qualified variants (association `plan`, start/end
+    # `starter`/`ender`) were verified to round-trip cleanly, so the guard
+    # forecloses #217/#226-style loss without masking any other known bug.
+    seen: set[tuple[str, str, str]] = set()
+
+    def fresh(kind: str, e1: str, e2: str) -> bool:
+        key = (kind, e1, e2)
+        if key in seen:
+            return False
+        seen.add(key)
+        return True
+
+    for _ in range(times()):
+        e, a = pick(entities), pick(activities)
+        if fresh("gen", e, a):
+            container.generation(e, a, time=draw(_rel_time))
+    for _ in range(times()):
+        a, e = pick(activities), pick(entities)
+        if fresh("use", a, e):
+            container.usage(a, e, time=draw(_rel_time))
+    for _ in range(times()):
+        a1, a2 = pick(activities), pick(activities)
+        if fresh("com", a1, a2):
+            container.communication(a1, a2)
+    for _ in range(times()):
+        a, e = pick(activities), pick(entities)
+        if fresh("start", a, e):
+            container.start(a, e, pick(activities), time=draw(_rel_time))
+    for _ in range(times()):
+        a, e = pick(activities), pick(entities)
+        if fresh("end", a, e):
+            container.end(a, e, pick(activities), time=draw(_rel_time))
+    for _ in range(times()):
+        e, a = pick(entities), pick(activities)
+        if fresh("inv", e, a):
+            container.invalidation(e, a, time=draw(_rel_time))
+    for _ in range(times()):
+        e1, e2 = pick(entities), pick(entities)
+        if fresh("der", e1, e2):
+            container.derivation(e1, e2)
+    for _ in range(times()):
+        e, g = pick(entities), pick(agents)
+        if fresh("attr", e, g):
+            container.attribution(e, g)
+    for _ in range(times()):
+        a, g = pick(activities), pick(agents)
+        if fresh("assoc", a, g):
+            container.association(a, g, pick(entities))
+    for _ in range(times()):
+        g1, g2 = pick(agents), pick(agents)
+        if fresh("deleg", g1, g2):
+            # No qualifying activity: #226. Qualified delegation is lost through
+            # RDF when two anonymous delegations share the same delegate AND
+            # qualifying activity but differ in responsible — the
+            # qualifiedDelegation blank nodes are keyed on (delegate, activity),
+            # which the endpoint-pair `fresh` guard cannot prevent (distinct from
+            # #217, which is about relations sharing an explicit identifier).
+            # Every other relation qualifier (relation prov:time,
+            # association plan, start/end starter/ender) round-trips fine and is
+            # kept. Omitting only delegation's activity keeps the relation type
+            # in the corpus without depending on that RDF-lossy construct.
+            container.delegation(g1, g2)
+    for _ in range(times()):
+        x1, x2 = pick(all_ids), pick(all_ids)
+        if fresh("infl", x1, x2):
+            container.influence(x1, x2)
+    for _ in range(times()):
+        e1, e2 = pick(entities), pick(entities)
+        if fresh("spec", e1, e2):
+            container.specialization(e1, e2)
+    for _ in range(times()):
+        e1, e2 = pick(entities), pick(entities)
+        if fresh("alt", e1, e2):
+            container.alternate(e1, e2)
+    for _ in range(times()):
+        e1, e2 = pick(entities), pick(entities)
+        if fresh("mem", e1, e2):
+            container.membership(e1, e2)
+
+    return entities
+
+
+@st.composite
+def prov_documents(draw) -> ProvDocument:
+    """Generate a valid PROV document for round-trip property testing."""
+    doc = ProvDocument()
+    for prefix, uri in NAMESPACES.items():
+        doc.add_namespace(prefix, uri)
+
+    doc_entities = _populate(draw, doc)
+
+    # Optionally one named sub-bundle, populated the same way. When a bundle is
+    # drawn, also emit anonymous cross-bundle mentionOf relations completing the
+    # 14-relation set: mention(specific, general, bundle) references a
+    # document-level entity as the general entity described in the sub-bundle.
+    # Guarded on the document having drawn at least one entity.
+    if draw(st.booleans()):
+        bundle_id = f"ex:b{draw(local_part)}"
+        bundle = doc.bundle(bundle_id)
+        _populate(draw, bundle)
+        if doc_entities:
+            for _ in range(draw(st.integers(min_value=0, max_value=2))):
+                specific = draw(st.sampled_from(doc_entities))
+                general = draw(st.sampled_from(doc_entities))
+                doc.mention(specific, general, bundle_id)
+
+    return doc

--- a/src/prov/tests/test_property_roundtrip.py
+++ b/src/prov/tests/test_property_roundtrip.py
@@ -1,0 +1,26 @@
+"""Property-based round-trip tests over Hypothesis-generated PROV documents.
+
+The ``prov_documents`` strategy (see ``strategies.py``) generates valid PROV
+documents; this module asserts that each one survives a serialize ->
+deserialize round trip through every *deserializable* format. PROV-N is
+write-only (no parser), so it is excluded — the format axis is
+``ROUNDTRIP_FORMATS`` (json, xml, rdf), reusing the same ``roundtrip_document``
+helper the example-based shared tests use.
+
+Example counts and determinism are controlled by the Hypothesis profile
+selected in ``conftest.py`` via ``HYPOTHESIS_PROFILE`` (CI uses the bounded
+``ci`` profile).
+"""
+
+import pytest
+from hypothesis import given
+
+from .conftest import ROUNDTRIP_FORMATS, roundtrip_document
+from .strategies import prov_documents
+
+
+@pytest.mark.parametrize("fmt", ROUNDTRIP_FORMATS)
+@given(doc=prov_documents())
+def test_generated_document_roundtrips(doc, fmt):
+    """A generated document equals itself after a serialize/deserialize cycle."""
+    assert roundtrip_document(doc, fmt) == doc

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -8,6 +8,7 @@ only the genuinely RDF-specific cases.
 
 import logging
 import os
+import struct
 from glob import glob
 from io import BytesIO, StringIO
 
@@ -24,6 +25,7 @@ from prov.serializers.provrdf import (
     ProvRDFSerializer,
     literal_rdf_representation,
 )
+from prov.tests.conftest import roundtrip_document
 
 logger = logging.getLogger(__name__)
 
@@ -314,3 +316,41 @@ def test_json_to_ttl_match():
             raise e
             # errors.append((e, idx, fname, in_first, in_second))
     assert not errors
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="#225: PROV types a Python float as xsd:float (single precision) and "
+    "RDF canonicalises it to a short decimal, so a precision-carrying float32 "
+    "value comes back changed (JSON/XML keep the full repr). Regression guard "
+    "from the Hypothesis property tests; remove when #225 is fixed in 3.0.",
+)
+def test_float_precision_survives_rdf_roundtrip():
+    # 0.1 narrowed to float32 -> 0.10000000149011612; RDF writes "1e-01",
+    # which reloads as 0.1, so the value is lost.
+    value = struct.unpack("f", struct.pack("f", 0.1))[0]
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e0", {"ex:k0": value})
+    assert roundtrip_document(document, "rdf") == document
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="#226: two qualified delegations sharing the same delegate and "
+    "qualifying activity but differing in responsible collapse through RDF -- "
+    "one loses its responsible (the qualifiedDelegation blank nodes are keyed "
+    "on delegate+activity). Regression guard from the Hypothesis property "
+    "tests; remove when #226 is fixed in 3.0.",
+)
+def test_qualified_delegation_pair_survives_rdf_roundtrip():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.agent("ex:g0")
+    document.agent("ex:g1")
+    document.activity("ex:a")
+    document.delegation("ex:g0", "ex:g1", "ex:a")
+    document.delegation("ex:g0", "ex:g0", "ex:a")
+    assert roundtrip_document(document, "rdf") == document

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -16,6 +16,7 @@ from prov.serializers.provxml import (
     ProvXMLSerializer,
     xml_qname_to_QualifiedName,
 )
+from prov.tests.conftest import roundtrip_document
 
 EX_NS = ("ex", "http://example.com/ns/ex#")
 EX_TR = ("tr", "http://example.com/ns/tr#")
@@ -465,6 +466,21 @@ def test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises():
     with pytest.raises(ProvXMLException) as ctx:
         xml_qname_to_QualifiedName(child, "noColonNoDefaultNs")
     assert "Could not create a valid QualifiedName" in str(ctx.value)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="#224: the XML serializer drops an attribute whose value is the "
+    "empty string; it vanishes on the round trip (JSON and RDF preserve it). "
+    "Regression guard from the Hypothesis property tests; remove when #224 is "
+    "fixed in 3.0.",
+)
+def test_empty_string_attribute_survives_xml_roundtrip():
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.agent("ex:g0", {"ex:k0": ""})
+    assert roundtrip_document(document, "xml") == document
 
 
 # Scaffolding for a per-file XML round-trip glob, left disabled.

--- a/uv.lock
+++ b/uv.lock
@@ -610,6 +610,65 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.156.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/275cf88c757bd96e91844d9b3aab3bc6a5a1942b70f75df255a3d2114518/hypothesis-6.156.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6ea5a7f3934daa5f81960271d5efbb9ac69871ac3cb2c027b8ce33e69a792e65", size = 749534, upload-time = "2026-07-03T14:31:00.668Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/cf/e657b924ab6f24f29841ad2e461775a0f048c24013df5be5099be98303ca/hypothesis-6.156.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ad6e5960b36452f3b904a3849e85c62377cf4ecc904541706c934dae439ce933", size = 743927, upload-time = "2026-07-03T14:30:55.816Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3f/f8dc6a19776d2a92e0a0b6595213ecc16446e41aeee8aa4b8e3bdd258a48/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79b4aa87fbb2e5121a24333906b7b481ddefc0af9d3ccd28463f5504b8d586f2", size = 1071039, upload-time = "2026-07-03T14:30:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1a/60a505991247430fd9e4429526292e2b054381615801f3c7efdfa08dc9fb/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63131c150146b44f49dd6be4d417e1ee62390951403569043e759e8513763426", size = 1120853, upload-time = "2026-07-03T14:30:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/14/83/e2f76554ffa6380fb935f09afe0e36cbedc5063114d58064181e821f091b/hypothesis-6.156.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f8385703ba1a03a09f2b2cbbf418344a82beef51b397101933a67535da7d0e19", size = 1245778, upload-time = "2026-07-03T14:30:49.652Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/b82eaf84529bb15f45166386a11ba2f0d43738b781cb4c1e5fb772546d6e/hypothesis-6.156.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b2e48eb61ddbcb8afbcba849fcffa6411bcef43977a34e55bcea582c9d391c11", size = 1288197, upload-time = "2026-07-03T14:30:16.901Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3d/9e19b368974bfedccdba6916b92fca8446f02018e0954a6e8b756d5450c1/hypothesis-6.156.1-cp310-cp310-win_amd64.whl", hash = "sha256:debc9f5a974e50e5806917cd514cb462f31caa18af94a979f3deb4827f034466", size = 640341, upload-time = "2026-07-03T14:31:11.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0f/102b24707a8e383e659a6b087d7d1369fe3b4bdce9c669b01010c075b835/hypothesis-6.156.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8063082444d4b75b437c8234cd5f5bcd26a25cb9a5db9d19c93dd9bc0b2094a0", size = 749167, upload-time = "2026-07-03T14:31:22.853Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5e/7ce63a67026ff547ac99710723b41447fa83f26ec010c018faee6ff36199/hypothesis-6.156.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a712d98f79b8ef14247ff336c4ce1f81d3958bb80b9f0b5cf61c7afc356d2cb3", size = 743704, upload-time = "2026-07-03T14:30:39.2Z" },
+    { url = "https://files.pythonhosted.org/packages/44/01/04757dea40ea3e3a9da566044bdd176e873149cdfc3903ac18aa3786db86/hypothesis-6.156.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea85fd8ca7be7acbba36c63de7a1450e8e267a29ed3a117a037e638be244c5b6", size = 1070931, upload-time = "2026-07-03T14:31:15.454Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bf/373cb4e14cc5014b33bf2e26720f983cd93da98964397ca92dc7ef07250f/hypothesis-6.156.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7da5067440cdc83e042ee8d60c3b0b76201dace66dd385f9d4057bdeda8c4f15", size = 1120661, upload-time = "2026-07-03T14:31:02.722Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e8/fd9dbacec4532a9c6815d8babeb36e4828673904a0ebc71fc6bb3915e34a/hypothesis-6.156.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:92f70ba9a29970315916f42cea4f708f5f3019665b7f18034acf2d07d1a82476", size = 1245245, upload-time = "2026-07-03T14:31:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/1e372225c844dce2a95c4dc1bf4d41813c14ee7856b0653db168e5714e79/hypothesis-6.156.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49bbeaa5efb1abb596f9e4d3a733be400a8e485db53134ef7cd78b4a3f3c3be7", size = 1287877, upload-time = "2026-07-03T14:30:51.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/1e4ae081682a95c141dde10b708711000cf41a8337504c70537a73c66df2/hypothesis-6.156.1-cp311-cp311-win_amd64.whl", hash = "sha256:b386bb3f149ec238dbc4cbfa8ddbae858ad16f489da62db9e3326c9591efb2d6", size = 640180, upload-time = "2026-07-03T14:30:46.336Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3d/1a0e54652f1b3cad354949ba83f6ab211048ff3a6cfb24edcddc748a8be1/hypothesis-6.156.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0409dea0c0b48705cad8413468282af9c5e7d3a017b6c2b94ef80e7ba4b64862", size = 749005, upload-time = "2026-07-03T14:30:26.045Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/c8b6084023faabef7612ea0169fd4df565fdc5fd73f47484e5edf03640fb/hypothesis-6.156.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72b9305414c20802540ec0cd798478c9e06c8a248ce32d7df04722b64d7150ad", size = 741899, upload-time = "2026-07-03T14:30:34.442Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/51644c53ae055a3a3411906cc8e41e5dd53af487ca76465342256e4f18c1/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40584eed6a57c402d8ab32ea5c1779bae6f7390ff33d073c876e09dc8af31941", size = 1069788, upload-time = "2026-07-03T14:31:24.552Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/43/d2ec198fa56f72f8690563247e5e71a81cf5f1c9c42e977008b76338803f/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76f2aaa6725185f16a8fa7b58e0ba5d5119cafa33eae5e5dec996d6a28cd9dc6", size = 1119541, upload-time = "2026-07-03T14:30:15.15Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/ba8a1bf72988e7b8b743b4f4f30705fe1c2128780a7d93b203cdeb6bae79/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bac95ae29f7850a923f43bc7e21bbc7ee8b8094bbf07691be4f153e537b5d3db", size = 1243864, upload-time = "2026-07-03T14:30:47.869Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a3/f30ebb96f099f19e71361aefb233542f3763a0fb7c0ba3c84513c353b065/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8159b5e93a7724920cf55dd4ec743a84fc9c3c457a6736a92283aa4068f54daa", size = 1286401, upload-time = "2026-07-03T14:30:07.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a9/19b36a5deb78217f4f6214c7be36a14cf2da8b29392199bcd18a0628b9b8/hypothesis-6.156.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8e7deed3bc76c8c12c30e092e228a6978180f2bcab9483f5fb22240cd8eaa7d", size = 637634, upload-time = "2026-07-03T14:30:40.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f7/6f0e4186a6575abddb19047e69cb0042252be27d0be0ddc3528bf3a81edd/hypothesis-6.156.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:da65e6be5461cac9d9d7f98f43d24afb5441932502e4d1b240738aaef84e95d9", size = 749428, upload-time = "2026-07-03T14:31:04.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0c/d45d778b14f22270ac1218faf4ec7de2e9e30d3e40fd91ad86d6b6b5259e/hypothesis-6.156.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:612277e6344defe39012812d5ae620d6323e11fa62c424d64633dfa09caaa387", size = 742070, upload-time = "2026-07-03T14:30:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8a/9c6863eae555c674e3ab2b7ac738f50350d176f88e7a5ac4fe85340b126f/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a593ad462c61f252d661ccc3a1093406cf9ca5a26a6b30cefd8911075d508c8", size = 1069945, upload-time = "2026-07-03T14:30:27.45Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/98/44d9ee83542e5cb50c07387091bd2dcfb2d0f9d7eaadd78357ae0962e76d/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a48cdb91afa09958926a364d241d00b08ece1d105bcd48e0b433428c7b4c29b", size = 1119946, upload-time = "2026-07-03T14:30:58.939Z" },
+    { url = "https://files.pythonhosted.org/packages/09/00/03957d11e4602e60982b535bf107a1995e712e797e32ca5cc9fe53daa11c/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72d4115ed2c4da2cc30189026eacd27c81e0891ec4ba9fff6719e0f47874d65c", size = 1244030, upload-time = "2026-07-03T14:30:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e3/149c3b9de0f9125becdf266af9eba6934885818867c93a457af60d4a3725/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1e1fecee9c79956ac5e7c38cb1d1374bf22fd4066ff6a9664d45d13a09251b1", size = 1286679, upload-time = "2026-07-03T14:30:57.516Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1c/f1a35abd3e5ef45badc3d8a128bb133725f6a93c9aa4eadc27db9d6c54c3/hypothesis-6.156.1-cp313-cp313-win_amd64.whl", hash = "sha256:32f512f6028ab2d4c56208b2edebefe384ab78a5880b098b039c65e9d08b62f7", size = 637909, upload-time = "2026-07-03T14:30:04.12Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/60/f81bc004dafc83f4fd3aee41c65ec6140481a4666495229c0102c636e74b/hypothesis-6.156.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3340f22fd71e615f9bca4499bddd7cc4e0987b08a8b4fc38f688aaac416c2aaf", size = 749464, upload-time = "2026-07-03T14:31:17.171Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/f884c2e908f5a888b22a6606368130fdf822565430e9eefcde5e765640dd/hypothesis-6.156.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19612761d128cd15d41e414389da6b65c1883db1f358025a4c1b2df96ba2dfb0", size = 742283, upload-time = "2026-07-03T14:31:06.23Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2e/8843ca9d7103692c06b912aaa06cc664d3cb3c764a44fb2feeb702b3b704/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c86c00cefcf58793aebb24238247398ad5d9ce281615329293d926d794e6fe5f", size = 1070136, upload-time = "2026-07-03T14:30:19.907Z" },
+    { url = "https://files.pythonhosted.org/packages/62/62/7a1b308b3977e3d3c1920828c5fc5a440caf8036b0d9df2e9ab7722682f8/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:047a0a6613ff06f191d9b1c7623a9b781baddc0fdebad531157d1417fa876627", size = 1120112, upload-time = "2026-07-03T14:31:13.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/7c691582cd5b0de6314fd712ce5e69960985a89e4f619b0c4b36c8845ce2/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9ace8e1e885b20ae129c68ff14e86edd55771a30559561b261a15bd8c17edd36", size = 1244289, upload-time = "2026-07-03T14:31:19.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ac/d15a7a9820ca05ef7a4e8d9dc95e9a0a70cd91fb8d021913888c69801c60/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:eb093affaa2257f9fd2d6542b5e242f5b9512bc1009a4f563ade91e30c298e0c", size = 1287201, upload-time = "2026-07-03T14:30:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ca/dcd80b4606d97b5dba2775526aa89a7735086559c5a80eaf5bf60610bc10/hypothesis-6.156.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:209b76dab690e2182599a83c079475115d69dd2c16aed38a57bb9db376ba4195", size = 586417, upload-time = "2026-07-03T14:30:42.657Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b3/555c291b24b9b1f2e6a712d485ad8c52bbe3e31e79a8a509adc5213e42aa/hypothesis-6.156.1-cp314-cp314-win_amd64.whl", hash = "sha256:1ea0711ac7792e3ade5dfe8a6a762eec64ddb79cd00fe63ff34f17fde0ce8109", size = 637729, upload-time = "2026-07-03T14:31:20.948Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/25f26e0ed769c127b049b4fb8c9378e74d07a37a44c5938e4f6518710ef6/hypothesis-6.156.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9b664a859ed5567bd2c0d804da4d96035e14caa15d91062cc50fcd758dc44111", size = 747497, upload-time = "2026-07-03T14:30:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/62/11/25f20b1cdbd8fc73fd8c0603aa4e817da7384400347f6d63ef569c56111e/hypothesis-6.156.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23acc5f333ce6bd2d888e7c6a33779b5c6cff42dac654f3209e9fa552103c3ba", size = 740841, upload-time = "2026-07-03T14:30:37.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/aa/9967dd9380d72d44a7973f7893383145f04277896554ebb2872ae9658de6/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15762876a64c66bd6ed18eb95fd8018df93b6961eb0b6c25e63409af9cb672c0", size = 1069108, upload-time = "2026-07-03T14:30:06.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6e/27999d70710a1d0d9440c1db59db385c63ed2dccca6ade5fe53258e9566f/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bab29b39b13603583c9874c38907071f333e7af0c48686af8c8f97f7a6a2398", size = 1119177, upload-time = "2026-07-03T14:31:09.67Z" },
+    { url = "https://files.pythonhosted.org/packages/39/45/fbaaae29a5650da6322737eeb085c78a4eb9066f815862c24c63a25dd5eb/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3c8831d5748394cab5ab81b3d469bcc543e7b8e1fc8422ed26a80e16b1e51c1b", size = 1243078, upload-time = "2026-07-03T14:30:10.678Z" },
+    { url = "https://files.pythonhosted.org/packages/53/9d/2db20037da6b206701ec22d6bb67d4393e4807281885663979fe7a5ff869/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:18ef80bdd7422e7823d8da99240c8804708bd44eeeed370fc8a71db56670e1dc", size = 1285519, upload-time = "2026-07-03T14:30:36.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/de/4fbc6afc03cb7098f51bea5be6300c7e13fc679c3c2d12cd40629a27278d/hypothesis-6.156.1-cp314-cp314t-win_amd64.whl", hash = "sha256:122963f511d31fb96254a5b3f0b8e3b9c3b9d2b05e10d9e67eca43e573d52d0f", size = 637822, upload-time = "2026-07-03T14:30:31.248Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4f/7538f785ee0ae5a7e2c959e875b3e48210698d91cc99b5802471d87500bb/hypothesis-6.156.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9d2c65a1294a1e58646f5437cf7924e08ccadf52689e66968960f86d684ecb31", size = 749719, upload-time = "2026-07-03T14:30:24.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/12/af4c5f049c5b3038dcd4f0f488d6b85d09a9a466c03951efbe39af2f9e9e/hypothesis-6.156.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4113a2c5044f79ac961b92e5cbbf4ac6f48ae30a4fd0c8e434fd4b6110041ba9", size = 744324, upload-time = "2026-07-03T14:30:23.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/3b/7734d825fda8fb24b94f10c9b00a8851aa86a387d83490a14d3a3ad5e2a1/hypothesis-6.156.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:953553556920478bad3ed8148ae83a383528ada6b6d5b18d25e20baad45980d3", size = 1071349, upload-time = "2026-07-03T14:30:44.195Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c2/9cd29826a58e88589f2e0603c7f1d4f9251fa4bce6ec3c0ca8d87842f41e/hypothesis-6.156.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2edd308e6907cb31854f8c0879235572c8e9d580bc31291bb1f6246d4242b56b", size = 1121411, upload-time = "2026-07-03T14:30:18.461Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/97/9cadecbfab29d294860b2c892e6c87437ed89611762531addaabae562a07/hypothesis-6.156.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:71a8449f5da886aea7eae097aa8c97fceb5e9e28fb2b268e46e3cbae2ce3cda9", size = 640781, upload-time = "2026-07-03T14:30:33.003Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1756,6 +1815,7 @@ xml = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "hypothesis" },
     { name = "lxml-stubs" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -1788,6 +1848,7 @@ provides-extras = ["rdf", "xml", "plot"]
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.6.10" },
+    { name = "hypothesis", specifier = ">=6.156.1" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.0.1" },
@@ -2045,6 +2106,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Task 13 of the Phase 3 modernisation roadmap (`docs/superpowers/plans/2026-07-05-phase-3-docs-tests-refactor.md`).

Adds a Hypothesis strategy generating valid PROV documents and a property test asserting `deserialize(serialize(doc)) == doc` across every deserializable format (json/xml/rdf; PROV-N is write-only and excluded).

## What is generated
`src/prov/tests/strategies.py` — multiple namespaces; entities/activities/agents with mixed attribute types (str incl. non-ASCII, int, float, bool, tz-aware datetime, QualifiedName); the full 14-relation set (incl. `mentionOf` when a sub-bundle is drawn); optionally one named sub-bundle populated the same way.

## Determinism / CI cost
`conftest.py` registers two Hypothesis profiles selected via `HYPOTHESIS_PROFILE`: `default` (exploratory, `max_examples=200`) and `ci` (`max_examples=50`, `deadline=None`, `derandomize=True`). CI runs the `ci` profile (wired into `CI.yml`). Suite time impact is ~12s (well under the +60s budget).

## Known-lossy constructs excluded from generation
Each exclusion is commented inline with its tracking issue: #77 (xsd:decimal via RDF), #217 (same-identifier relations via PROV-O), #218 (multi-datatype attrs via RDF), #223 (PROV-N metachar escaping).

## New round-trip bugs found (deferred to 3.0 under the 2.x output freeze — no serializer changes here)
The property surfaced three genuine bugs, each now filed AND guarded by a strict-`xfail` regression test that will XPASS-fail (prompting removal) once fixed:
- **#224** — PROV-XML drops attributes whose value is the empty string (`test_xml.py`).
- **#225** — PROV-O round-trip loses `xsd:float` precision (`test_rdf.py`).
- **#226** — PROV-O collapses anonymous qualified delegations sharing (delegate, activity) (`test_rdf.py`).

## Verification
Full suite green (912 passed / 14 skipped / 6 xfailed), coverage 98% (ratchet ≥97), ruff + mypy clean. No serializer or model source touched — only test files and config.