### PR TITLE
Duck-type file-like objects in serialize()/deserialize()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,12 @@ History
   child element carries only unrecognised XML attributes, instead of leaking a
   raw ``UnboundLocalError`` or silently reusing the previous attribute's value
   (#254)
+* ``ProvDocument.serialize()`` and ``deserialize()`` now accept any writable/
+  readable file-like object (e.g. ``tempfile.NamedTemporaryFile``), instead of
+  only ``io.IOBase`` instances; previously such destinations were silently
+  treated as file paths, writing to a repr-named file in the working
+  directory. The serializers' text/binary stream detection now also
+  recognises such wrapper objects as text streams (#240)
 
 2.4.0 (2026-07-06)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -11,8 +11,7 @@ import tempfile
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
-from io import IOBase
-from typing import Any
+from typing import IO, Any, cast
 from urllib.parse import urlparse
 
 from prov import serializers
@@ -1595,7 +1594,7 @@ class ProvDocument(ProvBundle):
     # Serializing and deserializing
     def serialize(
         self,
-        destination: io.IOBase | PathLike | None = None,
+        destination: io.IOBase | IO[Any] | PathLike | None = None,
         format: str = "json",
         **args: Any,
     ) -> str | None:
@@ -1605,10 +1604,11 @@ class ProvDocument(ProvBundle):
         and ``"provn"`` (see :func:`prov.serializers.get`).
 
         Args:
-            destination: A writable stream or a local file path to write to. If
-                ``None``, the serialization is returned as a string
-                (default: ``None``). A non-local (network) location is not
-                written and yields ``None``.
+            destination: A writable stream (any object with a ``write``
+                method) or a local file path to write to. If ``None``, the
+                serialization is returned as a string (default: ``None``). A
+                non-local (network) location is not written and yields
+                ``None``.
             format: The serialization format (default: ``"json"``, i.e.
                 PROV-JSON).
             **args: Extra keyword arguments passed to the underlying serializer.
@@ -1623,8 +1623,12 @@ class ProvDocument(ProvBundle):
             serializer.serialize(buffer, **args)
             return buffer.getvalue()
 
-        if isinstance(destination, IOBase):
-            stream = destination
+        # Duck-type on write() rather than isinstance(..., io.IOBase): common
+        # file-like wrappers such as tempfile.NamedTemporaryFile's
+        # _TemporaryFileWrapper proxy a stream's write() but are not
+        # themselves io.IOBase instances (#240).
+        if hasattr(destination, "write"):
+            stream = cast(io.IOBase, destination)
             serializer.serialize(stream, **args)
         else:
             location = str(destination)
@@ -1647,7 +1651,7 @@ class ProvDocument(ProvBundle):
 
     @staticmethod
     def deserialize(
-        source: io.IOBase | PathLike | None = None,
+        source: io.IOBase | IO[Any] | PathLike | None = None,
         content: str | bytes | None = None,
         format: str = "json",
         **args: Any,
@@ -1659,8 +1663,8 @@ class ProvDocument(ProvBundle):
         deserialization (PROV-N is write-only).
 
         Args:
-            source: A readable stream or a file path to read from
-                (default: ``None``).
+            source: A readable stream (any object with a ``read`` method) or
+                a file path to read from (default: ``None``).
             content: The document as a ``str`` or ``bytes`` to read from
                 (default: ``None``).
             format: The serialization format (default: ``"json"``, i.e.
@@ -1684,8 +1688,10 @@ class ProvDocument(ProvBundle):
             return serializer.deserialize(stream, **args)
 
         if source is not None:
-            if isinstance(source, io.IOBase):
-                return serializer.deserialize(source, **args)
+            # Duck-type on read() rather than isinstance(..., io.IOBase): see
+            # the matching comment in serialize() (#240).
+            if hasattr(source, "read"):
+                return serializer.deserialize(cast(io.IOBase, source), **args)
             else:
                 with open(source) as f:
                     return serializer.deserialize(f, **args)

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -15,6 +15,20 @@ __email__ = "trungdong@donggiang.com"
 __all__ = ["Registry", "Serializer", "get"]
 
 
+def _is_text_stream(stream: io.IOBase) -> bool:
+    """Return whether ``stream`` accepts/produces ``str`` rather than bytes.
+
+    ``isinstance(stream, io.TextIOBase)`` alone misses file-like wrappers
+    such as ``tempfile.NamedTemporaryFile``'s ``_TemporaryFileWrapper``,
+    which proxy a text stream without subclassing ``io.TextIOBase``. Such
+    wrappers expose the underlying text stream's ``encoding`` attribute,
+    while binary streams (``io.BytesIO``, buffered readers/writers) have no
+    ``encoding``, so the extra check only ever reclassifies text-stream
+    proxies that would otherwise crash on bytes (#240).
+    """
+    return isinstance(stream, io.TextIOBase) or hasattr(stream, "encoding")
+
+
 class Serializer(ABC):
     """Serializer for PROV documents."""
 

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -21,7 +21,7 @@ from prov.model import (
     first,
     parse_xsd_datetime,
 )
-from prov.serializers import Serializer
+from prov.serializers import Serializer, _is_text_stream
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class ProvJSONSerializer(Serializer):
             # Right now this is a bytestream. If the object to stream to is
             # a text object, it must be decoded. We assume utf-8 here, which
             # should be fine for almost every case.
-            if isinstance(stream, io.TextIOBase):
+            if _is_text_stream(stream):
                 stream.write(buf.read())
             else:
                 stream.write(buf.read().encode("utf-8"))
@@ -115,7 +115,7 @@ class ProvJSONSerializer(Serializer):
         Returns:
             The deserialized :class:`~prov.model.ProvDocument`.
         """
-        if not isinstance(stream, io.TextIOBase):
+        if not _is_text_stream(stream):
             buf = io.StringIO(stream.read().decode("utf-8"))
             stream = buf
         return cast(ProvDocument, json.load(stream, cls=ProvJSONDecoder, **args))

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -5,7 +5,7 @@ import io
 from typing import Any
 
 from prov.model import ProvDocument
-from prov.serializers import Serializer
+from prov.serializers import Serializer, _is_text_stream
 
 
 class ProvNSerializer(Serializer):
@@ -33,9 +33,7 @@ class ProvNSerializer(Serializer):
 
         provn_content = self.document.get_provn()
         stream.write(
-            provn_content
-            if isinstance(stream, io.TextIOBase)
-            else provn_content.encode("utf-8")
+            provn_content if _is_text_stream(stream) else provn_content.encode("utf-8")
         )
 
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -48,7 +48,7 @@ from prov.constants import (
     XSD_QNAME,
 )
 from prov.identifier import QualifiedName
-from prov.serializers import Serializer
+from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Satrajit S. Ghosh"
 __email__ = "satra@mit.edu"
@@ -192,7 +192,7 @@ class ProvRDFSerializer(Serializer):
             # Right now this is a bytestream. If the object to stream to is
             # a text object is must be decoded. We assume utf-8 here which
             # should be fine for almost every case.
-            if isinstance(stream, io.TextIOBase):
+            if _is_text_stream(stream):
                 stream.write(buf.read().decode("utf-8"))
             else:
                 stream.write(buf.read())

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -14,7 +14,7 @@ import prov
 import prov.identifier
 from prov.constants import *
 from prov.model import DEFAULT_NAMESPACES, sorted_attributes
-from prov.serializers import Serializer
+from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Lion Krischer"
 __email__ = "krischer@geophysik.uni-muenchen.de"
@@ -82,7 +82,7 @@ class ProvXMLSerializer(Serializer):
         # does not have the concept of an encoding as it should already
         # represent unicode code points.
         et = etree.ElementTree(xml_root)
-        if isinstance(stream, io.TextIOBase):
+        if _is_text_stream(stream):
             stream.write(
                 etree.tostring(et, xml_declaration=True, pretty_print=True).decode(
                     "utf-8"
@@ -262,7 +262,7 @@ class ProvXMLSerializer(Serializer):
         Returns:
             The deserialized :class:`~prov.model.ProvDocument`.
         """
-        if isinstance(stream, io.TextIOBase):
+        if _is_text_stream(stream):
             with io.BytesIO() as buf:
                 buf.write(stream.read().encode("utf-8"))
                 buf.seek(0, 0)

--- a/src/prov/tests/test_conformance_dm.py
+++ b/src/prov/tests/test_conformance_dm.py
@@ -104,20 +104,10 @@ def test_read_autodetects_prov_xml(tmp_path):
     assert prov.read(str(path)) == document
 
 
-# On Python 3.14+ NamedTemporaryFile's repr embeds the file path (slashes), so
-# serialize()'s repr-derived filename raises FileNotFoundError instead of
-# writing a junk file (the AssertionError path on <=3.13).
-@pytest.mark.xfail(
-    strict=True,
-    raises=(AssertionError, FileNotFoundError),
-    reason=(
-        "#240: ProvDocument.serialize() writes to a repr-named CWD file when "
-        "given a non-io.IOBase file object (e.g. NamedTemporaryFile)"
-    ),
-)
 def test_serialize_writes_to_named_temporary_file(tmp_path, monkeypatch):
-    # chdir into tmp_path so the bug's junk repr-named file cannot litter the repo
-    monkeypatch.chdir(tmp_path)
+    # #240 regression: non-io.IOBase writables (e.g. NamedTemporaryFile's
+    # _TemporaryFileWrapper proxy) must be treated as streams, not paths.
+    monkeypatch.chdir(tmp_path)  # any junk repr-named file would land here
     document = _doc()
     document.entity("ex:e1")
     with tempfile.NamedTemporaryFile(
@@ -125,7 +115,35 @@ def test_serialize_writes_to_named_temporary_file(tmp_path, monkeypatch):
     ) as stream:
         document.serialize(stream, format="json")
         name = stream.name
-    assert os.path.getsize(name) > 0
+    assert ProvDocument.deserialize(name, format="json") == document
+    junk = [p for p in os.listdir(tmp_path) if p.startswith("<")]
+    assert junk == []
+
+
+def test_deserialize_reads_from_named_temporary_file(tmp_path):
+    # #240 (read side): deserialize() had the same isinstance(…, IOBase)
+    # test; any object with read() must be accepted as a stream.
+    document = _doc()
+    document.entity("ex:e1")
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", dir=tmp_path) as stream:
+        stream.write(document.serialize(format="json"))
+        stream.flush()
+        stream.seek(0)
+        assert ProvDocument.deserialize(stream, format="json") == document
+
+
+def test_serialize_xml_to_text_mode_named_temporary_file(tmp_path):
+    # #240 as originally filed: text-mode NamedTemporaryFile + format="xml".
+    # Beyond the stream-vs-path routing in serialize(), the serializers'
+    # text/binary detection (isinstance(stream, io.TextIOBase)) also had to
+    # recognise such wrapper objects as text streams.
+    pytest.importorskip("lxml")
+    document = _doc()
+    document.entity("ex:e1")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", dir=tmp_path) as stream:
+        document.serialize(stream, format="xml")
+        stream.flush()
+        assert ProvDocument.deserialize(stream.name, format="xml") == document
 
 
 # --- Characterization of permissive behaviour (findings doc section 2.8) -----


### PR DESCRIPTION
## Summary

Two defect sites of the same class (`isinstance` checks that are false for common file-like proxy objects such as `tempfile.NamedTemporaryFile`'s `_TemporaryFileWrapper`):

1. **Routing** (`bundle.py`): `serialize()` decided stream-vs-path with `isinstance(destination, IOBase)`, so a `NamedTemporaryFile` destination fell into the file-path branch and the serialization landed in a repr-named junk file in the CWD while the intended file stayed empty. `deserialize()` had the identical test on the read side. Both now duck-type (`hasattr(destination, "write")` / `hasattr(source, "read")`); annotations widened to `io.IOBase | IO[Any] | PathLike | None`.
2. **Text/binary classification** (all four serializers): the issue's own repro (text-mode `NamedTemporaryFile`, `format="xml"`) still crashed after the routing fix because the serializers classify streams with `isinstance(stream, io.TextIOBase)` — also false for the proxy. All six sites now use a shared private helper `_is_text_stream()`: `isinstance(stream, io.TextIOBase) or hasattr(stream, "encoding")`. The check is monotone: every stream classified as text before still is; the only reclassified streams are proxies that previously crashed with `TypeError`/`AttributeError` (verified per stream type: `BytesIO`, `BufferedReader/Writer/Random`, `GzipFile`, binary-mode `NamedTemporaryFile` all lack `.encoding`).

Behaviour changes only on previously-failing paths, per the 2.x stability promise. Three regression tests (write-side routing, read-side routing, and the filed repro shape: text-mode NTF + XML round-trip); the #240 strict xfail in `test_conformance_dm.py` flips to a passing test.

Suite: 1136 passed / 22 skipped / 15 xfailed; ruff, ruff format, mypy --strict clean.

Fixes #240