### PR TITLE
Raise ProvXMLException on unrecognised-only XML attributes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+2.5.0 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* The PROV-XML deserializer now raises ``ProvXMLException`` when a record's
+  child element carries only unrecognised XML attributes, instead of leaking a
+  raw ``UnboundLocalError`` or silently reusing the previous attribute's value
+  (#254)
+
 2.4.0 (2026-07-06)
 ^^^^^^^^^^^^^^^^^^
 * **Documentation overhaul**: the documentation has been reorganised along the

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -420,8 +420,14 @@ def _extract_attributes(
     Warns:
         UserWarning: For any child attribute that is none of ``prov:ref``,
             ``xsi:type``, or ``xml:lang``; such attributes are ignored.
+
+    Raises:
+        ProvXMLException: If a child element carries XML attributes but
+            none of them is ``prov:ref``, ``xsi:type``, or ``xml:lang``, so
+            no attribute value can be determined.
     """
     attributes = []  # type: list[tuple[prov.identifier.QualifiedName, Any]]
+    _unassigned = object()
     for subel in element:
         sqname = etree.QName(subel)
         qname_str = (
@@ -429,10 +435,11 @@ def _extract_attributes(
         )
         _t = xml_qname_to_QualifiedName(subel, qname_str)
 
+        _v: Any = _unassigned
         for key, value in subel.attrib.items():
             value_str = value.decode("utf-8") if isinstance(value, bytes) else value
             if key == _ns_prov("ref"):
-                _v = xml_qname_to_QualifiedName(subel, value_str)  # type: Any
+                _v = xml_qname_to_QualifiedName(subel, value_str)
             elif key == _ns_xsi("type"):
                 datatype = xml_qname_to_QualifiedName(subel, value_str)
                 if datatype == XSD_QNAME:
@@ -453,6 +460,12 @@ def _extract_attributes(
         if not subel.attrib:
             _v = subel.text
 
+        if _v is _unassigned:
+            raise ProvXMLException(
+                f"The element '{_t}' has no representable value: it carries "
+                "XML attributes, but none of them is prov:ref, xsi:type, or "
+                "xml:lang."
+            )
         attributes.append((_t, _v))
 
     return attributes

--- a/src/prov/tests/test_unification_constraints.py
+++ b/src/prov/tests/test_unification_constraints.py
@@ -13,7 +13,8 @@ vendored ProvToolbox/W3C corpus (``unification/constraints/``):
   which the model cannot represent) or passes through untouched (uniqueness
   Constraints 24-29, mandatory-placeholder and impossibility cases, all keyed
   on something other than the record identifier);
-- three ``bundle-*`` files cannot be parsed at all (issue #254) and are
+- three ``bundle-*`` files cannot be parsed at all — prov's PROV-XML
+  deserializer rejects them with ``ProvXMLException`` (issue #254) — and are
   skipped as parse failures.
 
 In 3.0 (roadmap step 36b, umbrella issue #253) ``unified()`` will implement
@@ -39,8 +40,8 @@ pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 
 CORPUS = Path(__file__).parent / "unification" / "constraints"
 
-# prov's PROV-XML deserializer crashes on these (raw UnboundLocalError in
-# _extract_attributes, provxml.py:456) because they wrap bundle contents in
+# prov's PROV-XML deserializer rejects these with ProvXMLException
+# (_extract_attributes, provxml.py) because they wrap bundle contents in
 # ProvToolbox's <prov:bundle> container instead of the XSD's
 # <prov:bundleContent> — issue #254, recorded in the gap analysis.
 PARSE_FAILURES = {
@@ -111,9 +112,9 @@ def _cases():
         if xml_path.name in PARSE_FAILURES:
             marks.append(
                 pytest.mark.skip(
-                    reason="prov cannot parse: UnboundLocalError in provxml "
-                    "_extract_attributes on the <prov:bundle> container "
-                    "(#254) — recorded in the gap analysis"
+                    reason="prov cannot parse: ProvToolbox's <prov:bundle> "
+                    "dialect is rejected with ProvXMLException (crash fixed "
+                    "under #254) — recorded in the gap analysis"
                 )
             )
         yield pytest.param(xml_path, expected, id=xml_path.stem, marks=marks)

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -458,6 +458,51 @@ def test_unrepresentable_sub_element_attribute_warns_and_is_ignored():
     assert list(e1.get_attribute("ex:version")) == ["2"]
 
 
+def test_unrecognised_only_attribute_on_first_sub_element_raises():
+    # #254 mode 1: a child whose only XML attribute is unrecognised used to
+    # leak a raw UnboundLocalError when it was the record's first child.
+    xml_string = """<?xml version="1.0" encoding="UTF-8"?>
+    <prov:document
+        xmlns:prov="http://www.w3.org/ns/prov#"
+        xmlns:ex="http://example.com/ns/ex#">
+      <prov:entity prov:id="ex:e1">
+        <ex:only ex:junk="x">value</ex:only>
+      </prov:entity>
+    </prov:document>
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with (
+            pytest.raises(ProvXMLException) as ctx,
+            io.StringIO(xml_string) as xml,
+        ):
+            prov.ProvDocument.deserialize(source=xml, format="xml")
+    assert "no representable value" in str(ctx.value)
+
+
+def test_unrecognised_only_attribute_after_sibling_raises_not_reuses_value():
+    # #254 mode 2: with a previous sibling, the stale value used to be
+    # silently reused ("world" lost, "hello" duplicated).
+    xml_string = """<?xml version="1.0" encoding="UTF-8"?>
+    <prov:document
+        xmlns:prov="http://www.w3.org/ns/prov#"
+        xmlns:ex="http://example.com/ns/ex#">
+      <prov:entity prov:id="ex:e1">
+        <ex:first>hello</ex:first>
+        <ex:second ex:junk="x">world</ex:second>
+      </prov:entity>
+    </prov:document>
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with (
+            pytest.raises(ProvXMLException) as ctx,
+            io.StringIO(xml_string) as xml,
+        ):
+            prov.ProvDocument.deserialize(source=xml, format="xml")
+    assert "no representable value" in str(ctx.value)
+
+
 def test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises():
     element = etree.fromstring(
         '<root xmlns:ex="http://example.com/ns/ex#"><child/></root>'


### PR DESCRIPTION
## Summary

`_extract_attributes` (PROV-XML deserializer) assigned the attribute value `_v` only when a child element carried `prov:ref`, `xsi:type`, `xml:lang`, or no XML attributes at all. A child whose only XML attributes are unrecognised took neither path, producing two failure modes on malformed input:

1. a raw `UnboundLocalError` when it was the record's first child, and
2. silent data corruption when a previous sibling had assigned `_v` (the stale value was reused).

Both now raise `ProvXMLException` ("no representable value") via a per-child sentinel. Parse-side only: no serialization output changes; valid documents are unaffected (the warn-and-ignore behaviour for mixed recognised+unrecognised attributes is preserved and still tested).

Also updates the 3 `bundle-*` corpus-skip reasons in `test_unification_constraints.py` (they now describe the `ProvXMLException` rejection instead of the crash) and adds the 2.5.0 changelog section.

Suite: 1133 passed / 22 skipped / 16 xfailed (+2 regression tests); ruff, ruff format, mypy --strict clean.

Fixes #254
