### PR TITLE
feat: degrade serializer registry gracefully without rdf/xml extras

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,21 @@ jobs:
           uv run ruff check src/
           uv run ruff format --check src/
 
+  minimal-install:
+    # Proves the registry degrades cleanly without the optional rdf/xml
+    # extras: `uv sync --group dev` (no --extra rdf/xml) leaves rdflib and
+    # lxml absent, so this exercises the same environment shape a user gets
+    # from a plain `pip install prov`.
+    name: minimal install (no extras)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.2.0
+      - name: Sync without extras
+        run: uv sync --locked --group dev
+      - name: Degradation tests
+        run: uv run --no-sync pytest src/prov/tests/test_minimal_install.py -v
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 -------
 
+2.4.0 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* The serializer registry now degrades gracefully when the optional ``rdf``
+  (``rdflib``) or ``xml`` (``lxml``) extra is not installed: ``import prov``
+  and the JSON/PROV-N serializers work in a minimal install, and requesting
+  the ``rdf``/``xml`` format raises an informative ``DoNotExist`` naming the
+  missing extra instead of a bare ``ModuleNotFoundError``. (#230)
+
 2.3.0 (2026-07-05)
 ^^^^^^^^^^^^^^^^^^
 * **Dropped Python 3.9 support; minimum is now Python 3.10** (security fixes

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -77,24 +77,49 @@ class Registry:
 
     @staticmethod
     def load_serializers() -> None:
-        """Populate :attr:`serializers` with the four built-in serializer classes.
+        """Load all serializers whose optional dependencies are installed.
 
-        Imports the ``json``, ``rdf``, ``provn``, and ``xml`` serializer
-        modules lazily (to avoid import cycles) and (re-)registers them in
-        :attr:`serializers`, unconditionally overwriting any previous
-        contents.
+        ``json`` and ``provn`` have no optional dependencies and are always
+        registered. ``rdf`` (needs ``rdflib``) and ``xml`` (needs ``lxml``)
+        are registered only if their extra is installed, so that ``import
+        prov`` and JSON/PROV-N work in a minimal install; requesting an
+        unavailable format then raises an informative :class:`DoNotExist`
+        (see :func:`get`) rather than a bare ``ModuleNotFoundError``.
+
+        The insertion order is kept as ``json, rdf, provn, xml`` (the
+        historic order when all extras are present) because
+        :func:`prov.read`'s format auto-detection iterates
+        ``Registry.serializers`` in order and several tests
+        (``test_read_auto_detects_rdf``,
+        ``test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error``,
+        ``test_read_on_unparseable_content_raises_bad_syntax``) pin the
+        exact candidate tried second.
         """
         from prov.serializers.provjson import ProvJSONSerializer
         from prov.serializers.provn import ProvNSerializer
-        from prov.serializers.provrdf import ProvRDFSerializer
-        from prov.serializers.provxml import ProvXMLSerializer
 
-        Registry.serializers = {
+        serializers: dict[str, type[Serializer]] = {
             "json": ProvJSONSerializer,
-            "rdf": ProvRDFSerializer,
-            "provn": ProvNSerializer,
-            "xml": ProvXMLSerializer,
         }
+        try:
+            from prov.serializers.provrdf import ProvRDFSerializer
+        except ImportError:  # pragma: no cover -- rdflib (rdf extra) absent; covered by the minimal-install CI job
+            pass
+        else:
+            serializers["rdf"] = ProvRDFSerializer
+        serializers["provn"] = ProvNSerializer
+        try:
+            from prov.serializers.provxml import ProvXMLSerializer
+        except ImportError:  # pragma: no cover -- lxml (xml extra) absent; covered by the minimal-install CI job
+            pass
+        else:
+            serializers["xml"] = ProvXMLSerializer
+        Registry.serializers = serializers
+
+
+#: Formats provided by optional extras, used to build the DoNotExist message
+#: in :func:`get` when the corresponding dependency is not installed.
+_OPTIONAL_FORMAT_EXTRAS = {"rdf": "rdf", "xml": "xml"}
 
 
 def get(format_name: str) -> type[Serializer]:
@@ -118,6 +143,14 @@ def get(format_name: str) -> type[Serializer]:
     try:
         return serializers[format_name]
     except KeyError as e:
+        extra = _OPTIONAL_FORMAT_EXTRAS.get(format_name)
+        # The informative-message branch is reachable only when the optional
+        # extra is absent; the minimal-install CI job exercises it.
+        if extra is not None:  # pragma: no cover
+            raise DoNotExist(
+                f'Serializer for the "{format_name}" format requires the '
+                f'"{extra}" extra; install it with: pip install "prov[{extra}]"'
+            ) from e
         raise DoNotExist(
             f'No serializer available for the format "{format_name}"'
         ) from e

--- a/src/prov/tests/test_minimal_install.py
+++ b/src/prov/tests/test_minimal_install.py
@@ -1,0 +1,44 @@
+"""Degradation behaviour when optional extras are missing.
+
+Run by the ``minimal-install`` CI job (which syncs without the rdf/xml
+extras). Under the normal matrix (extras installed) the skipif-guarded tests
+are skipped and the availability test asserts all four formats register.
+"""
+
+import importlib.util
+
+import pytest
+
+import prov.serializers
+from prov.model import ProvDocument
+
+HAS_RDFLIB = importlib.util.find_spec("rdflib") is not None
+HAS_LXML = importlib.util.find_spec("lxml") is not None
+
+
+def test_core_import_and_json_roundtrip() -> None:
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1")
+    reloaded = ProvDocument.deserialize(content=doc.serialize(format="json"))
+    assert reloaded == doc
+
+
+@pytest.mark.skipif(HAS_RDFLIB, reason="only meaningful without rdflib")
+def test_rdf_unavailable_raises_informative_error() -> None:
+    with pytest.raises(prov.serializers.DoNotExist, match=r"prov\[rdf\]"):
+        prov.serializers.get("rdf")
+
+
+@pytest.mark.skipif(HAS_LXML, reason="only meaningful without lxml")
+def test_xml_unavailable_raises_informative_error() -> None:
+    with pytest.raises(prov.serializers.DoNotExist, match=r"prov\[xml\]"):
+        prov.serializers.get("xml")
+
+
+@pytest.mark.skipif(
+    not (HAS_RDFLIB and HAS_LXML), reason="only meaningful with both extras"
+)
+def test_all_formats_available_with_extras() -> None:
+    for fmt in ("json", "provn", "rdf", "xml"):
+        assert prov.serializers.get(fmt) is not None


### PR DESCRIPTION
Task 15 of the Phase 3 modernisation roadmap (`docs/superpowers/plans/2026-07-05-phase-3-docs-tests-refactor.md`).

## Problem
`Registry.load_serializers()` imported all four serializer modules unconditionally, so in a minimal install (no `rdf`/`xml` extras) a missing `rdflib`/`lxml` raised `ModuleNotFoundError` on the very first registry access — breaking even `get("json")` and `import`-driven use. A plain `pip install prov` was effectively unusable.

## Change (approved 2.4.0 behaviour improvement — only affects configs that are broken today)
- `load_serializers()` now always registers `json`/`provn` and registers `rdf`/`xml` only when their optional dependency imports successfully (try/except ImportError). The historic insertion order `{json, rdf, provn, xml}` is preserved so `prov.read()`s auto-detection (which iterates the registry) is unchanged.
- `get("rdf")`/`get("xml")` without the extra now raise an informative `DoNotExist` naming the extra (`... install it with: pip install "prov[rdf]"`) instead of a bare `ModuleNotFoundError`. Unknown formats still get the generic message; exception chaining (`from e`) preserved.
- `prov.read()` degrades for free — unavailable formats simply arent in the registry it iterates.

## Proof
New `minimal-install` CI job (`uv sync --group dev`, no extras; not `continue-on-error`) runs `src/prov/tests/test_minimal_install.py`, which asserts: core import + JSON round-trip work; `get("rdf")`/`get("xml")` raise `DoNotExist` naming `prov[rdf]`/`prov[xml]` (skipped when the extra is present); all four formats register when both extras are present.

## Verification
- Extras env: full suite unchanged — 928 passed / 16 skipped / 6 xfailed; coverage 98% (`serializers/__init__.py` 100%; the three extras-absent-only branches carry `# pragma: no cover` and are covered by the minimal-install job).
- Simulated minimal install (throwaway venv, no extras): `import prov` OK, `get("rdf")`/`get("xml")` → informative `DoNotExist`, `prov.read()` on JSON OK (no ModuleNotFoundError), degradation tests 3 passed / 1 skipped.
- ruff + mypy clean. HISTORY.rst gains a `2.4.0 (unreleased)` entry.