### PR TITLE
chore: 3.0 deprecation warnings and upgrading guide

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,15 @@ History
   and the JSON/PROV-N serializers work in a minimal install, and requesting
   the ``rdf``/``xml`` format raises an informative ``DoNotExist`` naming the
   missing extra instead of a bare ``ModuleNotFoundError``. (#230)
+* Deprecation warnings signposting planned 3.0 changes: importing
+  ``prov.dot``/``prov.graph`` now emits a ``DeprecationWarning`` naming the
+  future ``prov[dot]``/``prov[graph]`` extras those modules will require, and
+  ``ProvBundle.unified()``/``ProvDocument.unified()`` emit a ``FutureWarning``
+  about the upcoming PROV-CONSTRAINTS unification rework. Both warnings are
+  hidden by default (standard ``DeprecationWarning``/``FutureWarning``
+  semantics) and link to the new `Upgrading to 3.0
+  <https://github.com/trungdong/prov/blob/master/docs/upgrading-3.0.md>`_
+  guide, which tables every planned 3.0 change and what to do about it.
 
 2.3.0 (2026-07-05)
 ^^^^^^^^^^^^^^^^^^

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ code changes.
 |---|---|---|
 | **2.2.0** *(released 2026-07-03)* | Tooling & bug fixes | Modernised linting/formatting and test tooling; CI refresh; release automation. Bug fixes: graphics output regression ([#164](https://github.com/trungdong/prov/issues/164)), matplotlib as an optional extra ([#166](https://github.com/trungdong/prov/issues/166)), PROV-XML default-namespace parsing ([#155](https://github.com/trungdong/prov/issues/155)). |
 | **2.3.0** *(released 2026-07-05)* | Typing & test coverage | Complete type annotations across the codebase and ship `py.typed` (PEP 561), so downstream projects get real type checking against `prov`'s API. Coverage gaps closed, including the CLI scripts and format auto-detection. Progressively stricter lint and type-check rules enforced in CI as modules are annotated. A dependency audit documents why each runtime dependency exists, aiming for the smallest possible footprint. **Python 3.9 support dropped** (originally planned for 3.0, pulled forward because security fixes in transitive dependencies are only released for Python 3.10+). One sanctioned diagnostic tweak: serializer-lookup and CLI errors now chain the original exception (`__cause__`); exception types and messages are unchanged, so this stays within the 2.x stability promise. |
-| **2.4.0** | Documentation & internals | Refreshed, reorganised documentation (tutorials, how-to guides, API reference, explanations), including guides for graphics export ([#141](https://github.com/trungdong/prov/issues/141)) and for the `prov-convert`/`prov-compare` CLI tools ([#83](https://github.com/trungdong/prov/issues/83)). Internal restructuring behind the stable public API, plus deprecation warnings signposting the 3.0 changes. |
+| **2.4.0** | Documentation & internals | Refreshed, reorganised documentation (tutorials, how-to guides, API reference, explanations), including guides for graphics export ([#141](https://github.com/trungdong/prov/issues/141)) and for the `prov-convert`/`prov-compare` CLI tools ([#83](https://github.com/trungdong/prov/issues/83)). Internal restructuring behind the stable public API, plus deprecation warnings signposting the 3.0 changes. **This is the deprecation-signposting release**: importing `prov.dot`/`prov.graph` now emits a `DeprecationWarning` naming the future `prov[dot]`/`prov[graph]` extras, and `unified()` emits a `FutureWarning` about the PROV-CONSTRAINTS rework below; see the new [Upgrading to 3.0](docs/upgrading-3.0.md) guide for the full list and what to do. |
 | **3.0.0** | Compatibility release | The one release allowed to break compatibility (see the explicit list below). |
 | **3.1.0** | PROV-JSONLD support | A new serializer and deserializer for [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), the W3C member submission for representing PROV-DM natively in JSON-LD. Purely additive. |
 | **3.2.0** | Two-way PROV-N | A parser for [PROV-N](https://www.w3.org/TR/prov-n/), built from the specification's grammar, making the notation readable as well as writable (today `prov` can only write PROV-N). Purely additive. |
@@ -69,8 +69,9 @@ companion specifications, whose findings feed into this list. The planned change
     PROV-JSON output (an interop-affecting change).
   - Plus any further fixes surfaced by the conformance audit.
 
-An "Upgrading to 3.0" migration guide will accompany the release. The intent is that
-most users need no code changes; the guide demonstrates the exceptions.
+The [Upgrading to 3.0](docs/upgrading-3.0.md) guide, published starting in 2.4.0, tracks
+this list in detail alongside what to do for each change. The intent is that most users
+need no code changes; the guide demonstrates the exceptions.
 
 ## Feedback
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Prov Python package's documentation
 
    readme
    installation
+   upgrading-3.0
    contributing
    authors
    history

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -1,0 +1,94 @@
+# Upgrading to 3.0
+
+3.0 is the one release in the `prov` roadmap allowed to break compatibility. Every
+change below is signposted in 2.4.0 (with a runtime warning where that is feasible), so
+most code that only sees a `DeprecationWarning`/`FutureWarning` today needs no change to
+keep working right up until 3.0 ships; this page lists what to do for each planned
+change. See [ROADMAP.md](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for
+the release-by-release plan and the
+[modernisation roadmap design](https://github.com/trungdong/prov/blob/master/docs/superpowers/specs/2026-07-03-modernisation-roadmap-design.md)
+for the full rationale.
+
+## Smaller install footprint
+
+| Change | Signposted in 2.4.0 by | What to do |
+|---|---|---|
+| `pydot`/Graphviz support (`prov.dot`, `prov_to_dot()`) moves behind the `dot` extra | Importing `prov.dot` emits a `DeprecationWarning` | Depend on `prov[dot]` instead of (or in addition to) `prov` if your code imports `prov.dot` or calls `prov_to_dot()`. |
+| `networkx` graph interop (`prov.graph`, `prov_to_graph()`/`graph_to_prov()`) moves behind the `graph` extra | Importing `prov.graph` emits a `DeprecationWarning` | Depend on `prov[graph]` instead of (or in addition to) `prov` if your code imports `prov.graph` or calls `prov_to_graph()`/`graph_to_prov()`. Note `prov.dot` itself uses `prov.graph`, so `prov[dot]` will pull in `prov[graph]` too. |
+| `python-dateutil` dropped in favour of the standard library's `datetime.fromisoformat()` | Not separately warned (internal dependency swap) | No action for typical ISO-8601 timestamps. If you rely on `dateutil.parser.parse()`'s more permissive parsing of non-ISO date/time strings inside PROV-JSON/XML/RDF documents, verify those strings still parse under 3.0 — `fromisoformat()` accepts a narrower grammar. |
+
+A plain `pip install prov` will keep working for the core data model and the JSON/PROV-N
+serializers; add the relevant extra(s) if you use graphics export or graph interop.
+
+## Behaviour-changing bug fixes
+
+These fix real bugs, but each one changes output or equality semantics for inputs that
+work (without error) today, so none of them can land in the 2.x series under the
+API-stability promise. No 2.4.0 runtime warning is feasible for these — the affected
+code paths are ordinary attribute/literal handling with no single import or call site to
+hook a warning onto — so this table is their only 2.4.0 signpost.
+
+| Issue | Problem today | What changes in 3.0 | What to do |
+|---|---|---|---|
+| [#89](https://github.com/trungdong/prov/issues/89) | A literal parsed with an explicit `^^xsd:string` datatype and a plain (datatype-less) literal are both stored as a bare `str`, so the original form isn't recoverable on re-serialization, and the RDF/PROV-JSON serializers disagree on which form to emit. | Serializers emit one consistent canonical form for string literals (likely the plain, undecorated form, per RDF 1.1, where the two forms are the same literal). | If you compare serialized output byte-for-byte, re-check it against 3.0 output. Document-level (semantic) equality is unaffected. |
+| [#34](https://github.com/trungdong/prov/issues/34) | Extra attribute values are stored in a plain Python `set`, so Python-equal-but-differently-typed values (e.g. `2` and `2.0`, or `1` and `True`) silently collapse to whichever was inserted first — both at record construction and inside `unified()`. | Attribute values gain type-aware (value-space) handling as part of the PROV-CONSTRAINTS unification rework (see below), so distinct PROV values are retained instead of colliding. | If your code depends on same-value-different-type attributes collapsing (or on which of the colliding values survives), re-check it against 3.0; most callers will simply see more attributes preserved. |
+| [#77](https://github.com/trungdong/prov/issues/77) | `Literal` stores its value as a string and compares/hashes lexically, so `Literal(10, XSD_DECIMAL)` and `Literal(10.0, XSD_DECIMAL)` compare unequal despite denoting the same `xsd:decimal` value. | Decimal literals compare and hash in value space; `record.attributes` may expose native `Decimal` values instead of `Literal` objects, and attribute sets deduplicate value-equal decimals. | If you rely on lexical (string) inequality between differently-formatted decimal literals, or on receiving a `Literal` instance rather than a `Decimal`, re-check that code against 3.0. |
+| [#168](https://github.com/trungdong/prov/issues/168) | `xsd:QName`-typed attribute values are not handled correctly in PROV-JSON output, an interop-affecting bug. | PROV-JSON emits `xsd:QName` values per the PROV-JSON specification. | If you consume PROV-JSON produced by `prov` and parse `xsd:QName` attributes yourself, re-check that parsing against 3.0 output. |
+
+## Unification rework (PROV-CONSTRAINTS)
+
+`ProvBundle.unified()` and `ProvDocument.unified()` currently perform a simple,
+identifier-keyed attribute union: for each identifier shared by more than one record,
+the attributes of all such records are merged onto a copy of the first, with no
+conflict detection. See the
+[unification and flattening explanation](explanation/unification-flattening.md) for the
+full write-up of today's behaviour and how it diverges from the specification.
+
+In 3.0, `unified()` is reimplemented to follow the merging rules of
+[W3C PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) (key constraints and
+term unification). Concretely:
+
+- Calling `unified()` today already emits a `FutureWarning` naming this page and
+  ROADMAP.md.
+- Records sharing an identifier that also have **conflicting formal attributes** will
+  **raise a documented exception** in 3.0 instead of having their attributes silently
+  unioned.
+- The `#34` attribute-merging fix above lands as part of this same rework.
+
+**What to do:** if your code calls `unified()` on documents where records sharing an
+identifier can disagree on a formal attribute (for example, two `wasGeneratedBy`
+statements for the same identifier asserting different `prov:time` values — the
+"scruffy" pattern used in this repo's own test suite), expect that call to raise in 3.0
+where it previously merged silently. Catch the new exception (or restructure the
+document to avoid conflicting formal attributes) before upgrading. Documents without
+this pattern are unaffected.
+
+## Removal of names deprecated in 2.4.0
+
+3.0 removes everything 2.4.0 marked deprecated:
+
+- The unconditional `pydot`/`networkx` dependencies (superseded by the `dot`/`graph`
+  extras above) — `import prov.dot` / `import prov.graph` will raise
+  `ModuleNotFoundError` if the corresponding extra isn't installed, rather than working
+  out of the box.
+- `python-dateutil` as a runtime dependency (superseded by the stdlib swap above).
+
+There are no other 2.4.0-introduced deprecations beyond these two extras moves; nothing
+else is scheduled for removal.
+
+## Summary: is my code affected?
+
+If your code:
+
+- Doesn't import `prov.dot`/`prov.graph` (or their `prov_to_dot`/`prov_to_graph`/
+  `graph_to_prov` re-exports elsewhere) — unaffected by the extras moves.
+- Doesn't compare `xsd:decimal` literals across differing lexical forms, doesn't rely on
+  same-value-different-type attribute collapsing, doesn't byte-compare serialized string
+  literals or `xsd:QName` PROV-JSON output — unaffected by the bug fixes.
+- Doesn't call `unified()` on documents with conflicting formal attributes sharing an
+  identifier — unaffected by the unification rework.
+
+then upgrading to 3.0 should require no code changes at all. Where a runtime warning is
+feasible (the two extras moves and `unified()`), 2.4.0 already emits it under
+`-W error::DeprecationWarning` / `-W error::FutureWarning`, so you can audit your own
+call sites for these changes ahead of time.

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -63,6 +63,12 @@ where it previously merged silently. Catch the new exception (or restructure the
 document to avoid conflicting formal attributes) before upgrading. Documents without
 this pattern are unaffected.
 
+Note that `prov_to_dot()` (`prov.dot`) and `prov_to_graph()` (`prov.graph`, not
+`graph_to_prov()`, which does not unify) call `unified()` internally, so the
+`FutureWarning` above also fires on every call to those functions today — regardless of
+whether the document actually has conflicting attributes — so graphics/graph-export
+users will see it even without calling `unified()` themselves.
+
 ## Removal of names deprecated in 2.4.0
 
 3.0 removes everything 2.4.0 marked deprecated:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,10 @@ combine-as-imports = true  # keep multi-name `X as X` re-export blocks compact
 
 [tool.pytest.ini_options]
 testpaths = ["src/prov/tests"]
+filterwarnings = [
+    "ignore:In prov 3.0:DeprecationWarning",
+    "ignore:prov 3.0 will change unified:FutureWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -14,6 +14,7 @@ References:
 
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
+import warnings
 from datetime import datetime
 from html import escape
 from typing import Any
@@ -56,6 +57,14 @@ from prov.model import (
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
+
+warnings.warn(
+    "In prov 3.0, graphical export (prov.dot) will require the optional "
+    '"dot" extra; install "prov[dot]" to keep using it after upgrading. '
+    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 # Visual styles for various elements (nodes) and relations (edges)

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -21,9 +21,17 @@ from typing import Any
 
 import pydot
 
-from prov.graph import INFERRED_ELEMENT_CLASS
-from prov.identifier import QualifiedName
-from prov.model import (
+warnings.warn(
+    "In prov 3.0, graphical export (prov.dot) will require the optional "
+    '"dot" extra; install "prov[dot]" to keep using it after upgrading. '
+    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from prov.graph import INFERRED_ELEMENT_CLASS  # noqa: E402
+from prov.identifier import QualifiedName  # noqa: E402
+from prov.model import (  # noqa: E402
     PROV_ACTIVITY,
     PROV_AGENT,
     PROV_ALTERNATE,
@@ -57,14 +65,6 @@ from prov.model import (
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-
-warnings.warn(
-    "In prov 3.0, graphical export (prov.dot) will require the optional "
-    '"dot" extra; install "prov[dot]" to keep using it after upgrading. '
-    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 # Visual styles for various elements (nodes) and relations (edges)

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import networkx as nx
@@ -37,6 +38,14 @@ from prov.model import (
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
+
+warnings.warn(
+    "In prov 3.0, graph export (prov.graph) will require the optional "
+    '"graph" extra; install "prov[graph]" to keep using it after upgrading. '
+    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 INFERRED_ELEMENT_CLASS = {

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import tempfile
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from io import IOBase
@@ -426,6 +427,15 @@ class ProvBundle:
         Returns:
             The new, unified :class:`ProvBundle`.
         """
+        warnings.warn(
+            "prov 3.0 will change unified() to merge records per the W3C "
+            "PROV-CONSTRAINTS rules; records sharing an identifier but having "
+            "conflicting formal attributes will then raise an error instead of "
+            "having their attributes silently unioned. See "
+            "https://github.com/trungdong/prov/blob/master/ROADMAP.md",
+            FutureWarning,
+            stacklevel=2,
+        )
         unified_records = self._unified_records()
         bundle = ProvBundle(records=unified_records, identifier=self.identifier)
         return bundle
@@ -1453,6 +1463,15 @@ class ProvDocument(ProvBundle):
         Returns:
             The new, unified :class:`ProvDocument`.
         """
+        warnings.warn(
+            "prov 3.0 will change unified() to merge records per the W3C "
+            "PROV-CONSTRAINTS rules; records sharing an identifier but having "
+            "conflicting formal attributes will then raise an error instead of "
+            "having their attributes silently unioned. See "
+            "https://github.com/trungdong/prov/blob/master/ROADMAP.md",
+            FutureWarning,
+            stacklevel=2,
+        )
         document = ProvDocument(self._unified_records())
         document._namespaces = self._namespaces
         for bundle in self.bundles:

--- a/src/prov/tests/test_deprecations.py
+++ b/src/prov/tests/test_deprecations.py
@@ -1,0 +1,51 @@
+"""Covers the 2.4.0 deprecation signposts for 3.0 (roadmap step 26).
+
+``prov.dot`` and ``prov.graph`` emit a module-level ``DeprecationWarning``
+pointing at the future ``prov[dot]``/``prov[graph]`` extras, and
+``ProvBundle.unified()``/``ProvDocument.unified()`` emit a ``FutureWarning``
+about the PROV-CONSTRAINTS unification rework. The full narrative for both
+lives in docs/upgrading-3.0.md.
+
+Module-level warnings only fire once, at import time, so a test that isn't
+the first to import ``prov.dot``/``prov.graph`` (both are imported by other
+test modules in this suite) must ``importlib.reload()`` the module to
+observe the warning again.
+"""
+
+import importlib
+
+import pytest
+
+import prov.dot
+import prov.graph
+from prov.model import ProvDocument
+
+
+def test_import_dot_warns_deprecation():
+    with pytest.warns(DeprecationWarning, match=r"prov\[dot\]"):
+        importlib.reload(prov.dot)
+
+
+def test_import_graph_warns_deprecation():
+    with pytest.warns(DeprecationWarning, match=r"prov\[graph\]"):
+        importlib.reload(prov.graph)
+
+
+def test_bundle_unified_warns_future():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1")
+    bundle = doc.bundle("ex:b1")
+    bundle.entity("ex:e2")
+
+    with pytest.warns(FutureWarning, match="PROV-CONSTRAINTS"):
+        bundle.unified()
+
+
+def test_document_unified_warns_future():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1")
+
+    with pytest.warns(FutureWarning, match="PROV-CONSTRAINTS"):
+        doc.unified()


### PR DESCRIPTION
## Summary
- Phase 3, Task 17: signpost everything 3.0 will change (spec step 26).
- `import prov.dot` / `import prov.graph` now emit a `DeprecationWarning` naming the future `prov[dot]`/`prov[graph]` extras (spec 36c).
- `ProvBundle.unified()` / `ProvDocument.unified()` now emit a `FutureWarning` that 3.0 reimplements unification per W3C PROV-CONSTRAINTS (conflicting formal attributes will raise instead of silently merging).
- New `docs/upgrading-3.0.md` tabling all planned 3.0 changes (extras/dateutil moves, #89/#34/#77/#168 behaviour fixes, unification rework, 2.4.0-deprecation removals) with "what to do" guidance.
- New `src/prov/tests/test_deprecations.py`; `pyproject.toml` gets message-scoped `filterwarnings` so the suite stays clean.
- No public API or behaviour changes — additive warnings + docs only.

## Test plan
- [x] `uv run pytest src/prov/tests/test_deprecations.py -v` — 4 passed
- [x] `uv run pytest` — 932 passed, 16 skipped, 6 xfailed, no new warning spam
- [x] `uv run ruff check src/` / `uv run mypy src` — clean
- [x] `python -W error::DeprecationWarning -c "import prov.dot"` — raises with dot's own message
- [x] Sphinx docs build — 0 warnings, upgrading-3.0 page renders
- [x] Two-stage subagent review (spec compliance + code quality) completed; two Important issues found and fixed, re-reviewed and approved