### PR TITLE
Triage conformance audit findings; close out Phase 3.5 (roadmap steps 31-32)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,8 @@ code changes.
 | **2.2.0** *(released 2026-07-03)* | Tooling & bug fixes | Modernised linting/formatting and test tooling; CI refresh; release automation. Bug fixes: graphics output regression ([#164](https://github.com/trungdong/prov/issues/164)), matplotlib as an optional extra ([#166](https://github.com/trungdong/prov/issues/166)), PROV-XML default-namespace parsing ([#155](https://github.com/trungdong/prov/issues/155)). |
 | **2.3.0** *(released 2026-07-05)* | Typing & test coverage | Complete type annotations across the codebase and ship `py.typed` (PEP 561), so downstream projects get real type checking against `prov`'s API. Coverage gaps closed, including the CLI scripts and format auto-detection. Progressively stricter lint and type-check rules enforced in CI as modules are annotated. A dependency audit documents why each runtime dependency exists, aiming for the smallest possible footprint. **Python 3.9 support dropped** (originally planned for 3.0, pulled forward because security fixes in transitive dependencies are only released for Python 3.10+). One sanctioned diagnostic tweak: serializer-lookup and CLI errors now chain the original exception (`__cause__`); exception types and messages are unchanged, so this stays within the 2.x stability promise. |
 | **2.4.0** *(released 2026-07-06)* | Documentation & internals | Refreshed, reorganised documentation (tutorials, how-to guides, API reference, explanations), including guides for graphics export ([#141](https://github.com/trungdong/prov/issues/141)) and for the `prov-convert`/`prov-compare` CLI tools ([#83](https://github.com/trungdong/prov/issues/83)). Internal restructuring behind the stable public API, plus deprecation warnings signposting the 3.0 changes. **This is the deprecation-signposting release**: importing `prov.dot`/`prov.graph` now emits a `DeprecationWarning` naming the future `prov[dot]`/`prov[graph]` extras, and `unified()` emits a `FutureWarning` about the PROV-CONSTRAINTS rework below; see the new [Upgrading to 3.0](docs/upgrading-3.0.md) guide for the full list and what to do. |
+| **Conformance audit** *(completed 2026-07-11)* | Standards conformance (pre-3.0, not a release) | The pre-3.0 audit of the library against W3C PROV-DM, PROV-N, PROV-XML, PROV-JSON, PROV-O and PROV-CONSTRAINTS. Outcomes: a [conformance matrix](docs/reference/conformance.md) published in the docs and revisited at every release; schema-validation tests added (the W3C PROV-XML XSD closure and the PROV-JSON member-submission schema, both vendored); PROV-N grammar and PROV-O mapping audits; a PROV-CONSTRAINTS unification gap analysis with a 153-case test corpus (the authority for the 3.0 `unified()` rework). 20 new issues filed by the audit ([#235](https://github.com/trungdong/prov/issues/235)–[#240](https://github.com/trungdong/prov/issues/240), [#244](https://github.com/trungdong/prov/issues/244), [#246](https://github.com/trungdong/prov/issues/246), [#248](https://github.com/trungdong/prov/issues/248)–[#251](https://github.com/trungdong/prov/issues/251), [#253](https://github.com/trungdong/prov/issues/253), [#254](https://github.com/trungdong/prov/issues/254), [#256](https://github.com/trungdong/prov/issues/256)–[#261](https://github.com/trungdong/prov/issues/261)), and every finding triaged with maintainer sign-off into the 3.0.0 milestone (behaviour/output-changing fixes), a new 2.5.0 milestone (cheap, non-breaking items), or the post-3.0 `backlog` label. The PROV-CONSTRAINTS validation engine ([#62](https://github.com/trungdong/prov/issues/62)) remains out of scope (backlog). |
+| **2.5.0** | Low-risk fixes & additions | Small, non-breaking items carved out by the conformance-audit triage: record-level chaining convenience methods ([#154](https://github.com/trungdong/prov/issues/154)), the agent-subtype `prov:type` documentation fix ([#236](https://github.com/trungdong/prov/issues/236)), `prov.read()` auto-detection of PROV-XML ([#239](https://github.com/trungdong/prov/issues/239)), `serialize()` handling of non-`IOBase` file-likes ([#240](https://github.com/trungdong/prov/issues/240)), and PROV-XML deserializer error handling ([#254](https://github.com/trungdong/prov/issues/254)). All are additive or touch only already-broken paths, staying within the 2.x stability promise. |
 | **3.0.0** | Compatibility release | The one release allowed to break compatibility (see the explicit list below). |
 | **3.1.0** | PROV-JSONLD support | A new serializer and deserializer for [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), the W3C member submission for representing PROV-DM natively in JSON-LD. Purely additive. |
 | **3.2.0** | Two-way PROV-N | A parser for [PROV-N](https://www.w3.org/TR/prov-n/), built from the specification's grammar, making the notation readable as well as writable (today `prov` can only write PROV-N). Purely additive. |
@@ -39,8 +41,9 @@ code changes.
 ## What changes in 3.0
 
 3.0 batches every compatibility-affecting change into a single, clearly signposted
-release. It is preceded by a standards-conformance audit against W3C PROV-DM and its
-companion specifications, whose findings feed into this list. The planned changes are:
+release. It was preceded by a standards-conformance audit against W3C PROV-DM and its
+companion specifications (completed 2026-07-11, see the table above), whose findings
+feed into this list. The planned changes are:
 
 - ~~**Python floor raised to 3.10**~~ *Moved into 2.3.0* (July 2026): security fixes
   for several transitive dependencies are only published for Python 3.10+, so keeping
@@ -56,7 +59,10 @@ companion specifications, whose findings feed into this list. The planned change
   `unified()` currently just merges the attributes of records that share an
   identifier; in 3.0 it applies the specification's merging rules (key constraints
   and term unification), rejecting merges the spec disallows instead of silently
-  combining records. The gap analysis happens during the pre-3.0 conformance audit.
+  combining records. The
+  [gap analysis](docs/superpowers/specs/2026-07-10-unification-gap-analysis.md) was
+  produced by the pre-3.0 conformance audit (completed 2026-07-11) and is the authority
+  for this rework.
 - **Behaviour-changing bug fixes**, each individually reviewed with tests showing the
   old and new behaviour:
   - [#34](https://github.com/trungdong/prov/issues/34) — merging attributes with the
@@ -67,7 +73,11 @@ companion specifications, whose findings feed into this list. The planned change
     without an explicit datatype.
   - [#168](https://github.com/trungdong/prov/issues/168) — `xsd:QName` typing in
     PROV-JSON output (an interop-affecting change).
-  - Plus any further fixes surfaced by the conformance audit.
+  - Plus the further fixes surfaced by the conformance audit — now all filed and
+    assigned to the 3.0.0 milestone on GitHub (serializer conformance fixes such as
+    [#235](https://github.com/trungdong/prov/issues/235),
+    [#250](https://github.com/trungdong/prov/issues/250), and the
+    [#253](https://github.com/trungdong/prov/issues/253) `unified()` umbrella above).
 
 The [Upgrading to 3.0](docs/upgrading-3.0.md) guide, published starting in 2.4.0, tracks
 this list in detail alongside what to do for each change. The intent is that most users

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -28,7 +28,7 @@ Every cell below was checked directly against the current source: model classes 
   `,`, `(`, `:`, `;`, `[`, `]`, `=` — in an identifier's local part), which is a property of
   *identifiers*, not of any one record type; it is noted once here rather than on every row.
 
-Two more caveats apply across many rows rather than to one:
+More caveats apply across many rows rather than to one:
 
 - **[#217](https://github.com/trungdong/prov/issues/217)** (RDF): 14 statement-level test cases
   assert two relations that share one identifier but differ only in `prov:time`; PROV-O has no
@@ -42,6 +42,32 @@ Two more caveats apply across many rows rather than to one:
 - **[#225](https://github.com/trungdong/prov/issues/225)** (RDF): a Python `float` attribute
   (typed `xsd:float`) can lose precision through RDF, regardless of record type, because the
   RDF serializer canonicalises `xsd:float` to a short decimal form.
+- **[#235](https://github.com/trungdong/prov/issues/235)** (all formats): a `Literal`
+  explicitly typed `xsd:long` is silently collapsed to a plain `int` at assertion time, so
+  every serializer emits it as `xsd:int` — the asserted datatype is lost before serialization.
+- **[#244](https://github.com/trungdong/prov/issues/244)** (XML) /
+  **[#249](https://github.com/trungdong/prov/issues/249)** (PROV-N) /
+  **[#256](https://github.com/trungdong/prov/issues/256)** (RDF): plain Python `int` values
+  are always typed `xsd:int` with no magnitude check, so a value outside the 32-bit range
+  produces schema-invalid XML, a value-invalid PROV-N integer literal, and an ill-typed RDF
+  literal, respectively.
+- **[#246](https://github.com/trungdong/prov/issues/246)** (JSON): plain `int`/`float`
+  attribute values are encoded with a non-string `$` property, violating the PROV-JSON
+  submission's typed-literal schema (the output still round-trips through `prov` itself).
+- **[#251](https://github.com/trungdong/prov/issues/251)** (PROV-N): plain Python `float`
+  values are emitted as `%g`-formatted `xsd:float` — a different datatype (and, beyond 6
+  significant digits, a different value) than the `xsd:double` the JSON/XML/RDF serializers
+  assert for the same document.
+- **[#238](https://github.com/trungdong/prov/issues/238)** (JSON): `prov:QUALIFIED_NAME`-typed
+  `Literal`s are stored opaquely by the model but resolved to `QualifiedName`s by the JSON
+  decoder, so such a value mutates across a JSON round trip and breaks document equality.
+- **[#237](https://github.com/trungdong/prov/issues/237)** (model): every factory
+  `time=`/`startTime=`/`endTime=` parameter leaks a raw `dateutil` `ParserError` on
+  unparseable strings (instead of `ProvException`) and rejects the valid `xsd:dateTime`
+  hour-24 lexical form.
+- **[#259](https://github.com/trungdong/prov/issues/259)** (model): `Literal` language tags
+  compare case-sensitively, diverging from RDF 1.1's case-insensitive language-tag value
+  space (tags are never normalised, so values do survive round trips unchanged).
 
 ## Component 1 — Entities and Activities
 
@@ -51,7 +77,7 @@ Two more caveats apply across many rows rather than to one:
 | Activity §5.1.2 | {py:class}`~prov.model.ProvActivity` | `activity()` | `activity` | ✓ | ✓ | ✓ |
 | Generation §5.1.3 | {py:class}`~prov.model.ProvGeneration` | `generation()` / `wasGeneratedBy()` | `wasGeneratedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
 | Usage §5.1.4 | {py:class}`~prov.model.ProvUsage` | `usage()` / `used()` | `used` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
-| Communication §5.1.5 | {py:class}`~prov.model.ProvCommunication` | `communication()` / `wasInformedBy()` | `wasInformedBy` | ✓ | ✓ | ✓ |
+| Communication §5.1.5 | {py:class}`~prov.model.ProvCommunication` | `communication()` / `wasInformedBy()` | `wasInformedBy` | ✓ | ✓ | ✓ (anonymous *qualified* communications omit `prov:activity`: [#250](https://github.com/trungdong/prov/issues/250)) |
 | Start §5.1.6 | {py:class}`~prov.model.ProvStart` | `start()` / `wasStartedBy()` | `wasStartedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 4 same-id/differing-time cases) |
 | End §5.1.7 | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` | `wasEndedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 4 same-id/differing-time cases) |
 | Invalidation §5.1.8 | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` | `wasInvalidatedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
@@ -86,11 +112,11 @@ output from this library always uses the base `wasDerivedFrom` form.
 | --- | --- | --- | --- | --- | --- | --- |
 | Agent §5.3.1 | {py:class}`~prov.model.ProvAgent` | `agent()` | `agent` | ✓ | ✓ | ✓ |
 | Person / Organization / SoftwareAgent §5.3.1 | via `prov:type` on {py:class}`~prov.model.ProvAgent` | none — see finding below | `person` / `organization` / `softwareAgent` (`ADDITIONAL_N_MAP`, not emitted directly by this library) | ✓ | ✓ | ✓ |
-| Attribution §5.3.2 | {py:class}`~prov.model.ProvAttribution` | `attribution()` / `wasAttributedTo()` | `wasAttributedTo` | ✓ | ✓ | ✓ |
+| Attribution §5.3.2 | {py:class}`~prov.model.ProvAttribution` | `attribution()` / `wasAttributedTo()` | `wasAttributedTo` | ✓ | ✓ | ✓ (anonymous *qualified* attributions omit `prov:agent`: [#250](https://github.com/trungdong/prov/issues/250)) |
 | Association §5.3.3 | {py:class}`~prov.model.ProvAssociation` | `association()` / `wasAssociatedWith()` | `wasAssociatedWith` | ✓ | ✓ | ✓ |
 | Plan §5.3.3 | via `association(plan=...)` | — | — (plan is an ordinary entity referenced by the association's `plan` formal attribute) | ✓ | ✓ | ✓ |
-| Delegation §5.3.4 | {py:class}`~prov.model.ProvDelegation` | `delegation()` / `actedOnBehalfOf()` | `actedOnBehalfOf` | ✓ | ✓ | ✓ (anonymous qualified delegations sharing (delegate, activity): [#226](https://github.com/trungdong/prov/issues/226)) |
-| Influence §5.3.5 | {py:class}`~prov.model.ProvInfluence` | `influence()` / `wasInfluencedBy()` | `wasInfluencedBy` | ✓ | ✓ | ✓ |
+| Delegation §5.3.4 | {py:class}`~prov.model.ProvDelegation` | `delegation()` / `actedOnBehalfOf()` | `actedOnBehalfOf` | ✓ | ✓ | ✓ (anonymous qualified delegations sharing (delegate, activity): [#226](https://github.com/trungdong/prov/issues/226); the encode-side root cause — the qualified node omits `prov:agent` — is [#250](https://github.com/trungdong/prov/issues/250)) |
+| Influence §5.3.5 | {py:class}`~prov.model.ProvInfluence` | `influence()` / `wasInfluencedBy()` | `wasInfluencedBy` | ✓ | ✓ | ✓ (anonymous *qualified* influences omit `prov:influencer`: [#250](https://github.com/trungdong/prov/issues/250)) |
 
 **Finding:** PROV-DM defines Person, Organization, and SoftwareAgent as agent subtypes, and Plan
 as an entity subtype used with associations. `prov` has no dedicated classes or factories for the
@@ -98,6 +124,9 @@ agent subtypes — you express them with `agent("ag", {PROV_TYPE: "prov:Person"}
 needs no special handling at all, since it is just an entity passed as the `plan=` argument to
 `association()`. This is a documented, intentional design choice
 (`docs/explanation/prov-dm.md:111-114`), not a defect; see finding log for the audit note.
+Convenience factories for the three agent subtypes (together with `EmptyCollection`, see
+Component 6) are now tracked as
+[#260](https://github.com/trungdong/prov/issues/260).
 
 ## Component 4 — Bundles
 
@@ -117,15 +146,16 @@ are consumed only by `dot.py` (for node styling) — no serializer or
 {py:class}`~prov.model.ProvBundle` method ever produces a `prov:Bundle`-typed entity, and
 `get_provn()`'s `bundle <id> ... endBundle` output is generated structurally (branching on
 `is_document()`), not through that keyword lookup. There is currently no supported way to
-attribute a bundle to an agent as a first-class PROV statement.
+attribute a bundle to an agent as a first-class PROV statement. Tracked as
+[#261](https://github.com/trungdong/prov/issues/261).
 
 ## Component 5 — Alternate Entities
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF |
 | --- | --- | --- | --- | --- | --- | --- |
 | Specialization §5.5.1 | {py:class}`~prov.model.ProvSpecialization` | `specialization()` / `specializationOf()` | `specializationOf` | ✓ | ✓ | ✓ |
-| Alternate §5.5.2 | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` | `alternateOf` | ✓ | ✓ | ✓ |
-| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` | ✓ | ✓ | ✓ |
+| Alternate §5.5.2 | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` | `alternateOf` | ✓ | ✓ | ✓ (the RDF triple is emitted with subject/object transposed relative to the PROV-DM argument order — symmetric-relation-safe, but third-party consumers see the arguments swapped: [#258](https://github.com/trungdong/prov/issues/258)) |
+| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` (emitted *without* the `prov:` prefix the PROV-Links grammar requires: [#248](https://github.com/trungdong/prov/issues/248)) | ✓ | ✓ | ✓ |
 
 ## Component 6 — Collections
 
@@ -139,7 +169,8 @@ attribute a bundle to an agent as a first-class PROV statement.
 `ADDITIONAL_N_MAP`/`PROV_BASE_CLS` entry in `constants.py`, so the round-trip machinery
 understands it — but there is no `empty_collection()` factory or `empty=` flag on `collection()`
 to set the type for you; you would add `prov:type: "prov:EmptyCollection"` by hand via
-`other_attributes`.
+`other_attributes`. Tracked (together with the agent-subtype factories, see Component 3) as
+[#260](https://github.com/trungdong/prov/issues/260).
 
 ## Additional attributes
 
@@ -159,12 +190,24 @@ shared attribute test matrix (`test_attributes.py`, `ATTRIBUTE_VALUES` in
 Any attribute value (regardless of which of the five above it is) is additionally subject to
 **[#224](https://github.com/trungdong/prov/issues/224)** (XML drops the empty string `""`) and
 **[#225](https://github.com/trungdong/prov/issues/225)** (RDF can lose `xsd:float` precision) —
-both are properties of the value's type, not of the attribute name.
+both are properties of the value's type, not of the attribute name — as are the other
+value-level caveats listed under the round-trip column key above
+([#235](https://github.com/trungdong/prov/issues/235),
+[#238](https://github.com/trungdong/prov/issues/238),
+[#244](https://github.com/trungdong/prov/issues/244)/[#249](https://github.com/trungdong/prov/issues/249)/[#256](https://github.com/trungdong/prov/issues/256),
+[#246](https://github.com/trungdong/prov/issues/246),
+[#251](https://github.com/trungdong/prov/issues/251),
+[#259](https://github.com/trungdong/prov/issues/259)).
 
 ## Maintenance
 
-This matrix reflects the codebase as of the Phase 3.5 conformance audit (roadmap step 28) and
-should be revisited at each release as serializers change or issues close. Release 3.1.0 adds a
+This matrix reflects the codebase as of the Phase 3.5 conformance audit (roadmap steps 28–32,
+completed 2026-07-11) and should be revisited at each release as serializers change or issues
+close. Beyond the per-format round trips above, the audit also confirmed that
+`ProvBundle.unified()` performs an identifier-keyed attribute union rather than
+[PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) merging — tracked as the umbrella
+issue [#253](https://github.com/trungdong/prov/issues/253), with the full gap analysis in the
+audit findings; the rework is scheduled for 3.0. Release 3.1.0 adds a
 PROV-JSONLD serializer; when that lands, this page gains a JSON-LD column
 alongside JSON/XML/RDF. See {doc}`../explanation/prov-dm` for the conceptual background behind
 each component, and {doc}`model` for the full class/method API reference.

--- a/docs/superpowers/specs/2026-07-10-conformance-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-10-conformance-audit-findings.md
@@ -1,7 +1,10 @@
 # Conformance audit findings — Phase 3.5 (roadmap steps 28–32)
 
-**Status:** In progress. Working document; each audit task appends its section.
-**Triage:** Section 6 is filled by the triage task (step 31) after maintainer sign-off.
+**Status:** Complete. Phase 3.5 closed 2026-07-11: the triage in section 6 was approved at
+the maintainer checkpoint on 2026-07-11 and applied on GitHub the same day (milestones and
+labels set, follow-up issues #256–#261 filed, phase summary posted on
+[#181](https://github.com/trungdong/prov/issues/181)).
+**Triage:** Section 6 records the approved classification (step 31).
 
 ## 0. Baseline (recorded before any audit work)
 
@@ -1005,31 +1008,96 @@ by `src/prov/tests/test_unification_constraints.py`. Headlines:
 | [#244](https://github.com/trungdong/prov/issues/244) | `PROV-XML conformance:` plain Python ints are always typed `xsd:int`, producing schema-invalid output outside the int32 range | §3.1 |
 | [#246](https://github.com/trungdong/prov/issues/246) | `PROV-JSON conformance:` numeric attribute values are encoded with a non-string `$`, violating the submission's typed-literal schema | §3.2 |
 | [#248](https://github.com/trungdong/prov/issues/248) | `PROV-N conformance:` `mentionOf` is emitted without the `prov:` prefix required by the PROV-Links `mentionExpression` production | §3.3 |
-| [#249](https://github.com/trungdong/prov/issues/249) | `PROV-N/PROV-O conformance:` plain Python ints outside the 32-bit range are asserted as `xsd:int` in PROV-N and PROV-O output | §3.3/§3.4 |
+| [#249](https://github.com/trungdong/prov/issues/249) | `PROV-N conformance:` plain Python ints outside the 32-bit range are asserted as `xsd:int` in PROV-N output (originally filed covering the PROV-O leg too; split at the §6 triage checkpoint — the PROV-O leg is now #256) | §3.3 |
 | [#250](https://github.com/trungdong/prov/issues/250) | `PROV-O conformance:` anonymous qualified Communication/Attribution/Delegation/Influence nodes omit their influencer property, producing ambiguous PROV-O (root cause of #226) | §3.4 |
 | [#251](https://github.com/trungdong/prov/issues/251) | `PROV-N conformance:` plain Python floats serialize as `%g`-formatted `xsd:float`, diverging from the `xsd:double` all other serializers assert and truncating precision | §3.3 |
 | [#253](https://github.com/trungdong/prov/issues/253) | `PROV-CONSTRAINTS conformance:` `unified()` does not implement PROV-CONSTRAINTS merging (umbrella; authority: the step-30b gap-analysis doc; fix vehicle: step 36b) | §4 |
 | [#254](https://github.com/trungdong/prov/issues/254) | `Bug:` PROV-XML deserializer leaks raw `UnboundLocalError` or silently reuses the previous attribute's value on unrecognised XML attributes (sibling of #228) | §4 |
+| [#256](https://github.com/trungdong/prov/issues/256) | `PROV-O conformance:` plain Python ints outside the 32-bit range are asserted as `xsd:int` in RDF output (the PROV-O leg split out of #249) | §3.4 (filed at the §6 triage checkpoint) |
+| [#257](https://github.com/trungdong/prov/issues/257) | `PROV-DM conformance:` unenforced normative structural constraints allow silently invalid statements (the §2.8 family — 3.0 API-philosophy umbrella, also covering the §3.4 low-level `new_record` invented-vocabulary/dropped-attribute paths) | §2.8 (filed at the §6 triage checkpoint) |
+| [#258](https://github.com/trungdong/prov/issues/258) | `PROV-O conformance:` the `alternateOf` triple is emitted with subject/object transposed relative to the PROV-DM argument order | §3.4 (filed at the §6 triage checkpoint) |
+| [#259](https://github.com/trungdong/prov/issues/259) | `PROV-DM conformance:` `Literal` language tags compare case-sensitively, diverging from RDF 1.1's case-insensitive value space (§5.7.3) | §2.7.3 (filed at the §6 triage checkpoint) |
+| [#260](https://github.com/trungdong/prov/issues/260) | `Feature:` add convenience factories for the PROV-DM agent subtypes (Person/Organization/SoftwareAgent) and `EmptyCollection` | §1 (filed at the §6 triage checkpoint) |
+| [#261](https://github.com/trungdong/prov/issues/261) | `Feature:` support `prov:Bundle` as a first-class entity type for provenance-of-provenance (PROV-DM §5.4.2) | §1 (filed at the §6 triage checkpoint) |
 
-Not filed (findings-doc only): the §2.8 validation-gap family (needs maintainer
-confirmation — enforcement is a 3.0 API-philosophy decision), the `Literal` language-tag
-case-sensitivity nit (§2.7.3, needs maintainer confirmation), the Mention/PROV-Links
-labelling nit (§2.5), the feature gaps already recorded in section 1, the two §3.1
-PROV-XML format limitations (QName-incompatible local names; language tags on
-non-`prov:label` attributes) — both are inherent to the PROV-XML schema, not
-implementation defects — the two §3.2 PROV-JSON schema-authoring quirks
-(`wasEndedby` casing typo; top-level-only `additionalProperties: false` gap for
-`mentionOf`) — both are bugs in the submission's own vendored schema, not `prov` — the
-§3.3 metacharacter local-part failures (all instances of the already-filed #223), the
-§3.4 Alternate argument-order reversal (symmetric-relation-safe, needs maintainer
-confirmation), the §3.4 low-level `new_record`-only invented-vocabulary/dropped-attribute
-paths (§2.8-item-4 family, not reachable via the public API), and the §3.4 TriG
-duplicate-prefix cosmetic quirk (#96-adjacent).
+Not filed (findings-doc only): the Mention/PROV-Links labelling nit (§2.5, cosmetic), the
+two §3.1 PROV-XML format limitations (QName-incompatible local names; language tags on
+non-`prov:label` attributes) — both inherent to the PROV-XML schema itself, not
+implementation defects — the two §3.2 PROV-JSON schema-authoring quirks (`wasEndedby`
+casing typo; top-level-only `additionalProperties: false` gap for `mentionOf`) — both bugs
+in the submission's own vendored schema, not `prov` — the §3.3 metacharacter local-part
+failures (all instances of the already-filed #223), and the §3.4 TriG duplicate-prefix
+cosmetic quirk (#96-adjacent). Every other item originally held back as findings-doc-only
+was promoted to a real issue at the triage checkpoint (2026-07-11): the §2.8 validation-gap
+family — including the §3.4 low-level `new_record` invented-vocabulary/dropped-attribute
+paths — is now covered by umbrella #257, the `Literal` language-tag case-sensitivity nit is
+#259, the §3.4 Alternate argument-order reversal is #258, and the section-1 feature gaps
+are #260 (agent-subtype/`EmptyCollection` factories) and #261 (`prov:Bundle` entity type).
 ## 6. Triage (step 31) — proposed → approved
-| Issue | Bucket (2.x / 3.0 / backlog) | Rationale |
+
+The classification below was presented at the maintainer checkpoint on 2026-07-11 and
+**approved**, with the following checkpoint outcomes (all applied on GitHub the same day):
+
+- **#249 split**: #249 was retitled to cover the PROV-N leg only ("PROV-N conformance:
+  plain Python ints outside the 32-bit range are asserted as xsd:int in PROV-N output");
+  the PROV-O leg was split out as new issue #256.
+- **All five proposed 2.x items confirmed**, and a new **`2.5.0` milestone** was created
+  on GitHub to hold them.
+- **The backlog bucket is represented as a new `backlog` label** (post-3.0 features carry
+  the label rather than a milestone).
+- **All four deliberately-unfiled borderline finding groups were promoted to issues,
+  yielding five** (the section-1 feature-gap finding split into two): #257
+  (§2.8 validation-gap family umbrella), #258 (alternateOf transposition), and #259
+  (language-tag case-sensitivity) went to the 3.0.0 milestone; #260
+  (agent-subtype/`EmptyCollection` factories) and #261 (`prov:Bundle` entity type) went
+  to the `backlog` label.
+
+| Issue | Bucket | Rationale |
 |---|---|---|
+| [#34](https://github.com/trungdong/prov/issues/34) | 3.0.0 | Pre-existing milestone confirmed — merging attributes across types is behaviour-changing; folds into the `unified()` rework (#253, step 36b). |
+| [#77](https://github.com/trungdong/prov/issues/77) | 3.0.0 | Pre-existing milestone confirmed — fixing `Decimal` Literal comparison changes equality semantics. |
+| [#89](https://github.com/trungdong/prov/issues/89) | 3.0.0 | Pre-existing milestone confirmed — distinguishing typed from untyped literals changes representation and output. |
+| [#168](https://github.com/trungdong/prov/issues/168) | 3.0.0 | Pre-existing milestone confirmed — changing QName typing alters PROV-JSON output. |
+| [#217](https://github.com/trungdong/prov/issues/217) | 3.0.0 | Pre-existing milestone confirmed — representing scruffy same-id/differing-time relations in RDF requires output changes. |
+| [#218](https://github.com/trungdong/prov/issues/218) | 3.0.0 | Pre-existing milestone confirmed — restoring RDF multi-datatype fidelity changes round-trip output. |
+| [#223](https://github.com/trungdong/prov/issues/223) | 3.0.0 | Pre-existing milestone confirmed — escaping metacharacter local parts changes PROV-N output. |
+| [#224](https://github.com/trungdong/prov/issues/224) | 3.0.0 | Pre-existing milestone confirmed — preserving empty-string attributes changes PROV-XML output. |
+| [#225](https://github.com/trungdong/prov/issues/225) | 3.0.0 | Pre-existing milestone confirmed — preserving `xsd:float` precision changes RDF output. |
+| [#226](https://github.com/trungdong/prov/issues/226) | 3.0.0 | Pre-existing milestone confirmed — fixing anonymous qualified delegations changes RDF output (encode-side root cause now #250). |
+| [#228](https://github.com/trungdong/prov/issues/228) | 3.0.0 | Pre-existing milestone confirmed — tightening the JSON deserializer's exception contract is a behaviour change. |
+| [#96](https://github.com/trungdong/prov/issues/96) | 3.0.0 | Newly milestoned — turtle prefix propagation is an output-changing serializer fix. |
+| [#235](https://github.com/trungdong/prov/issues/235) | 3.0.0 | Newly milestoned — undoing the `xsd:long`→`xsd:int` mutation changes output in every serialization (#89 sibling). |
+| [#237](https://github.com/trungdong/prov/issues/237) | 3.0.0 | Newly milestoned — raising `ProvException` (and accepting hour-24) in the factory time params is an exception-contract change. |
+| [#238](https://github.com/trungdong/prov/issues/238) | 3.0.0 | Newly milestoned — resolving `prov:QUALIFIED_NAME` literals to QualifiedNames changes equality (#89 sibling). |
+| [#244](https://github.com/trungdong/prov/issues/244) | 3.0.0 | Newly milestoned — magnitude-aware integer typing changes PROV-XML output (`xsd:int` outside int32). |
+| [#246](https://github.com/trungdong/prov/issues/246) | 3.0.0 | Newly milestoned — stringifying the `$` property changes PROV-JSON output. |
+| [#248](https://github.com/trungdong/prov/issues/248) | 3.0.0 | Newly milestoned — emitting `prov:mentionOf` changes PROV-N output (ProvToolbox-parity nuance recorded on the issue). |
+| [#249](https://github.com/trungdong/prov/issues/249) | 3.0.0 | Newly milestoned — magnitude-aware integer typing changes PROV-N output (split at the checkpoint to the PROV-N leg only; PROV-O leg is #256). |
+| [#250](https://github.com/trungdong/prov/issues/250) | 3.0.0 | Newly milestoned — emitting the missing influencer property changes RDF output (root cause of #226). |
+| [#251](https://github.com/trungdong/prov/issues/251) | 3.0.0 | Newly milestoned — asserting plain floats as full-precision `xsd:double` changes PROV-N output. |
+| [#253](https://github.com/trungdong/prov/issues/253) | 3.0.0 | Newly milestoned — PROV-CONSTRAINTS merging is the behaviour-changing `unified()` rework umbrella (fix vehicle: 3.0 step 36b). |
+| [#256](https://github.com/trungdong/prov/issues/256) | 3.0.0 | Filed at the checkpoint (PROV-O leg of #249) — magnitude-aware integer typing changes RDF output. |
+| [#257](https://github.com/trungdong/prov/issues/257) | 3.0.0 | Filed at the checkpoint (§2.8 family umbrella) — any enforcement of the unchecked normative constraints is a 3.0 API-philosophy decision. |
+| [#258](https://github.com/trungdong/prov/issues/258) | 3.0.0 | Filed at the checkpoint (§3.4) — aligning `alternateOf` with the PROV-DM argument order changes RDF output. |
+| [#259](https://github.com/trungdong/prov/issues/259) | 3.0.0 | Filed at the checkpoint (§2.7.3) — normalising language-tag comparison changes equality semantics. |
+| [#154](https://github.com/trungdong/prov/issues/154) | 2.5.0 | Purely additive record-level chaining methods — no existing behaviour or output changes. |
+| [#236](https://github.com/trungdong/prov/issues/236) | 2.5.0 | Docs-only fix (teach the QualifiedName `prov:type` idiom); any model-side string coercion stays 3.0. |
+| [#239](https://github.com/trungdong/prov/issues/239) | 2.5.0 | Fix only touches an already-failing path (`read()` on PROV-XML currently raises), so no working behaviour changes. |
+| [#240](https://github.com/trungdong/prov/issues/240) | 2.5.0 | Fix only touches an already-broken path (repr-named junk file), so no working behaviour changes. |
+| [#254](https://github.com/trungdong/prov/issues/254) | 2.5.0 | Parse-side only — raising `ProvXMLException` on malformed input changes no serialized output. |
+| [#62](https://github.com/trungdong/prov/issues/62) | backlog | PROV-CONSTRAINTS validation engine — the step-32 out-of-scope item; post-3.0 feature. |
+| [#122](https://github.com/trungdong/prov/issues/122) | backlog | PROV-N parser — planned as its own post-3.0 release (Phase 5b, release 3.2.0). |
+| [#124](https://github.com/trungdong/prov/issues/124) | backlog | Relations-as-set API design question — needs its own post-3.0 design work. |
+| [#129](https://github.com/trungdong/prov/issues/129) | backlog | PROV-Dictionary support — post-3.0 feature. |
+| [#130](https://github.com/trungdong/prov/issues/130) | backlog | Deterministic PROV-N output — post-3.0 feature. |
+| [#131](https://github.com/trungdong/prov/issues/131) | backlog | Pretty PROV-N output — post-3.0 feature. |
+| [#260](https://github.com/trungdong/prov/issues/260) | backlog | Filed at the checkpoint (§1 feature gaps) — additive agent-subtype/`EmptyCollection` convenience factories, post-3.0 feature. |
+| [#261](https://github.com/trungdong/prov/issues/261) | backlog | Filed at the checkpoint (§1) — first-class `prov:Bundle` entity support for provenance-of-provenance, post-3.0 feature. |
 
 ## Out of scope (step 32)
 The PROV-CONSTRAINTS validation engine (#62 — inferences, event ordering,
 typing and impossibility checks) stays on the post-3.0 features backlog.
 Only the unification/merging rules that back `unified()` are in scope.
+This scope decision was restated in the Phase 3.5 summary comment posted on
+the roadmap tracking issue
+[#181](https://github.com/trungdong/prov/issues/181) (2026-07-11).


### PR DESCRIPTION
Closes out Phase 3.5 (standards conformance audit, roadmap steps 31–32). Docs-only.

## What this PR does

- **Findings doc** (`docs/superpowers/specs/2026-07-10-conformance-audit-findings.md`): section 6 now records the full maintainer-approved triage (checkpoint 2026-07-11) — 39 issues bucketed as 26 × 3.0.0 / 5 × 2.5.0 / 8 × backlog, each with a one-line rationale; section 5 gains the six issues filed at the checkpoint (#256–#261); status → Complete.
- **Conformance matrix** (`docs/reference/conformance.md`): refreshed with the audit-filed issue references from Tasks 2–6 (#235, #237, #238, #244, #246, #248, #249/#256, #250, #251, #253, #258, #259) and the now-filed feature gaps (#260, #261).
- **ROADMAP.md**: conformance-audit entry marked completed 2026-07-11 with the outcome summary; new 2.5.0 planned-release row listing its five triaged items (#154, #236, #239, #240, #254).

## Triage already applied on GitHub (maintainer-approved)

- 3.0.0 milestone: #34 #77 #89 #96 #168 #217 #218 #223 #224 #225 #226 #228 #235 #237 #238 #244 #246 #248 #249 #250 #251 #253 #256 #257 #258 #259 (#249 split at the checkpoint into the PROV-N leg (#249) and PROV-O leg (#256)).
- 2.5.0 milestone (new): #154 #236 #239 #240 #254 — cheap, non-breaking; listed as follow-ups, deliberately not fixed here.
- `backlog` label (new): #62 #122 #124 #129 #130 #131 #260 #261.
- Phase summary posted on #181, restating the step-32 out-of-scope note (validation engine #62 stays backlog).

## Verification

- `sphinx-build -b html docs docs/_build/html` → build succeeded, 0 warnings.
- `uv run pytest` → 1131 passed / 22 skipped / 16 xfailed (baseline unchanged).