### PR TITLE
PROV-CONSTRAINTS unification gap analysis and test corpus (roadmap step 30b)

### DIFF
--- a/docs/superpowers/specs/2026-07-10-conformance-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-10-conformance-audit-findings.md
@@ -951,7 +951,48 @@ items. Emitting qualified-form-only (identified/qualified cases) is conformant u
 PROV-O §3.1's explicit either-or-both allowance, though the spec encourages also including
 the binary triple — a 3.0 consideration.
 ## 4. Unification vs PROV-CONSTRAINTS (step 30b) — summary
-See docs/superpowers/specs/2026-07-10-unification-gap-analysis.md (authority for step 36b).
+
+Full rule-by-rule analysis (the authority for the step 36b reimplementation):
+`docs/superpowers/specs/2026-07-10-unification-gap-analysis.md`. Audited 2026-07-11 on
+branch `audit/unification-constraints` against
+[PROV-CONSTRAINTS (W3C REC 2013-04-30)](https://www.w3.org/TR/prov-constraints/) §4
+(term unification), §6.1 (uniqueness/key Constraints 22–29), and §7.2 (bundle
+scoping), using the 153-case ProvToolbox/W3C unification corpus vendored under
+`src/prov/tests/unification/constraints/` (origin/licence in its README) and locked
+by `src/prov/tests/test_unification_constraints.py`. Headlines:
+
+- **`_unified_records()` (`src/prov/model/bundle.py:384-414`) is an identifier-keyed
+  attribute union, not PROV-CONSTRAINTS merging** — umbrella **filed #253** (fix
+  vehicle: step 36b, 3.0). Gap classes, each with an executed example and a
+  characterization test: no pairwise term unification of formal attributes
+  (Constraints 22/23); concrete-vs-concrete conflicts rejected only *accidentally*
+  by `add_attributes`'s cardinality guard (`records.py:622-643` — right outcome
+  class, undocumented generic `ProvException`, 25 corpus fail-cases); placeholder
+  (`-`) vs concrete merges silently (the model cannot represent `-`; 12 corpus
+  fail-cases); incompatible types merge silently (entity + activity sharing an id
+  become an *entity* carrying `prov:startTime` as a literal extra attribute — the
+  result depends on record order; Constraints 50/55); uniqueness Constraints 24–29
+  (keys other than the identifier) are not applied in either direction — invalid
+  duplicates pass through *and* valid instances never reach the spec's normal form
+  (anonymous records that unique-generation would fold in stay separate).
+- **Bundle scoping is the conformant part:** `ProvDocument.unified()`
+  (`bundle.py:1455-1480`) unifies the toplevel and each sub-bundle independently of
+  each other (§7.2), confirmed by test. The `flattened().unified()` idiom (as
+  `test_unifying` uses) merges across bundle boundaries — spec-invalid usage,
+  characterized and recorded for 36b to document as outside PROV-CONSTRAINTS.
+- **Corpus tally:** 85 success / 68 fail files; 83 parseable success cases all unify
+  without complaint; 25 fail-cases hit the accidental guard; 42 fail-cases merge or
+  pass silently; 3 files cannot be parsed at all.
+- **En-route PROV-XML bug (filed #254):** the 3 unparseable `bundle-*` files crash
+  the XML deserializer with a raw `UnboundLocalError`
+  (`provxml._extract_attributes`, `provxml.py:456`) — a child element whose only XML
+  attributes are unrecognised (here ProvToolbox's `<prov:bundle>` dialect, not the
+  XSD's `<prov:bundleContent>`) assigns no value, and a second, worse mode silently
+  reuses the *previous sibling's* value (executed: after `<ex:first>hello</ex:first>`,
+  `<ex:second ex:junk="x">world</ex:second>` deserializes as `ex:second="hello"`).
+  Sibling of
+  #228 (JSON leg); the inputs are schema-invalid, but malformed input must raise
+  `ProvXMLException`, not corrupt data.
 ## 5. Issues filed by this audit
 | Issue | Finding | Section |
 |---|---|---|
@@ -967,6 +1008,8 @@ See docs/superpowers/specs/2026-07-10-unification-gap-analysis.md (authority for
 | [#249](https://github.com/trungdong/prov/issues/249) | `PROV-N/PROV-O conformance:` plain Python ints outside the 32-bit range are asserted as `xsd:int` in PROV-N and PROV-O output | §3.3/§3.4 |
 | [#250](https://github.com/trungdong/prov/issues/250) | `PROV-O conformance:` anonymous qualified Communication/Attribution/Delegation/Influence nodes omit their influencer property, producing ambiguous PROV-O (root cause of #226) | §3.4 |
 | [#251](https://github.com/trungdong/prov/issues/251) | `PROV-N conformance:` plain Python floats serialize as `%g`-formatted `xsd:float`, diverging from the `xsd:double` all other serializers assert and truncating precision | §3.3 |
+| [#253](https://github.com/trungdong/prov/issues/253) | `PROV-CONSTRAINTS conformance:` `unified()` does not implement PROV-CONSTRAINTS merging (umbrella; authority: the step-30b gap-analysis doc; fix vehicle: step 36b) | §4 |
+| [#254](https://github.com/trungdong/prov/issues/254) | `Bug:` PROV-XML deserializer leaks raw `UnboundLocalError` or silently reuses the previous attribute's value on unrecognised XML attributes (sibling of #228) | §4 |
 
 Not filed (findings-doc only): the §2.8 validation-gap family (needs maintainer
 confirmation — enforcement is a 3.0 API-philosophy decision), the `Literal` language-tag

--- a/docs/superpowers/specs/2026-07-10-unification-gap-analysis.md
+++ b/docs/superpowers/specs/2026-07-10-unification-gap-analysis.md
@@ -1,0 +1,331 @@
+# Unification gap analysis — `unified()` vs PROV-CONSTRAINTS (roadmap step 30b)
+
+**Status:** Complete (audited 2026-07-11, branch `audit/unification-constraints`).
+**Authority for:** the 3.0 `unified()` reimplementation (roadmap step 36b).
+**Umbrella issue:** [#253](https://github.com/trungdong/prov/issues/253).
+**Characterization tests:** `src/prov/tests/test_unification_constraints.py` over the
+vendored corpus `src/prov/tests/unification/constraints/` (provenance/licence in that
+directory's README).
+
+Spec: [PROV-CONSTRAINTS (W3C REC 2013-04-30)](https://www.w3.org/TR/prov-constraints/).
+Constraint numbers below are the REC's; the relevant sections are §4 (terms,
+substitution, unification), §6.1 (uniqueness and key constraints, Constraints 22–29),
+and §7.2 (bundles and documents). The pre-existing hand-made fixtures
+(`src/prov/tests/unification/*.json`, untouched by this audit) already cite these
+numbers in their names (`...-PASS-c22`, `-c23`, `-c28`, `-c29`); the vendored
+ProvToolbox corpus uses `<category>-successN`/`-failN` names instead and covers the
+full rule surface, including cases 2.x gets wrong.
+
+## 1. Spec baseline
+
+### 1.1 Terms and unification (§4)
+
+A PROV term is a constant identifier, a **placeholder `-`**, a literal value, or an
+**existential variable**. Unification of two terms:
+
+- constant/literal (including `-`) vs constant/literal: succeeds with the empty
+  substitution iff they are **equal**, otherwise **fails** — in particular, `-` does
+  *not* unify with a concrete identifier;
+- existential variable vs anything: succeeds, binding the variable.
+
+Omitted optional parameters are generally expanded to existential variables
+("unknown"), but §5.1's expansion definitions leave `-` in specific positions
+(derivation's activity/generation/usage, association's plan, delegation's activity,
+start/end's trigger...) meaning "definitely nothing" — a constant that only unifies
+with itself or a variable.
+
+### 1.2 Merging and key constraints (§6.1)
+
+Uniqueness constraints are enforced by **merging**: given two statements of the same
+relation whose key fields are equal, unify corresponding parameters pairwise; on
+success, replace both statements with one carrying the unified parameters and the
+**union of the attribute lists**, and apply the substitution to the rest of the
+instance; on failure, **constraint application fails and the instance is invalid**
+(there is no valid normal form). The worked example (§6.1):
+`activity(a, 2011-11-16T16:00:00, _t1, [a=1])` + `activity(a, _t2,
+2011-11-16T18:00:00, [b=2])` → `activity(a, 2011-11-16T16:00:00,
+2011-11-16T18:00:00, [a=1, b=2])`.
+
+The key constraints:
+
+- **Constraint 22 (key-object):** `id` is a KEY for `entity(id, attrs)`,
+  `activity(id, t1, t2, attrs)`, and `agent(id, attrs)`.
+- **Constraint 23 (key-properties):** `id` is a KEY for all eleven identified
+  relations — `wasGeneratedBy(id; e, a, t, attrs)`, `used(id; a, e, t, attrs)`,
+  `wasInformedBy(id; a2, a1, attrs)`, `wasStartedBy(id; a2, e, a1, t, attrs)`,
+  `wasEndedBy(id; a2, e, a1, t, attrs)`, `wasInvalidatedBy(id; e, a, t, attrs)`,
+  `wasDerivedFrom(id; e2, e1, a, g2, u1, attrs)`, `wasAttributedTo(id; e, ag,
+  attrs)`, `wasAssociatedWith(id; a, ag, pl, attrs)`, `actedOnBehalfOf(id; ag2, ag1,
+  a, attrs)`, `wasInfluencedBy(id; o2, o1, attrs)`.
+  (Specialization/Alternate/Membership/Mention have no identifier and no key
+  constraint.)
+- **Constraints 24–27 (unique-generation / unique-invalidation / unique-wasStartedBy
+  / unique-wasEndedBy):** the generation/invalidation events per (entity, activity)
+  pair, and the start/end events per (activity, starter/ender-activity) pair, have
+  equal identifiers — i.e. the key is *not* the identifier, and two records with
+  distinct constant identifiers for the same pair make the instance invalid, while an
+  anonymous record (existential identifier) merges into the identified one.
+- **Constraints 28–29 (unique-startTime / unique-endTime):** an activity's
+  `startTime`/`endTime` equals the time of its `wasStartedBy`/`wasEndedBy` event —
+  a cross-record-type uniqueness constraint.
+
+Related non-merging constraints exercised by the corpus's fail-cases: Constraint 50
+(typing), Constraint 52 (impossible-specialization-reflexive), Constraint 55
+(entity-activity-disjoint), the event-ordering constraints (§6.2), and the §5.1
+definitions that make a placeholder in a mandatory position ill-formed.
+
+### 1.3 Bundle scoping (§7.2)
+
+Each bundle (named instance) and the toplevel instance are normalized and validated
+**independently**: "there is no interaction between bundles from the perspective of
+applying definitions, inferences, or constraints". Nothing ever merges across bundle
+boundaries; a document is valid iff each instance is valid and bundle names are
+distinct.
+
+## 2. Current implementation
+
+`ProvBundle._unified_records()` (`src/prov/model/bundle.py:384-414`): group records
+by identifier via `_id_map`; for each identifier held by more than one record, copy
+the **first** record and `add_attributes()` every other record's attributes onto the
+copy; return the records with each same-id group replaced by its merged copy.
+Records without an identifier, or whose identifier is unique, pass through untouched.
+There is no term unification, no placeholder representation (an absent formal
+attribute is simply absent), no type compatibility check, and no application of
+Constraints 24–29.
+
+One accident does reject some invalid merges: `ProvRecord.add_attributes`'s
+formal-attribute cardinality guard (`src/prov/model/records.py:622-643`) raises a
+generic `ProvException("Cannot have more than one value for attribute prov:X")` when
+the merge would give a formal attribute two *different concrete* values. That is the
+right outcome class for concrete-vs-concrete conflicts, but it is an undocumented
+side effect with a misleading message (cardinality, not non-unifiability), and it
+covers only that one conflict shape.
+
+`ProvDocument.unified()` (`src/prov/model/bundle.py:1455-1480`) applies
+`_unified_records()` to the document's own records, then calls
+`bundle.unified()` on each sub-bundle and adds the results to the new document —
+i.e. the toplevel instance and every bundle are unified **independently of each
+other**, matching §7.2. Confirmed by test
+(`test_document_unified_scopes_unification_per_bundle`): a document whose top level
+and two bundles all assert `entity(e)` unifies each scope separately; b1's two
+same-id records merge within b1 only, and neither b2 nor the top level absorbs
+anything from another scope.
+
+Both methods emit a `FutureWarning` (2.4.0 signpost) announcing the 3.0 rework.
+
+## 3. Rule-by-rule gaps
+
+Format per rule: spec statement → current behaviour → executed example → 36b
+requirement. All examples were executed on this branch and are locked by
+characterization tests in `test_unification_constraints.py`.
+
+### 3.1 Term unification and the placeholder `-`
+
+- **Spec (§4, §5.1):** `-` is a constant ("definitely nothing"); it unifies only
+  with itself or an existential variable. A record asserting a concrete plan and a
+  record asserting *no* plan, under the same identifier, cannot merge.
+- **Current:** the model has no representation of `-` at all — deserializers drop
+  the distinction (an XML/JSON absent attribute, whether the source meant `-` or
+  "unknown", becomes an absent attribute), and the attribute union then treats
+  absent-vs-concrete as trivially compatible.
+- **Example (corpus `association-fail4` analogue, executed):**
+  `wasAssociatedWith(assoc1; a1, ag1, pl1)` + `wasAssociatedWith(assoc1; a1, ag1, -)`
+  → silently merges to `wasAssociatedWith(assoc1; a1, ag1, pl1)` (1 record). Spec:
+  merge failure, instance invalid. Same shape: `delegation-fail4/5`,
+  `derivation-fail1/2/3/4`, `generation-fail7`, `invalidation-fail7`, `usage-fail7`,
+  `start-fail7`, `association-fail5` — 12 corpus fail-cases merge silently for this
+  reason.
+- **36b:** decide the placeholder story for the model (represent `-` distinctly
+  from "omitted", or document that `prov` treats deserialized input as scruffy) and,
+  wherever `-` is representable, make placeholder-vs-concrete unification raise the
+  documented merge-failure exception. This interacts with the §5.1 expansion rules
+  (which positions default to `-` vs an existential) — 36b must implement that table.
+
+### 3.2 Constraint 22 (key-object): entity / activity / agent
+
+- **Spec:** same-id element statements merge; merging fails if formal parameters
+  (activity's `startTime`/`endTime`) hold different concrete values.
+- **Current:** attribute union; a concrete `startTime` conflict trips the
+  cardinality guard (accidental rejection, undocumented generic exception); extra
+  attributes union (correct — the spec unions attribute lists).
+- **Example (executed):** `activity(a1, 2011-11-16T16:00:00, -)` +
+  `activity(a1, 2012-01-01T00:00:00, -)` → `ProvException: Cannot have more than one
+  value for attribute prov:startTime` raised from inside `unified()`. Right outcome
+  class, wrong API: the exception is the generic cardinality guard, undocumented for
+  this purpose, raised mid-merge. Corpus: the compatible cases
+  (`activity-success1..4`, `attributes-*-success*`) all merge correctly, e.g. the
+  §6.1 worked example reproduces exactly:
+  `activity(a, 2011-11-16T16:00:00, -, [ex:a=1])` + `activity(a, -,
+  2011-11-16T18:00:00, [ex:b=2])` → `activity(a, 2011-11-16T16:00:00,
+  2011-11-16T18:00:00, [ex:a=1, ex:b=2])` (executed;
+  `test_compatible_partial_information_merges_like_the_spec_example`).
+- **36b:** replace the accidental guard with explicit pairwise unification of formal
+  attributes; merge failure raises the documented exception.
+
+### 3.3 Constraint 23 (key-properties): the eleven identified relations
+
+- **Spec:** same-id relation statements merge by pairwise unification of all formal
+  parameters; any concrete-vs-concrete disagreement is a merge failure.
+- **Current:** as 3.2 — concrete-vs-concrete conflicts accidentally raise the
+  cardinality guard (25 corpus fail-cases across
+  association/delegation/end/generation/invalidation/start/usage — the
+  `CARDINALITY_GUARD_REJECTS` set in the test module); placeholder-vs-concrete
+  conflicts merge silently (3.1); compatible merges union correctly.
+- **Example:** `generation-fail2` (`wasGeneratedBy(gen1; e1, a1, -)` +
+  `wasGeneratedBy(gen1; e2, a1, -)` with distinct concrete entities) →
+  `ProvException: Cannot have more than one value for attribute prov:entity`.
+  Versus `derivation-fail2` (`wasDerivedFrom(der1; e2, e1, a, -, -)` +
+  `wasDerivedFrom(der1; e2, e1, -, -, -)`) → silent merge to
+  `wasDerivedFrom(der1; e2, e1, a, -, -)` where the spec fails the merge (the
+  second statement's `-` asserts *no* activity).
+- **36b:** as 3.2, plus the placeholder handling of 3.1.
+
+### 3.4 Constraints 24–27: uniqueness keyed on formal-attribute pairs
+
+- **Spec:** e.g. Constraint 24: IF `wasGeneratedBy(gen1; e, a, _t1)` and
+  `wasGeneratedBy(gen2; e, a, _t2)` THEN `gen1 = gen2`. Two *distinct constant*
+  identifiers for the same (entity, activity) pair fail unification → invalid.
+  An anonymous generation (existential id) merges into the identified one — the
+  spec's §6.1 closing example normalizes `wasGeneratedBy(id1; e, a, -, [...])` +
+  `wasGeneratedBy(-; e, a, -, [...])` into a single statement.
+- **Current:** not implemented in either direction. `unified()` keys on the record
+  identifier only: differently-identified duplicates pass through untouched (no
+  rejection), and anonymous records never merge with identified ones (no
+  normalization).
+- **Examples (executed):** `generation-fail1` (`gen1` vs `gen1-other`, same pair)
+  → 4 records in, 4 out, no error (spec: invalid). `generation-success7`
+  (`gen1` twice plus one *anonymous* generation of the same pair) → the two `gen1`
+  records merge, the anonymous one stays separate (3 generations in, 2 out; spec
+  normal form: 1). So the gap is visible on the success side too: `unified()` does
+  not reach the spec's normal form even for valid instances. Same families:
+  `invalidation-fail1`, `usage-fail1` (also invalid under Constraint 50 — its
+  entity/activity arguments swap types), `start-fail4`, `end-fail4`,
+  `generation/invalidation/usage-fail5/6` (anonymous records with conflicting
+  times), `mention-fail4` (PROV-LINKS' analogous unique-mention rule).
+- **36b:** decide scope: a spec-complete `unified()` must apply Constraints 24–27
+  (merging anonymous records and failing on distinct-id duplicates); alternatively
+  36b documents `unified()` as Constraint-22/23-only and defers 24–29 to the #62
+  validation engine. Either way the behaviour must be documented and deliberate.
+
+### 3.5 Constraints 28–29: activity times vs start/end event times
+
+- **Spec:** IF `activity(a2, t1, _t2)` and `wasStartedBy(_start; a2, _e, _a1, t)`
+  THEN `t1 = t` (and the endTime dual). Conflicting concrete times → invalid.
+- **Current:** not implemented — the constraint spans two *record types*, which an
+  identifier-keyed union can never see.
+- **Example (corpus `activity-start-fail1`, executed):** `activity(a1,
+  2012-11-16T16:05:00, -)` + `activity(a1, -, 2012-11-16T17:05:00)` +
+  `wasStartedBy(start1; a1, -, -, 2111-11-11T11:11:11)` → the two activity records
+  merge (times compatible), the wildly different start-event time is never compared:
+  3 records in, 2 out, no error. Spec: invalid.
+- **36b:** same scope decision as 3.4.
+
+### 3.6 Incompatible record types (Constraints 50 typing / 55 entity-activity-disjoint)
+
+- **Spec:** `typeOf(e, entity)` and `typeOf(e, activity)` for the same identifier is
+  an impossibility — the instance is invalid. Key constraints only ever merge
+  statements of the *same* relation.
+- **Current:** `_id_map` keys on identifier alone, so records of *different types*
+  sharing an identifier are merged into a copy of whichever record came **first**;
+  the other record's formal attributes are demoted to extra attributes on the wrong
+  type.
+- **Example (executed, `test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity`):**
+  `entity(thing)` + `activity(thing, 2011-11-16T16:00:00, -)` → one record:
+  `entity(thing, [prov:startTime="2011-11-16T16:00:00" %% xsd:dateTime])` — an
+  entity wearing an activity's start time as a literal. Reversing assertion order
+  yields an activity instead: the merge result depends on record order.
+- **36b:** same-identifier records of incompatible base types must raise the
+  documented merge-failure exception (entity/activity disjointness at minimum;
+  agent/entity and agent/activity overlaps are *permitted* by the spec — Constraint
+  54 only forbids overlaps among entity/activity/generation/usage/... object kinds —
+  so 36b needs the spec's exact compatibility table, not a blanket "same class"
+  check).
+
+### 3.7 Fail-cases outside merging scope (for completeness)
+
+The corpus also contains fail-cases whose invalidity is *not* a merge failure:
+mandatory-position placeholders (`attribution-fail1/2`, `communication-fail1/2`,
+`influence-fail1/2`, `membership-fail1`, `mention-fail1/2/3`,
+`specialization-fail1/2`, `association-fail6`, `delegation-fail6` — ill-formed under
+the §5.1 expansion definitions; `prov` accepts them per the documented §2.8
+permissiveness family in the findings doc), impossibility
+(`specialization-fail3`, Constraint 52 reflexive) and ordering
+(`specialization-fail4`, Constraints 45/46 cycle) violations. `unified()` passes all
+of them through untouched today, and even a spec-complete 36b `unified()` would:
+these belong to the #62 validation engine. They are characterized as silent passes
+and must *remain* out of `unified()`'s documented scope (or 36b must say otherwise
+explicitly).
+
+## 4. Bundle scoping (§7.2)
+
+- **Spec:** every bundle and the toplevel instance normalize independently; no
+  cross-instance constraint application.
+- **`ProvDocument.unified()` — conformant.** Confirmed by code reading
+  (`bundle.py:1455-1480`: `_unified_records()` on the toplevel `_records` only —
+  `_id_map` is per-bundle — then `bundle.unified()` per sub-bundle) and by test
+  (`test_document_unified_scopes_unification_per_bundle`): sub-bundles are unified
+  independently of the parent document and of each other, even when all scopes share
+  record identifiers.
+- **`flattened().unified()` — spec-invalid usage, worth calling out.** `flattened()`
+  hoists every bundle's records into one instance, so the subsequent `unified()`
+  merges across bundle boundaries — executed: a document whose top level, `b1`, and
+  `b2` each assert `entity(e, [prov:label=...])` flattens+unifies to a single
+  `entity(e, [prov:label="top level", prov:label="in b1", prov:label="in b2"])`.
+  No PROV-CONSTRAINTS rule licenses this; two bundles describing different
+  real-world things under the same local name are silently conflated. This is
+  exactly what `test_unifying` (`src/prov/tests/test_model.py:83-97`) exercises over
+  the `unification/*.json` fixtures (which are single-instance documents, so it
+  happens to be harmless there). Characterized in
+  `test_flattened_unified_merges_across_bundle_boundaries`; kept working in 2.x.
+- **36b:** keep the per-bundle scoping of `ProvDocument.unified()`; document
+  `flattened()` composition as outside PROV-CONSTRAINTS semantics (a deliberate
+  "single-instance view" tool, not part of normalization).
+
+## 5. Corpus import and characterization summary
+
+153 files vendored from ProvToolbox (85 `-success`, 68 `-fail`; README in the corpus
+directory records origin, licence, naming convention). Observed behaviour, locked by
+`test_unified_corpus_characterization` — every non-raising case asserts the *exact*
+post-`unified()` record count implied by the identifier-keyed union (one record per
+distinct identifier per scope, plus every anonymous record unchanged: anonymous
+records never enter `_id_map`, `bundle.py:469-475`, so not even exact anonymous
+duplicates deduplicate); the formula matched the observed count for all 125
+non-raising cases with zero deviations:
+
+| Class | Count | Current behaviour |
+|---|---|---|
+| Parse failure (skip) | 3 | `bundle-fail1`, `bundle-success1`, `bundle-success2`: raw `UnboundLocalError` in `provxml._extract_attributes` on the `<prov:bundle>` container — **filed [#254](https://github.com/trungdong/prov/issues/254)** (new defect class: XML sibling of #228, with a second, silent-corruption mode where a previous sibling's value is reused; the files themselves are ProvToolbox-dialect, not XSD-valid PROV-XML) |
+| Success, parseable | 83 | `unified()` succeeds on all; same-id merges union attributes; **but** anonymous records that Constraints 24–27 would fold in stay separate (normal form not reached, §3.4) |
+| Fail, accidental rejection | 25 | concrete-vs-concrete formal-attribute conflicts raise the generic cardinality `ProvException` (`CARDINALITY_GUARD_REJECTS` set, §3.2/§3.3) |
+| Fail, silent merge/pass | 42 | placeholder-vs-concrete merges (12, §3.1/§3.3), uniqueness-constraint violations untouched (§3.4/§3.5), mandatory-placeholder / impossibility / ordering cases untouched (§3.7) |
+
+Every corpus case is asserted (pass) or skipped with a reason; nothing is hidden.
+
+## 6. Requirements for step 36b (3.0)
+
+1. **Documented merge-failure exception.** `unified()` merge failures raise a
+   dedicated, documented exception type (the 2.4.0 `FutureWarning` already promises
+   this); the accidental `add_attributes` cardinality guard stops being the
+   rejection mechanism.
+2. **Pairwise term unification of formal attributes** for same-id records of the
+   same relation/element type (Constraints 22/23), replacing the attribute union
+   for formal attributes; extra (non-formal) attributes keep set-union semantics
+   (that part of current behaviour matches the spec's `attrs1 ∪ attrs2`).
+3. **Placeholder semantics** (§3.1): decide the model representation of `-` vs
+   "unknown" and implement the §5.1 expansion table; placeholder-vs-concrete
+   unification fails.
+4. **Type compatibility** (§3.6): same-id records of incompatible base types fail
+   the merge, per the spec's object-overlap table (Constraints 54/55), not a naive
+   same-class check.
+5. **Scope decision for Constraints 24–29** (§3.4/§3.5): implement them in
+   `unified()` (both the anonymous-record merges and the failure cases) or document
+   `unified()` as key-constraint-only and defer to the #62 validation engine.
+   Explicitly out of scope either way: ordering, impossibility, and
+   mandatory-placeholder validation (§3.7).
+6. **Bundle scoping stays per-instance** (§4 above); `flattened()` composition is
+   documented as outside PROV-CONSTRAINTS semantics.
+7. **Corpus flip:** the fail-cases in `test_unification_constraints.py` covered by
+   the chosen scope flip from characterizing silent merges/accidental exceptions to
+   asserting the documented merge-failure exception; success-cases additionally
+   assert the spec's normal form where Constraints 24–27 apply (anonymous-record
+   folding, §3.4).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ prov = ["py.typed"]
     "rdf/*.ttl",
     "rdf/*.trig",
     "unification/*.json",
+    "unification/constraints/*",
     "malformed/*",
     "schemas/*",
 ]

--- a/src/prov/tests/test_unification_constraints.py
+++ b/src/prov/tests/test_unification_constraints.py
@@ -1,0 +1,310 @@
+"""Characterize unified() against the PROV-CONSTRAINTS unification corpus (roadmap step 30b).
+
+2.x locks CURRENT behaviour: ``unified()`` is an identifier-keyed attribute
+union with no PROV-CONSTRAINTS term unification. Observed outcomes over the
+vendored ProvToolbox/W3C corpus (``unification/constraints/``):
+
+- fail-cases whose same-identifier records carry *conflicting concrete* formal
+  attribute values are rejected, but only accidentally — ``ProvRecord.
+  add_attributes``'s cardinality guard (``src/prov/model/records.py:622-643``)
+  raises a generic ``ProvException("Cannot have more than one value for
+  attribute ...")`` mid-merge (``CARDINALITY_GUARD_REJECTS`` below);
+- every other fail-case silently merges (placeholder-vs-concrete conflicts,
+  which the model cannot represent) or passes through untouched (uniqueness
+  Constraints 24-29, mandatory-placeholder and impossibility cases, all keyed
+  on something other than the record identifier);
+- three ``bundle-*`` files cannot be parsed at all (issue #254) and are
+  skipped as parse failures.
+
+In 3.0 (roadmap step 36b, umbrella issue #253) ``unified()`` will implement
+the spec's merging: the key-constraint fail-cases below flip to asserting the
+documented merge-failure exception (fail-cases outside ``unified()``'s
+merging scope — ordering/impossibility/mandatory-placeholder validation —
+get their disposition decided in step 36b). Authority:
+docs/superpowers/specs/2026-07-10-unification-gap-analysis.md
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("lxml")
+
+from prov.model import ProvDocument, ProvException
+
+# unified()'s FutureWarning (2.4.0 signpost for the 3.0 rework) is already
+# ignored via pyproject.toml's filterwarnings; the mark keeps these tests
+# self-contained should that global filter ever change.
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+CORPUS = Path(__file__).parent / "unification" / "constraints"
+
+# prov's PROV-XML deserializer crashes on these (raw UnboundLocalError in
+# _extract_attributes, provxml.py:456) because they wrap bundle contents in
+# ProvToolbox's <prov:bundle> container instead of the XSD's
+# <prov:bundleContent> — issue #254, recorded in the gap analysis.
+PARSE_FAILURES = {
+    "bundle-fail1.xml",
+    "bundle-success1.xml",
+    "bundle-success2.xml",
+}
+
+# Fail-cases currently rejected by the accidental cardinality guard: their
+# same-identifier records carry two *different concrete* values for the same
+# formal attribute, so the merge's add_attributes() call raises. This is the
+# only rejection unified() performs today.
+CARDINALITY_GUARD_REJECTS = {
+    "association-fail1.xml",
+    "association-fail2.xml",
+    "association-fail3.xml",
+    "delegation-fail1.xml",
+    "delegation-fail2.xml",
+    "delegation-fail3.xml",
+    "end-fail1.xml",
+    "end-fail2.xml",
+    "end-fail3.xml",
+    "end-fail5.xml",
+    "generation-fail2.xml",
+    "generation-fail3.xml",
+    "generation-fail4.xml",
+    "invalidation-fail2.xml",
+    "invalidation-fail3.xml",
+    "invalidation-fail4.xml",
+    "start-fail1.xml",
+    "start-fail2.xml",
+    "start-fail3.xml",
+    "start-fail5.xml",
+    "start-fail6.xml",
+    "start-fail8.xml",
+    "usage-fail2.xml",
+    "usage-fail3.xml",
+    "usage-fail4.xml",
+}
+
+
+def _n_records(document):
+    return len(document.get_records()) + sum(
+        len(b.get_records()) for b in document.bundles
+    )
+
+
+def _expected_unified_count(document):
+    # The exact record count _unified_records() (bundle.py:384-414) produces,
+    # computed from the pre-merge document: per scope (toplevel and each
+    # bundle), identified records collapse to one per distinct identifier
+    # (regardless of record type or attribute conflicts), while anonymous
+    # records never enter _id_map (bundle.py:469-475) and ALL pass through
+    # unchanged — not even exact duplicates are deduplicated.
+    total = 0
+    for scope in (document, *document.bundles):
+        records = scope.get_records()
+        identified = {r.identifier for r in records if r.identifier is not None}
+        anonymous = sum(1 for r in records if r.identifier is None)
+        total += len(identified) + anonymous
+    return total
+
+
+def _cases():
+    for xml_path in sorted(CORPUS.glob("*.xml")):
+        expected = "success" if "-success" in xml_path.stem else "fail"
+        marks = []
+        if xml_path.name in PARSE_FAILURES:
+            marks.append(
+                pytest.mark.skip(
+                    reason="prov cannot parse: UnboundLocalError in provxml "
+                    "_extract_attributes on the <prov:bundle> container "
+                    "(#254) — recorded in the gap analysis"
+                )
+            )
+        yield pytest.param(xml_path, expected, id=xml_path.stem, marks=marks)
+
+
+def test_corpus_inventory():
+    # Guard against the vendored corpus being truncated or renamed: 153 files,
+    # and the behaviour sets above must keep referring to real fail-cases.
+    files = {p.name for p in CORPUS.glob("*.xml")}
+    assert len(files) == 153
+    assert files >= PARSE_FAILURES
+    assert files >= CARDINALITY_GUARD_REJECTS
+    assert all("-fail" in name for name in CARDINALITY_GUARD_REJECTS)
+
+
+@pytest.mark.parametrize("xml_path, expected", list(_cases()))
+def test_unified_corpus_characterization(xml_path, expected):
+    with open(xml_path, "rb") as f:
+        document = ProvDocument.deserialize(f, format="xml")
+    if expected == "success":
+        # Valid instances all unify without complaint, and the result is
+        # exactly the identifier-keyed union (verified for the whole corpus:
+        # the observed count matches the formula for all 125 non-raising
+        # cases). Note this is NOT always the spec's normal form: anonymous
+        # records that Constraints 24-27 would fold into an identified one
+        # stay separate (gap analysis section 3.4).
+        unified = document.unified()
+        assert _n_records(unified) == _expected_unified_count(document)
+    elif xml_path.name in CARDINALITY_GUARD_REJECTS:
+        # Invalid instance rejected, but only via the accidental cardinality
+        # guard — not a documented merge-failure API.
+        # 3.0 triage (#253): must raise the documented merge-failure exception.
+        with pytest.raises(ProvException, match="more than one value"):
+            document.unified()
+    else:
+        # Invalid instance ("fail" per the corpus label) that unified()
+        # nevertheless accepts, producing the plain identifier-keyed union —
+        # this silent acceptance IS the documented gap.
+        # 3.0 triage (#253): key-constraint fail-cases must raise instead.
+        unified = document.unified()
+        assert _n_records(unified) == _expected_unified_count(document)
+
+
+# --- Hand-written per-rule gap examples (see the gap-analysis doc, section 3)
+
+
+def test_conflicting_start_times_currently_hit_the_cardinality_guard():
+    # PROV-CONSTRAINTS Constraint 22 (key-object): two activity records with
+    # the same id and different startTime values do not unify; the spec
+    # requires the merge (and thus normalization) to FAIL. Currently the
+    # attribute union trips ProvRecord.add_attributes's cardinality guard
+    # (records.py:622-643) — the right outcome class by accident, via an
+    # undocumented generic exception.
+    # 3.0 triage (#253): must raise the documented merge-failure exception.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.activity("a1", startTime="2011-11-16T16:00:00")
+    doc.activity("a1", startTime="2012-01-01T00:00:00")
+    with pytest.raises(
+        ProvException, match="more than one value for attribute prov:startTime"
+    ):
+        doc.unified()
+
+
+def test_placeholder_vs_concrete_plan_currently_merges_silently():
+    # PROV-CONSTRAINTS §4: the placeholder - is a constant; it unifies only
+    # with itself or an existential variable, never with a concrete value.
+    # Corpus analogue association-fail4: wasAssociatedWith(assoc1; a1, ag1,
+    # ex:pl1) + wasAssociatedWith(assoc1; a1, ag1, -) must FAIL to merge.
+    # prov cannot represent -, so the absent plan merges silently with the
+    # concrete one.
+    # 3.0 triage (#253): 36b must decide the model's placeholder story and
+    # raise the documented merge-failure exception here.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.association("a1", agent="ag1", plan="pl1", identifier="assoc1")
+    doc.association("a1", agent="ag1", identifier="assoc1")
+    unified = doc.unified()
+    records = unified.get_records()
+    assert len(records) == 1
+    assert records[0].get_provn() == "wasAssociatedWith(assoc1; a1, ag1, pl1)"
+
+
+def test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity():
+    # PROV-CONSTRAINTS Constraint 55 (entity-activity-disjoint) makes an
+    # entity and an activity with the same identifier INVALID (with
+    # Constraint 50, typing). Currently they merge into a copy of whichever
+    # record came first — here a ProvEntity — with the activity's formal
+    # startTime demoted to an extra literal attribute.
+    # 3.0 triage (#253): must raise the documented merge-failure exception.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.entity("thing")
+    doc.activity("thing", startTime="2011-11-16T16:00:00")
+    unified = doc.unified()
+    records = unified.get_records()
+    assert len(records) == 1
+    assert (
+        records[0].get_provn()
+        == 'entity(thing, [prov:startTime="2011-11-16T16:00:00" %% xsd:dateTime])'
+    )
+
+
+def test_uniqueness_constraints_on_other_keys_are_currently_ignored():
+    # PROV-CONSTRAINTS Constraint 24 (unique-generation): two generations of
+    # the same (entity, activity) pair must have equal identifiers — two
+    # *different* constant identifiers cannot unify, so this instance is
+    # INVALID (corpus analogue generation-fail1). unified() keys on the
+    # record identifier only and leaves both records untouched.
+    # 3.0 triage (#253): 36b must decide whether Constraints 24-29 are in
+    # unified()'s scope; if so this must raise.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.entity("e1")
+    doc.activity("a1")
+    doc.generation("e1", "a1", identifier="gen1")
+    doc.generation("e1", "a1", identifier="gen1-other")
+    unified = doc.unified()
+    assert len(unified.get_records()) == 4  # nothing merged, nothing rejected
+
+
+def test_compatible_partial_information_merges_like_the_spec_example():
+    # The one case current behaviour gets right: PROV-CONSTRAINTS §6.1's
+    # worked example — activity(a, t1, _t, [ex:a=1]) + activity(a, _t, t2,
+    # [ex:b=2]) merge into activity(a, t1, t2, [ex:a=1, ex:b=2]) — because
+    # absent formal attributes union cleanly with concrete ones.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.add_namespace("ex", "http://example.org/ns#")
+    doc.activity("a", startTime="2011-11-16T16:00:00", other_attributes={"ex:a": 1})
+    doc.activity("a", endTime="2011-11-16T18:00:00", other_attributes={"ex:b": 2})
+    unified = doc.unified()
+    records = unified.get_records()
+    assert len(records) == 1
+    assert (
+        records[0].get_provn()
+        == "activity(a, 2011-11-16T16:00:00, 2011-11-16T18:00:00, [ex:a=1, ex:b=2])"
+    )
+
+
+# --- Bundle scoping (PROV-CONSTRAINTS section 7.2)
+
+
+def test_document_unified_scopes_unification_per_bundle():
+    # PROV-CONSTRAINTS 7.2: each bundle is normalized independently; nothing
+    # merges across bundle boundaries. ProvDocument.unified()
+    # (bundle.py:1455-1480) conforms: the top level and each sub-bundle are
+    # unified independently of the document and of each other, even when
+    # they share record identifiers.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.entity("e", {"prov:label": "top level"})
+    b1 = doc.bundle("b1")
+    b1.entity("e", {"prov:label": "in b1 first"})
+    b1.entity("e", {"prov:label": "in b1 second"})
+    b2 = doc.bundle("b2")
+    b2.entity("e", {"prov:label": "in b2"})
+
+    unified = doc.unified()
+
+    assert len(unified.get_records()) == 1  # top level untouched by bundles
+    bundles = {str(b.identifier): b for b in unified.bundles}
+    assert set(bundles) == {"b1", "b2"}
+    # b1's two same-id records merged within b1 only (label set union).
+    (b1_record,) = bundles["b1"].get_records()
+    assert {str(label) for label in b1_record.get_attribute("prov:label")} == {
+        "in b1 first",
+        "in b1 second",
+    }
+    # b2's record did not absorb anything from b1 or the top level.
+    (b2_record,) = bundles["b2"].get_records()
+    assert {str(label) for label in b2_record.get_attribute("prov:label")} == {"in b2"}
+
+
+def test_flattened_unified_merges_across_bundle_boundaries():
+    # The flattened().unified() idiom (as test_unifying in test_model.py uses)
+    # merges same-id records ACROSS bundles — no PROV-CONSTRAINTS rule
+    # licenses that (7.2 scopes constraints per bundle). Characterized here as
+    # spec-invalid usage; kept working in 2.x.
+    # 3.0 triage (#253): 36b must document this as outside PROV-CONSTRAINTS.
+    doc = ProvDocument()
+    doc.set_default_namespace("http://example.org/")
+    doc.entity("e", {"prov:label": "top level"})
+    doc.bundle("b1").entity("e", {"prov:label": "in b1"})
+    doc.bundle("b2").entity("e", {"prov:label": "in b2"})
+
+    merged = doc.flattened().unified()
+
+    (record,) = merged.get_records()
+    assert {str(label) for label in record.get_attribute("prov:label")} == {
+        "top level",
+        "in b1",
+        "in b2",
+    }

--- a/src/prov/tests/unification/constraints/README.md
+++ b/src/prov/tests/unification/constraints/README.md
@@ -1,0 +1,71 @@
+# PROV-CONSTRAINTS unification corpus
+
+153 PROV-XML documents exercising the W3C PROV-CONSTRAINTS unification and
+key-constraint rules, consumed by `src/prov/tests/test_unification_constraints.py`
+(characterization of `unified()`, roadmap step 30b; the 3.0 reimplementation is
+roadmap step 36b — umbrella issue
+[#253](https://github.com/trungdong/prov/issues/253)).
+
+## Origin
+
+Copied verbatim (retrieved 2026-07-11) from a local checkout of
+[ProvToolbox](https://github.com/lucmoreau/ProvToolbox), the Java reference
+implementation, at:
+
+```
+modules-validation/prov-validation/src/test/resources/validate/unification/*.xml
+```
+
+The source directory also carries a paired `.provn` file per case (consumed by
+ProvToolbox's `ValidateTest.java`); only the `.xml` files are vendored here
+because `prov` has no PROV-N parser. These cases derive from the test cases
+assembled by the W3C Provenance Working Group for the PROV-CONSTRAINTS
+implementation report (PROV-CONSTRAINTS is a W3C Recommendation, 2013-04-30,
+<https://www.w3.org/TR/prov-constraints/>), as implemented and maintained in
+ProvToolbox's validation module.
+
+## Licence
+
+ProvToolbox is distributed under an MIT-style licence (`license.txt` in its
+repository root):
+
+> Copyright (c) 2018–2023 King's College London,
+> 2011–2017 University of Southampton
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to
+> deal in the Software without restriction, including without limitation the
+> rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+> sell copies of the Software [...] subject to [inclusion of] the above
+> copyright notice and this permission notice [...]. THE SOFTWARE IS PROVIDED
+> "AS IS", WITHOUT WARRANTY OF ANY KIND.
+
+## Naming convention
+
+Files are named `<category>-successN.xml` / `<category>-failN.xml`:
+
+- `*-successN`: a **valid** instance — applying the PROV-CONSTRAINTS
+  uniqueness/key constraints (§6.1, Constraints 22–29) normalizes it
+  successfully (same-identifier statements merge; compatible partial
+  information is combined).
+- `*-failN`: an **invalid** instance — normalization/validation fails, e.g.
+  a key-constraint merge fails (non-unifiable formal attributes, placeholder
+  `-` vs a concrete value), a uniqueness constraint (24–29) is violated, a
+  mandatory argument is the placeholder `-`, or an impossibility constraint
+  (e.g. 52) is violated.
+
+`<category>` names the record type or rule family under test (`activity`,
+`generation`, ..., `activity-start`/`activity-end` for Constraints 28/29,
+`attributes-*` for attribute-combination cases, `bundle` for bundle scoping).
+
+## Local quirks
+
+- Each file begins with a `<?org.openprovenance.prov.xml ...?>` processing
+  instruction instead of a standard XML declaration; XML parsers accept it.
+- The three `bundle-*.xml` files wrap bundle contents in `<prov:bundle>`
+  (ProvToolbox's dialect) where the W3C PROV-XML XSD (vendored under
+  `src/prov/tests/schemas/`) defines `<prov:bundleContent>`; `prov` cannot
+  parse them (issue [#254](https://github.com/trungdong/prov/issues/254)) and
+  the test module skips them as parse failures.
+
+Do not edit the `.xml` files; they are a vendored upstream corpus.

--- a/src/prov/tests/unification/constraints/activity-end-fail1.xml
+++ b/src/prov/tests/unification/constraints/activity-end-fail1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+
+        <prov:wasEndedBy prov:id="ex:end1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:time>2111-11-11T11:11:11</prov:time>
+        </prov:wasEndedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-end-success1.xml
+++ b/src/prov/tests/unification/constraints/activity-end-success1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+
+        <prov:wasEndedBy prov:id="ex:end1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:time>2012-11-16T17:05:00</prov:time>
+        </prov:wasEndedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-start-fail1.xml
+++ b/src/prov/tests/unification/constraints/activity-start-fail1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+
+        <prov:wasStartedBy prov:id="ex:start1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:time>2111-11-11T11:11:11</prov:time>
+        </prov:wasStartedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-start-success1.xml
+++ b/src/prov/tests/unification/constraints/activity-start-success1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+
+        <prov:wasStartedBy prov:id="ex:start1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:time>2012-11-16T16:05:00</prov:time>
+        </prov:wasStartedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-success1.xml
+++ b/src/prov/tests/unification/constraints/activity-success1.xml
@@ -1,0 +1,9 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-success2.xml
+++ b/src/prov/tests/unification/constraints/activity-success2.xml
@@ -1,0 +1,10 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-success3.xml
+++ b/src/prov/tests/unification/constraints/activity-success3.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+        <prov:activity prov:id="ex:a1">
+
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/activity-success4.xml
+++ b/src/prov/tests/unification/constraints/activity-success4.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:a1">
+          <prov:startTime>2012-11-16T16:05:00</prov:startTime>
+        </prov:activity>
+        <prov:activity prov:id="ex:a1">
+          <prov:endTime>2012-11-16T17:05:00</prov:endTime>
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail1.xml
+++ b/src/prov/tests/unification/constraints/association-fail1.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1-other"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail2.xml
+++ b/src/prov/tests/unification/constraints/association-fail2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1-other"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail3.xml
+++ b/src/prov/tests/unification/constraints/association-fail3.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1-other"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail4.xml
+++ b/src/prov/tests/unification/constraints/association-fail4.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+		<!-- Does not match known plan -->
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail5.xml
+++ b/src/prov/tests/unification/constraints/association-fail5.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+		<!-- matches known agent -->
+		<!-- Does not match known plan -->
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-fail6.xml
+++ b/src/prov/tests/unification/constraints/association-fail6.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+	         <!-- missing activity -->
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-success1.xml
+++ b/src/prov/tests/unification/constraints/association-success1.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-success2.xml
+++ b/src/prov/tests/unification/constraints/association-success2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc2">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-success3.xml
+++ b/src/prov/tests/unification/constraints/association-success3.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-success4.xml
+++ b/src/prov/tests/unification/constraints/association-success4.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith prov:id="ex:assoc1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/association-success5.xml
+++ b/src/prov/tests/unification/constraints/association-success5.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">prov:Plan</prov:type>
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:wasAssociatedWith >
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+            <prov:wasAssociatedWith >
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:agent prov:ref="ex:ag1"/>
+                <prov:plan prov:ref="ex:e1"/>
+            </prov:wasAssociatedWith>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-activity-success1.xml
+++ b/src/prov/tests/unification/constraints/attributes-activity-success1.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+
+
+        <prov:activity prov:id="ex:a1">
+	  <prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+        </prov:activity>
+        <prov:activity prov:id="ex:a1">
+	  <prov:type xsi:type="xsd:QName">ex:test2</prov:type>
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-end-success1.xml
+++ b/src/prov/tests/unification/constraints/attributes-end-success1.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy>  <!-- able to unify the end id -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:QName">ex:test2</prov:type>
+            </prov:wasEndedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-end-success2.xml
+++ b/src/prov/tests/unification/constraints/attributes-end-success2.xml
@@ -1,0 +1,30 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+		<prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+            </prov:wasEndedBy>
+
+            <prov:wasEndedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:string">ex:test1</prov:type>
+            </prov:wasEndedBy>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:ender prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:int">1</prov:type>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-entity-success1.xml
+++ b/src/prov/tests/unification/constraints/attributes-entity-success1.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+        </prov:entity>
+
+        <prov:entity prov:id="ex:e1">
+	  <prov:type xsi:type="xsd:QName">ex:test2</prov:type>
+        </prov:entity>
+
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-start-success1.xml
+++ b/src/prov/tests/unification/constraints/attributes-start-success1.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy>  <!-- able to unify the start id -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:QName">ex:test2</prov:type>
+            </prov:wasStartedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/attributes-start-success2.xml
+++ b/src/prov/tests/unification/constraints/attributes-start-success2.xml
@@ -1,0 +1,30 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+		<prov:type xsi:type="xsd:QName">ex:test1</prov:type>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:string">ex:test1</prov:type>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+		<prov:type xsi:type="xsd:int">1</prov:type>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-fail1.xml
+++ b/src/prov/tests/unification/constraints/attribution-fail1.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo prov:id="ex:del1">
+                <prov:entity prov:ref="ex:e1"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-fail2.xml
+++ b/src/prov/tests/unification/constraints/attribution-fail2.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo prov:id="ex:del1">
+                <prov:agent prov:ref="ex:e1"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-success1.xml
+++ b/src/prov/tests/unification/constraints/attribution-success1.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo prov:id="ex:del1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+            <prov:wasAttributedTo prov:id="ex:del1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-success2.xml
+++ b/src/prov/tests/unification/constraints/attribution-success2.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo prov:id="ex:del1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+            <prov:wasAttributedTo prov:id="ex:del2">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-success3.xml
+++ b/src/prov/tests/unification/constraints/attribution-success3.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+            <prov:wasAttributedTo prov:id="ex:del2">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/attribution-success4.xml
+++ b/src/prov/tests/unification/constraints/attribution-success4.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1"></prov:entity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+
+            <prov:wasAttributedTo>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+            <prov:wasAttributedTo>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:agent prov:ref="ex:ag2"/>
+            </prov:wasAttributedTo>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/bundle-fail1.xml
+++ b/src/prov/tests/unification/constraints/bundle-fail1.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+	 <prov:bundle prov:id="ex:bundle1">
+           <prov:entity prov:id="ex:e1">
+           </prov:entity>
+           <prov:activity prov:id="ex:e1">
+           </prov:activity>
+	 </prov:bundle>
+
+
+	 <prov:bundle prov:id="ex:bundle2">
+           <prov:entity prov:id="ex:e1">
+	     <prov:type xsi:type="xsd:QName">prov:EmptyCollection</prov:type>
+           </prov:entity>
+
+           <prov:hadMember>
+             <prov:collection prov:ref="ex:e1"/>
+             <prov:entity prov:ref="ex:e2"/>
+           </prov:hadMember>
+
+	 </prov:bundle>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/bundle-success1.xml
+++ b/src/prov/tests/unification/constraints/bundle-success1.xml
@@ -1,0 +1,12 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+	 <prov:bundle prov:id="ex:bundle1">
+           <prov:entity prov:id="ex:e1">
+           </prov:entity>
+	 </prov:bundle>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/bundle-success2.xml
+++ b/src/prov/tests/unification/constraints/bundle-success2.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+	 <prov:bundle prov:id="ex:bundle1">
+           <prov:entity prov:id="ex:e1">
+           </prov:entity>
+	 </prov:bundle>
+
+
+	 <prov:bundle prov:id="ex:bundle2">
+           <prov:activity prov:id="ex:e1">
+           </prov:activity>
+	 </prov:bundle>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-fail1.xml
+++ b/src/prov/tests/unification/constraints/communication-fail1.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy prov:id="ex:inf1">
+                <prov:informed prov:ref="ex:a1"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-fail2.xml
+++ b/src/prov/tests/unification/constraints/communication-fail2.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy prov:id="ex:inf1">
+                <prov:informant prov:ref="ex:a1"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-success1.xml
+++ b/src/prov/tests/unification/constraints/communication-success1.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy prov:id="ex:inf1">
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+            <prov:wasInformedBy prov:id="ex:inf1">
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-success2.xml
+++ b/src/prov/tests/unification/constraints/communication-success2.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy prov:id="ex:inf1">
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+            <prov:wasInformedBy prov:id="ex:inf2">
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-success3.xml
+++ b/src/prov/tests/unification/constraints/communication-success3.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy>
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+            <prov:wasInformedBy prov:id="ex:inf2">
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/communication-success4.xml
+++ b/src/prov/tests/unification/constraints/communication-success4.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a1"></prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasInformedBy>
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+            <prov:wasInformedBy>
+                <prov:informed prov:ref="ex:a1"/>
+                <prov:informant prov:ref="ex:a2"/>
+            </prov:wasInformedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail1.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail1.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1-other"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail2.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2-other"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail3.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail3.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2-other"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail4.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail4.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+		<!-- Does not match known activity -->
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail5.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail5.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+		<!-- matches known agent -->
+		<!-- Does not match known activity -->
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-fail6.xml
+++ b/src/prov/tests/unification/constraints/delegation-fail6.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+	         <!-- missing agent -->
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-success1.xml
+++ b/src/prov/tests/unification/constraints/delegation-success1.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-success2.xml
+++ b/src/prov/tests/unification/constraints/delegation-success2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del2">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-success3.xml
+++ b/src/prov/tests/unification/constraints/delegation-success3.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-success4.xml
+++ b/src/prov/tests/unification/constraints/delegation-success4.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf prov:id="ex:del1">
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/delegation-success5.xml
+++ b/src/prov/tests/unification/constraints/delegation-success5.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:a2">
+	  
+        </prov:activity>
+        <prov:agent prov:id="ex:ag2">
+        </prov:agent>
+        <prov:agent prov:id="ex:ag1">
+        </prov:agent>
+
+            <prov:actedOnBehalfOf >
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+            <prov:actedOnBehalfOf >
+                <prov:delegate prov:ref="ex:ag2"/>
+                <prov:responsible prov:ref="ex:ag1"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:actedOnBehalfOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-fail1.xml
+++ b/src/prov/tests/unification/constraints/derivation-fail1.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:generation prov:ref="ex:gen"/>
+		<prov:usage prov:ref="ex:use"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-fail2.xml
+++ b/src/prov/tests/unification/constraints/derivation-fail2.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-fail3.xml
+++ b/src/prov/tests/unification/constraints/derivation-fail3.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:generation prov:ref="ex:gen"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-fail4.xml
+++ b/src/prov/tests/unification/constraints/derivation-fail4.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:usage prov:ref="ex:use"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-success1.xml
+++ b/src/prov/tests/unification/constraints/derivation-success1.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-success2.xml
+++ b/src/prov/tests/unification/constraints/derivation-success2.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-success3.xml
+++ b/src/prov/tests/unification/constraints/derivation-success3.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:generation prov:ref="ex:gen"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<!-- successful unification of generation -->
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-success4.xml
+++ b/src/prov/tests/unification/constraints/derivation-success4.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:usage prov:ref="ex:use"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<!-- successful unification of use -->
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/derivation-success5.xml
+++ b/src/prov/tests/unification/constraints/derivation-success5.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:generation prov:ref="ex:gen"/>
+		<prov:usage prov:ref="ex:use"/>
+            </prov:wasDerivedFrom>
+            <prov:wasDerivedFrom prov:id="ex:der1">
+                <prov:generatedEntity prov:ref="ex:e2"/>
+                <prov:usedEntity prov:ref="ex:e1"/>
+		<prov:activity prov:ref="ex:a"/>
+		<prov:generation prov:ref="ex:gen"/>
+		<prov:usage prov:ref="ex:use"/>
+            </prov:wasDerivedFrom>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-fail1.xml
+++ b/src/prov/tests/unification/constraints/end-fail1.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1"> 
+                <prov:activity prov:ref="ex:a1-other"/>  <!-- unable to unify -->
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-fail2.xml
+++ b/src/prov/tests/unification/constraints/end-fail2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1"> 
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1-other"/><!-- unable to unify -->
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-fail3.xml
+++ b/src/prov/tests/unification/constraints/end-fail3.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1"> 
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2-other"/><!-- unable to unify -->
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-fail4.xml
+++ b/src/prov/tests/unification/constraints/end-fail4.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1-other">  <!-- unable to unify, simulatenous start -->
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-fail5.xml
+++ b/src/prov/tests/unification/constraints/end-fail5.xml
@@ -1,0 +1,24 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+	        <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1"> 
+	        <prov:time>2011-11-16T16:05:00</prov:time>  <!-- fails to unify -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success1.xml
+++ b/src/prov/tests/unification/constraints/end-success1.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy>  <!-- able to unify the end id -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success2.xml
+++ b/src/prov/tests/unification/constraints/end-success2.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+        <prov:wasEndedBy prov:id="ex:end1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:trigger prov:ref="ex:e1"/>
+          <prov:ender prov:ref="ex:a2"/>
+        </prov:wasEndedBy>
+
+        <prov:wasEndedBy>
+	  <!-- able to unify the end id -->
+          <prov:activity prov:ref="ex:a1"/>
+	  <!-- able to unify the trigger id -->
+          <prov:ender prov:ref="ex:a2"/>
+        </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success3.xml
+++ b/src/prov/tests/unification/constraints/end-success3.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+        <prov:wasEndedBy prov:id="ex:end1">
+          <!-- able to unify time -->
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:trigger prov:ref="ex:e1"/>
+          <prov:ender prov:ref="ex:a2"/>
+        </prov:wasEndedBy>
+        <prov:wasEndedBy>
+	  <prov:time>2011-11-16T16:05:00</prov:time>
+	  <!-- able to unify the end id -->
+          <prov:activity prov:ref="ex:a1"/>
+	  <!-- able to unify the trigger id -->
+          <prov:ender prov:ref="ex:a2"/>
+        </prov:wasEndedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success4.xml
+++ b/src/prov/tests/unification/constraints/end-success4.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy>
+	         <!-- able to unify the end id -->
+                <prov:activity prov:ref="ex:a1"/>
+		<!-- able to unify the trigger id -->
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success5.xml
+++ b/src/prov/tests/unification/constraints/end-success5.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+            </prov:wasEndedBy>
+
+            <prov:wasEndedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/end-success6.xml
+++ b/src/prov/tests/unification/constraints/end-success6.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasEndedBy>
+
+            <prov:wasEndedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+            <prov:wasEndedBy prov:id="ex:end1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:ender prov:ref="ex:a2"/>
+            </prov:wasEndedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail1.xml
+++ b/src/prov/tests/unification/constraints/generation-fail1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1-other">  <!-- unable to unify, simult gen -->
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail2.xml
+++ b/src/prov/tests/unification/constraints/generation-fail2.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1-other"/>  <!-- unable to unify -->
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail3.xml
+++ b/src/prov/tests/unification/constraints/generation-fail3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1-other"/>  <!-- unable to unify -->
+            </prov:wasGeneratedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail4.xml
+++ b/src/prov/tests/unification/constraints/generation-fail4.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail5.xml
+++ b/src/prov/tests/unification/constraints/generation-fail5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail6.xml
+++ b/src/prov/tests/unification/constraints/generation-fail6.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-fail7.xml
+++ b/src/prov/tests/unification/constraints/generation-fail7.xml
@@ -1,0 +1,24 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success1.xml
+++ b/src/prov/tests/unification/constraints/generation-success1.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success2.xml
+++ b/src/prov/tests/unification/constraints/generation-success2.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+		 <!-- able to unify activity -->
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success3.xml
+++ b/src/prov/tests/unification/constraints/generation-success3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy> 		 <!-- able to unify id -->
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success4.xml
+++ b/src/prov/tests/unification/constraints/generation-success4.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen2">   <!-- different generation entirely -->
+                <prov:entity prov:ref="ex:e2"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success5.xml
+++ b/src/prov/tests/unification/constraints/generation-success5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success6.xml
+++ b/src/prov/tests/unification/constraints/generation-success6.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success7.xml
+++ b/src/prov/tests/unification/constraints/generation-success7.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/generation-success8.xml
+++ b/src/prov/tests/unification/constraints/generation-success8.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+            <prov:wasGeneratedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasGeneratedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-fail1.xml
+++ b/src/prov/tests/unification/constraints/influence-fail1.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy prov:id="ex:infl1">
+                <prov:influencee prov:ref="ex:x1"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-fail2.xml
+++ b/src/prov/tests/unification/constraints/influence-fail2.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy prov:id="ex:infl1">
+                <prov:influencer prov:ref="ex:x1"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-success1.xml
+++ b/src/prov/tests/unification/constraints/influence-success1.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy prov:id="ex:infl1">
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+            <prov:wasInfluencedBy prov:id="ex:infl1">
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-success2.xml
+++ b/src/prov/tests/unification/constraints/influence-success2.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy prov:id="ex:infl1">
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+            <prov:wasInfluencedBy prov:id="ex:infl2">
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-success3.xml
+++ b/src/prov/tests/unification/constraints/influence-success3.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy>
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+            <prov:wasInfluencedBy prov:id="ex:infl2">
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/influence-success4.xml
+++ b/src/prov/tests/unification/constraints/influence-success4.xml
@@ -1,0 +1,16 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        
+        
+        
+
+            <prov:wasInfluencedBy>
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+            <prov:wasInfluencedBy>
+                <prov:influencee prov:ref="ex:x1"/>
+                <prov:influencer prov:ref="ex:x2"/>
+            </prov:wasInfluencedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail1.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1-other">  <!-- unable to unify, simult gen -->
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail2.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail2.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1-other"/>  <!-- unable to unify -->
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail3.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1-other"/>  <!-- unable to unify -->
+            </prov:wasInvalidatedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail4.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail4.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail5.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail6.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail6.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-fail7.xml
+++ b/src/prov/tests/unification/constraints/invalidation-fail7.xml
@@ -1,0 +1,24 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success1.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success1.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success2.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success2.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+		 <!-- able to unify activity -->
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success3.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy> 		 <!-- able to unify id -->
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success4.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success4.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen2">   <!-- different generation entirely -->
+                <prov:entity prov:ref="ex:e2"/>
+                <prov:activity prov:ref="ex:a2"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success5.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success6.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success6.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success7.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success7.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/invalidation-success8.xml
+++ b/src/prov/tests/unification/constraints/invalidation-success8.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy prov:id="ex:gen1">
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+            <prov:wasInvalidatedBy>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:entity prov:ref="ex:e1"/>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasInvalidatedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/membership-fail1.xml
+++ b/src/prov/tests/unification/constraints/membership-fail1.xml
@@ -1,0 +1,12 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+        <prov:hadMember>
+          <prov:collection prov:ref="ex:e2"/>
+        </prov:hadMember>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/membership-success1.xml
+++ b/src/prov/tests/unification/constraints/membership-success1.xml
@@ -1,0 +1,13 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+        <prov:hadMember>
+          <prov:collection prov:ref="ex:e2"/>
+          <prov:entity prov:ref="ex:e1"/>
+        </prov:hadMember>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-fail1.xml
+++ b/src/prov/tests/unification/constraints/mention-fail1.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+	       <!-- missing -->
+                <prov:generalEntity prov:ref="ex:e1"/>
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-fail2.xml
+++ b/src/prov/tests/unification/constraints/mention-fail2.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-fail3.xml
+++ b/src/prov/tests/unification/constraints/mention-fail3.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-fail4.xml
+++ b/src/prov/tests/unification/constraints/mention-fail4.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+
+            <prov:mentionOf> 
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1-other"/>  <!-- other -->
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-success1.xml
+++ b/src/prov/tests/unification/constraints/mention-success1.xml
@@ -1,0 +1,14 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/mention-success2.xml
+++ b/src/prov/tests/unification/constraints/mention-success2.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:mentionOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+
+            <prov:mentionOf> <!-- duplicate -->
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+                <prov:bundle prov:ref="ex:b"/>
+            </prov:mentionOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-fail1.xml
+++ b/src/prov/tests/unification/constraints/specialization-fail1.xml
@@ -1,0 +1,12 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-fail2.xml
+++ b/src/prov/tests/unification/constraints/specialization-fail2.xml
@@ -1,0 +1,12 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:generalEntity prov:ref="ex:e1"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-fail3.xml
+++ b/src/prov/tests/unification/constraints/specialization-fail3.xml
@@ -1,0 +1,11 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e1"/>  <!-- reflexive -->
+                <prov:generalEntity prov:ref="ex:e1"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-fail4.xml
+++ b/src/prov/tests/unification/constraints/specialization-fail4.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+            </prov:specializationOf>
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e1"/>
+                <prov:generalEntity prov:ref="ex:e2"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-success1.xml
+++ b/src/prov/tests/unification/constraints/specialization-success1.xml
@@ -1,0 +1,13 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/specialization-success2.xml
+++ b/src/prov/tests/unification/constraints/specialization-success2.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:entity prov:id="ex:e2">
+        </prov:entity>
+        <prov:entity prov:id="ex:e3">
+        </prov:entity>
+
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e2"/>
+                <prov:generalEntity prov:ref="ex:e1"/>
+            </prov:specializationOf>
+            <prov:specializationOf>
+                <prov:specificEntity prov:ref="ex:e3"/>
+                <prov:generalEntity prov:ref="ex:e2"/>
+            </prov:specializationOf>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail1.xml
+++ b/src/prov/tests/unification/constraints/start-fail1.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1"> 
+                <prov:activity prov:ref="ex:a1-other"/>  <!-- unable to unify -->
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail2.xml
+++ b/src/prov/tests/unification/constraints/start-fail2.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1"> 
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1-other"/><!-- unable to unify -->
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail3.xml
+++ b/src/prov/tests/unification/constraints/start-fail3.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1"> 
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2-other"/><!-- unable to unify -->
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail4.xml
+++ b/src/prov/tests/unification/constraints/start-fail4.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1-other">  <!-- unable to unify, simulatenous start -->
+                <prov:activity prov:ref="ex:a1"/>  
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail5.xml
+++ b/src/prov/tests/unification/constraints/start-fail5.xml
@@ -1,0 +1,24 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1"> 
+	        <prov:time>2011-11-16T16:05:00</prov:time>  <!-- fails to unify -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail6.xml
+++ b/src/prov/tests/unification/constraints/start-fail6.xml
@@ -1,0 +1,30 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail7.xml
+++ b/src/prov/tests/unification/constraints/start-fail7.xml
@@ -1,0 +1,29 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>  
+                <prov:activity prov:ref="ex:a1"/>
+
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+	        <prov:time>2012-11-16T16:05:00</prov:time>  <!-- mismatch -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-fail8.xml
+++ b/src/prov/tests/unification/constraints/start-fail8.xml
@@ -1,0 +1,31 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2013-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time> <!-- first failed unify -->
+                <prov:activity prov:ref="ex:a1"/>
+
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+	        <prov:time>2012-11-16T16:05:00</prov:time> <!-- second failed unify -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success1.xml
+++ b/src/prov/tests/unification/constraints/start-success1.xml
@@ -1,0 +1,21 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy>  <!-- able to unify the start id -->
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success2.xml
+++ b/src/prov/tests/unification/constraints/start-success2.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+        <prov:wasStartedBy prov:id="ex:start1">
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:trigger prov:ref="ex:e1"/>
+          <prov:starter prov:ref="ex:a2"/>
+        </prov:wasStartedBy>
+
+        <prov:wasStartedBy>
+	  <!-- able to unify the start id -->
+          <prov:activity prov:ref="ex:a1"/>
+	  <!-- able to unify the trigger id -->
+          <prov:starter prov:ref="ex:a2"/>
+        </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success3.xml
+++ b/src/prov/tests/unification/constraints/start-success3.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+        <prov:wasStartedBy prov:id="ex:start1">
+          <!-- able to unify time -->
+          <prov:activity prov:ref="ex:a1"/>
+          <prov:trigger prov:ref="ex:e1"/>
+          <prov:starter prov:ref="ex:a2"/>
+        </prov:wasStartedBy>
+        <prov:wasStartedBy>
+	  <prov:time>2011-11-16T16:05:00</prov:time>
+	  <!-- able to unify the start id -->
+          <prov:activity prov:ref="ex:a1"/>
+	  <!-- able to unify the trigger id -->
+          <prov:starter prov:ref="ex:a2"/>
+        </prov:wasStartedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success4.xml
+++ b/src/prov/tests/unification/constraints/start-success4.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy>
+	         <!-- able to unify the start id -->
+                <prov:activity prov:ref="ex:a1"/>
+		<!-- able to unify the trigger id -->
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success5.xml
+++ b/src/prov/tests/unification/constraints/start-success5.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success6.xml
+++ b/src/prov/tests/unification/constraints/start-success6.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success7.xml
+++ b/src/prov/tests/unification/constraints/start-success7.xml
@@ -1,0 +1,27 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success8.xml
+++ b/src/prov/tests/unification/constraints/start-success8.xml
@@ -1,0 +1,28 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/start-success9.xml
+++ b/src/prov/tests/unification/constraints/start-success9.xml
@@ -1,0 +1,28 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:entity prov:id="ex:e1">
+        </prov:entity>
+        <prov:activity prov:id="ex:a1">
+        </prov:activity>
+        <prov:activity prov:id="ex:a2">
+        </prov:activity>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+                <prov:activity prov:ref="ex:a1"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy>
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:trigger prov:ref="ex:e1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+            <prov:wasStartedBy prov:id="ex:start1">
+	        <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:a1"/>
+                <prov:starter prov:ref="ex:a2"/>
+            </prov:wasStartedBy>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail1.xml
+++ b/src/prov/tests/unification/constraints/usage-fail1.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1-other">  <!-- unable to unify, simult gen -->
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail2.xml
+++ b/src/prov/tests/unification/constraints/usage-fail2.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1-other"/>  <!-- unable to unify -->
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail3.xml
+++ b/src/prov/tests/unification/constraints/usage-fail3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1-other"/>  <!-- unable to unify -->
+            </prov:used>
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail4.xml
+++ b/src/prov/tests/unification/constraints/usage-fail4.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail5.xml
+++ b/src/prov/tests/unification/constraints/usage-fail5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail6.xml
+++ b/src/prov/tests/unification/constraints/usage-fail6.xml
@@ -1,0 +1,20 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used>
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-fail7.xml
+++ b/src/prov/tests/unification/constraints/usage-fail7.xml
@@ -1,0 +1,24 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2012-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success1.xml
+++ b/src/prov/tests/unification/constraints/usage-success1.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success2.xml
+++ b/src/prov/tests/unification/constraints/usage-success2.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+		 <!-- able to unify entity -->
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success3.xml
+++ b/src/prov/tests/unification/constraints/usage-success3.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used> 		 <!-- able to unify id -->
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success4.xml
+++ b/src/prov/tests/unification/constraints/usage-success4.xml
@@ -1,0 +1,17 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use2">   <!-- different generation entirely -->
+                <prov:activity prov:ref="ex:e2"/>
+                <prov:entity prov:ref="ex:a2"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success5.xml
+++ b/src/prov/tests/unification/constraints/usage-success5.xml
@@ -1,0 +1,19 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success6.xml
+++ b/src/prov/tests/unification/constraints/usage-success6.xml
@@ -1,0 +1,18 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success7.xml
+++ b/src/prov/tests/unification/constraints/usage-success7.xml
@@ -1,0 +1,23 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>

--- a/src/prov/tests/unification/constraints/usage-success8.xml
+++ b/src/prov/tests/unification/constraints/usage-success8.xml
@@ -1,0 +1,22 @@
+<?org.openprovenance.prov.xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#" xmlns:prim="http://openprovenance.org/primitives#" xmlns:ex="http://example.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <prov:activity prov:id="ex:e1">
+        </prov:activity>
+        <prov:entity prov:id="ex:a1">
+        </prov:entity>
+
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used prov:id="ex:use1">
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+            <prov:used>
+                <prov:time>2011-11-16T16:05:00</prov:time>
+                <prov:activity prov:ref="ex:e1"/>
+                <prov:entity prov:ref="ex:a1"/>
+            </prov:used>
+
+</prov:document>


### PR DESCRIPTION
Phase 3.5 conformance audit, Task 6 (roadmap step 30b). Audit-only under the 2.x freeze: no model/serializer behaviour changes.

## What this adds

- **Gap-analysis doc** `docs/superpowers/specs/2026-07-10-unification-gap-analysis.md` — rule-by-rule comparison of `ProvBundle._unified_records()` against PROV-CONSTRAINTS (§4 unification, §6.1 key/uniqueness Constraints 22–29, §7.2 bundle scoping), each rule with spec statement → current behaviour → executed example → step-36b requirement. This is the authority document for the 3.0 reimplementation of `unified()` (#253).
- **Test corpus** `src/prov/tests/unification/constraints/` — 153 W3C-derived unification cases vendored from ProvToolbox (`modules-validation/prov-validation/.../validate/unification/`), with a README recording origin, upstream W3C PROV-CONSTRAINTS implementation-report provenance, the MIT-style ProvToolbox licence, and the `*-successN`/`*-failN` naming convention. Added to `prov.tests` package-data for sdist completeness.
- **Characterization tests** `src/prov/tests/test_unification_constraints.py` — locks current behaviour over the full corpus (exact identifier-keyed post-merge counts, not loose bounds) plus hand-written per-rule gap tests and a `ProvDocument.unified()` bundle-independence test. 158 passed / 3 skipped.

## Key findings (documented, not fixed — 2.x freeze)

- Current behaviour is a three-way split, not a uniform silent union: 25 fail-cases raise an *accidental* generic `ProvException` via the `add_attributes` cardinality guard; 42 fail-cases silently merge (placeholder-vs-concrete, uniqueness Constraints 24–29 ignored); 3 `bundle-*` cases cannot be parsed at all.
- The 3 parse failures exposed a new PROV-XML deserializer defect (raw `UnboundLocalError` or silent reuse of the previous sibling's value in `_extract_attributes`) — filed as #254.
- `ProvDocument.unified()` is §7.2-conformant (top level and each sub-bundle unified independently); the `flattened().unified()` idiom merges across bundle boundaries, which is spec-invalid usage — called out in the gap doc.

## Issues filed

- #253 — umbrella: `unified()` does not implement PROV-CONSTRAINTS merging (no milestone; Task 7 triage proposes the bucket).
- #254 — PROV-XML deserializer `UnboundLocalError`/silent value reuse (new defect class, sibling of #228).

Findings doc sections 4 and 5 updated. Full suite: 1131 passed / 22 skipped / 16 xfailed (baseline 973/19/16 + exactly this task's additions); ruff and mypy clean.