### PR TITLE
Fix prov.read() auto-detection: XML, raw content, empty input

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,12 @@ History
   treated as file paths, writing to a repr-named file in the working
   directory. The serializers' text/binary stream detection now also
   recognises such wrapper objects as text streams (#240)
+* ``prov.read()`` fixes (#239): valid PROV-XML is now auto-detected (the RDF
+  parser's ``BadSyntax`` no longer aborts detection); a ``str``/``bytes``
+  source that is not an existing file path is parsed as raw content, as the
+  documentation always advertised; and input that no deserializer can
+  meaningfully parse (e.g. an empty file) now raises ``TypeError`` instead of
+  silently returning an empty document
 
 2.4.0 (2026-07-06)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
+import io
 import os
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from prov.model import ProvDocument
@@ -20,23 +21,27 @@ class Error(Exception):
 
 
 def read(
-    source: str | bytes | os.PathLike[str], format: str | None = None
+    source: io.IOBase | IO[Any] | str | bytes | os.PathLike[str],
+    format: str | None = None,
 ) -> ProvDocument | None:
     """Read a :class:`~prov.model.ProvDocument` from a file, path, or string.
 
-    If ``format`` is not given, the format is detected lazily by trying each
-    registered serializer's ``deserialize()`` in turn and returning the first
-    one that succeeds. The deserializers should fail fairly early when data of
-    the wrong type is passed to them thus the try/except is likely cheap. One
-    could of course also do some more advanced format auto-detection but I am
-    not sure that is necessary.
+    A ``str``/``bytes`` source naming an existing file is read from that
+    file; any other ``str``/``bytes`` is parsed as raw document content.
 
-    The downside of auto-detection is that no proper error messages will be
-    produced; pass the ``format`` parameter explicitly to get the actual
-    traceback from the matching deserializer.
+    If ``format`` is not given, the format is detected by trying each
+    registered deserializer in turn and returning the first that both
+    succeeds and produces a non-empty document (a parse yielding no records
+    or bundles -- e.g. rdflib parsing empty/foreign input to an empty graph
+    -- is treated as "not this format"; registered namespaces are not used
+    as a signal here since the rdf deserializer always registers rdflib's
+    own default-bound namespace prefixes on every successful parse, empty
+    or not). Auto-detection swallows all deserializer errors; pass
+    ``format`` explicitly to get the actual traceback from the matching
+    deserializer.
 
     Args:
-        source: File-like stream, path, or raw content to deserialize.
+        source: File-like stream, path to an existing file, or raw content.
         format: Serialization format to use (e.g. ``"json"``, ``"xml"``,
             ``"rdf"``, ``"provn"``). If ``None``, every registered format is
             tried in turn.
@@ -45,8 +50,8 @@ def read(
         The deserialized :class:`~prov.model.ProvDocument`.
 
     Raises:
-        TypeError: If ``format`` is ``None`` and none of the registered
-            serializers could deserialize ``source``.
+        TypeError: If ``format`` is ``None`` and no registered serializer
+            produced a non-empty document from ``source``.
     """
     # Lazy imports to not globber the namespace.
     from prov.model import ProvDocument
@@ -56,19 +61,38 @@ def read(
     assert Registry.serializers is not None  # populated by load_serializers()
     serializers = Registry.serializers.keys()
 
+    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None = source
+    content: str | bytes | None = None
+    if isinstance(src, (str, bytes)) and not os.path.isfile(src):
+        # Not a path to an existing file: treat the string itself as raw
+        # document content.
+        content, src = src, None
+
     if format:
-        return ProvDocument.deserialize(source=source, format=format.lower())
+        return ProvDocument.deserialize(
+            source=src, content=content, format=format.lower()
+        )
 
     for format in serializers:
         try:
-            return ProvDocument.deserialize(source=source, format=format)
-        except (TypeError, ValueError, AttributeError, KeyError):
-            # Catch specific exceptions that can occur during deserialization
-            # This allows for better debugging information
+            document = ProvDocument.deserialize(
+                source=src, content=content, format=format
+            )
+        except Exception:
+            # Any failure from a candidate deserializer means "not this
+            # format" -- move on to the next candidate.
             continue
-    else:
-        raise TypeError(
-            "Could not read from the source. To get a proper "
-            "error message, specify the format with the 'format' "
-            "parameter."
-        )
+        if document.get_records() or document.has_bundles():
+            return document
+        # A parse producing a completely empty document (e.g. rdflib
+        # accepts empty input, or the xml deserializer walking a
+        # childless foreign root) is treated as not detected. Registered
+        # namespaces are deliberately not consulted: the rdf deserializer
+        # always copies rdflib's own default-bound namespace prefixes onto
+        # the document on every successful parse, so that signal is always
+        # truthy and would defeat this check for the rdf format.
+    raise TypeError(
+        "Could not read from the source. To get a proper "
+        "error message, specify the format with the 'format' "
+        "parameter."
+    )

--- a/src/prov/tests/test_conformance_dm.py
+++ b/src/prov/tests/test_conformance_dm.py
@@ -89,13 +89,6 @@ def test_factory_time_accepts_hour24_datetime():
     assert activity.get_startTime() is not None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "#239: prov.read() cannot auto-detect valid PROV-XML (RDF deserializer's "
-        "BadSyntax propagates before the XML deserializer is tried)"
-    ),
-)
 def test_read_autodetects_prov_xml(tmp_path):
     document = _doc()
     document.entity("ex:e1")

--- a/src/prov/tests/test_malformed.py
+++ b/src/prov/tests/test_malformed.py
@@ -124,23 +124,22 @@ def test_xml_childless_foreign_root_parses_to_empty_document():
     assert list(doc.get_records()) == []
 
 
-def test_read_on_unparseable_content_raises_bad_syntax(tmp_path):
+def test_read_on_unparseable_content_raises_type_error(tmp_path):
     """``prov.read()`` on content none of the auto-detected deserializers accept.
 
     With ``format=None``, ``read()`` tries each registered format in turn
-    (json, rdf, provn, xml -- see ``Registry.load_serializers()``). For a
-    real file with genuinely unparseable content, the json attempt fails
-    with a caught ``JSONDecodeError``, but the next attempt, rdf (default
-    ``rdf_format="trig"``), raises rdflib's ``BadSyntax`` -- a
-    ``SyntaxError``, which is *not* one of the ``(TypeError, ValueError,
-    AttributeError, KeyError)`` types ``read()`` catches -- so it propagates
-    immediately and auto-detection never reaches provn/xml. This mirrors
-    ``test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error`` in
-    test_read.py (a known limitation, not fixed here).
+    (json, rdf, provn, xml -- see ``Registry.load_serializers()``). Since
+    #239, ANY exception from a candidate deserializer -- including rdflib's
+    ``BadSyntax`` on the rdf attempt -- means "not this format" and
+    auto-detection moves on to the next candidate. For a real file with
+    genuinely unparseable content, every candidate fails and ``read()``
+    raises its own ``TypeError`` rather than leaking the last candidate's
+    exception. This mirrors ``test_read_auto_detect_swallows_any_deserializer_error``
+    in test_read.py.
     """
     path = tmp_path / "garbage.txt"
     path.write_text("this is not any known prov serialization at all, just prose.")
-    with pytest.raises(BadSyntax):
+    with pytest.raises(TypeError):
         prov.read(str(path))
 
 

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -88,23 +88,13 @@ def test_read_auto_detects_rdf(document, tmp_path):
     assert result == document
 
 
-def test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error(document, tmp_path):
-    """
-    Documents actual current behaviour rather than the aspirational
-    "xml auto-detects too": Registry order is json, rdf, provn, xml
-    (see prov.serializers.Registry.load_serializers). For an XML
-    document, the json attempt fails cleanly (caught ValueError), but
-    the *rdf* candidate -- deserialized with its default "trig" format
-    -- raises rdflib's BadSyntax, a SyntaxError. read() only catches
-    (TypeError, ValueError, AttributeError, KeyError), so this
-    propagates and auto-detection never reaches the real xml
-    serializer. This is a known limitation (see
-    docs/test-gap-checklist.md, T13 item on the auto-detection
-    exception whitelist), not something fixed by this test-only change.
-    """
+def test_read_auto_detects_xml(document, tmp_path):
+    # #239: the rdf candidate raises rdflib's BadSyntax (a SyntaxError) on
+    # XML input; read() must treat any candidate failure as "try the next
+    # format" so the xml deserializer is reached.
     path = _write(document, tmp_path, "xml", "auto.xml")
-    with pytest.raises(SyntaxError):
-        prov.read(str(path))
+    result = prov.read(str(path))
+    assert result == document
 
 
 def test_read_unknown_format_propagates_do_not_exist(document, tmp_path):
@@ -113,21 +103,12 @@ def test_read_unknown_format_propagates_do_not_exist(document, tmp_path):
         prov.read(str(path), format="nonexistent")
 
 
-def test_read_raises_type_error_when_all_serializers_fail_to_parse():
-    """
-    The final "exhausted all serializers" branch of read() can only be
-    reached if every registered deserializer raises one of the caught
-    exception types. In practice ProvNSerializer.deserialize() always
-    raises NotImplementedError (uncaught by read()) regardless of
-    content, and the rdf/xml parsers raise SyntaxError subclasses on
-    garbage, so that branch is unreachable via any real file. (The real
-    json deserializer already fails with a caught JSONDecodeError; it
-    is mocked here too only for uniformity.) Mock the deserializers to
-    make the branch reachable and pin the resulting error message.
-    """
-
+def test_read_auto_detect_swallows_any_deserializer_error():
+    # Since #239, ANY exception from a candidate deserializer means "not
+    # this format"; when every candidate fails, read() raises its own
+    # TypeError rather than leaking the last candidate's error.
     def boom(self, stream, **kwargs):
-        raise ValueError("simulated parse failure")
+        raise RuntimeError("arbitrary deserializer failure")
 
     with (
         mock.patch.object(ProvJSONSerializer, "deserialize", boom),
@@ -140,20 +121,37 @@ def test_read_raises_type_error_when_all_serializers_fail_to_parse():
     assert "specify the format" in str(ctx.value)
 
 
-def test_read_auto_detect_only_swallows_the_documented_exception_types():
-    """
-    Pins the intended behaviour of the auto-detection loop (checklist
-    item under prov/__init__.py, T13): only (TypeError, ValueError,
-    AttributeError, KeyError) from a candidate deserializer are caught
-    and treated as "try the next format"; anything else must propagate
-    immediately rather than being swallowed.
-    """
+# -- raw-content strings (not a file path) ---------------------------------
 
-    def boom(self, stream, **kwargs):
-        raise RuntimeError("not one of the caught types")
 
-    with (
-        mock.patch.object(ProvJSONSerializer, "deserialize", boom),
-        pytest.raises(RuntimeError),
-    ):
-        prov.read(io.StringIO("garbage"))
+def test_read_accepts_raw_content_string_with_explicit_format(document):
+    content = document.serialize(format="json")
+    assert prov.read(content, format="json") == document
+
+
+def test_read_auto_detects_raw_content_string(document):
+    content = document.serialize(format="json")
+    assert prov.read(content) == document
+
+
+# -- empty / unparseable input raises TypeError -----------------------------
+
+
+def test_read_empty_file_raises_type_error(tmp_path):
+    # #239: rdflib parses empty (trig) input successfully, which used to
+    # yield a silent empty document; an empty parse is not a detection.
+    path = tmp_path / "empty.json"
+    path.touch()
+    with pytest.raises(TypeError):
+        prov.read(str(path))
+
+
+def test_read_empty_string_raises_type_error():
+    with pytest.raises(TypeError):
+        prov.read("")
+
+
+def test_read_garbage_content_raises_type_error():
+    # A str that is not an existing file path is treated as raw content.
+    with pytest.raises(TypeError):
+        prov.read("no/such/file.json")

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -121,7 +121,7 @@ def test_read_auto_detect_swallows_any_deserializer_error():
     assert "specify the format" in str(ctx.value)
 
 
-# -- raw-content strings (not a file path) ---------------------------------
+# -- raw-content strings/bytes (not a file path) ----------------------------
 
 
 def test_read_accepts_raw_content_string_with_explicit_format(document):
@@ -132,6 +132,22 @@ def test_read_accepts_raw_content_string_with_explicit_format(document):
 def test_read_auto_detects_raw_content_string(document):
     content = document.serialize(format="json")
     assert prov.read(content) == document
+
+
+def test_read_accepts_raw_content_bytes_with_explicit_format(document):
+    content = document.serialize(format="json").encode()
+    assert prov.read(content, format="json") == document
+
+
+def test_read_auto_detects_raw_content_bytes(document):
+    content = document.serialize(format="json").encode()
+    assert prov.read(content) == document
+
+
+def test_read_accepts_bytes_file_path(document, tmp_path):
+    # A bytes source naming an existing file is a path, not raw content.
+    path = _write(document, tmp_path, "json", "doc-bytes-path.json")
+    assert prov.read(str(path).encode(), format="json") == document
 
 
 # -- empty / unparseable input raises TypeError -----------------------------


### PR DESCRIPTION
## Summary

`prov.read()` had three related auto-detection bugs, all tracked as #239:

- **PROV-XML was never auto-detected.** The registry tries formats in the
  order json, rdf, provn, xml. For an XML document, the json attempt fails
  cleanly, but the *rdf* attempt (default `rdf_format="trig"`) raises
  rdflib's `BadSyntax`, a `SyntaxError` -- which was not one of the four
  exception types `read()` caught (`TypeError`, `ValueError`,
  `AttributeError`, `KeyError`). That uncaught exception escaped before the
  real xml deserializer ever got a turn. `read()` now catches *any*
  exception from a candidate deserializer and moves on to the next one, so
  auto-detection actually reaches the format that matches.
- **Raw-content strings didn't work**, despite the docstring documenting
  `source` as accepting "raw content to deserialize". A `str`/`bytes`
  `source` is now checked with `os.path.isfile()`: if it names an existing
  file it's read from disk as before; otherwise it's passed through as the
  document content itself. This applies both with and without an explicit
  `format=`.
- **Empty/unparseable input silently returned an empty document** instead
  of signalling failure, because rdflib happily parses empty (and some
  foreign) input into an empty graph with no exception. `read()` now
  treats a successful parse that yields no records and no bundles as "not
  this format" and keeps trying; if every candidate is empty or errors,
  it raises `TypeError`, same as the pre-existing "no serializer could
  parse this" path. Note: registered namespaces are deliberately *not*
  used as a non-empty signal, since the RDF deserializer always copies
  rdflib's own default-bound namespace prefixes onto the document on every
  successful parse (empty input included), which would defeat the check.

**Behaviour change flagged for 2.5.0:** the empty-input case previously
returned a valid (if empty) `ProvDocument` with no exception -- now it
raises `TypeError`. This is a behaviour change on a path that used to
succeed silently. The maintainer has explicitly approved this change for
2.5.0 despite the 2.x public-API/behaviour freeze (decision recorded
2026-07-12); everything else in this PR is a bug fix restoring documented
behaviour, not a new behaviour change.

Explicit `format=` behaviour for streams and existing file paths is
unchanged.

## Test plan

- [x] Rewrote `test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error`
      -> `test_read_auto_detects_xml`, asserting the round trip now
      succeeds instead of pinning the `SyntaxError` escape.
- [x] Rewrote `test_read_auto_detect_only_swallows_the_documented_exception_types`
      -> `test_read_auto_detect_swallows_any_deserializer_error`, pinning
      that *any* exception is swallowed and a `TypeError` is raised when
      every candidate fails.
- [x] Dropped `test_read_raises_type_error_when_all_serializers_fail_to_parse`
      (its docstring claimed the "exhausted all serializers" branch was
      only reachable via mocks; that's no longer true) in favour of the
      swallow test above plus a real garbage-content case.
- [x] Added `test_read_accepts_raw_content_string_with_explicit_format`,
      `test_read_auto_detects_raw_content_string`,
      `test_read_empty_file_raises_type_error`,
      `test_read_empty_string_raises_type_error`,
      `test_read_garbage_content_raises_type_error`.
- [x] Flipped the `#239` `xfail` on `test_read_autodetects_prov_xml` in
      `test_conformance_dm.py`.
- [x] Updated the matching pin in `test_malformed.py`
      (`test_read_on_unparseable_content_raises_type_error`, was
      `..._raises_bad_syntax`) to expect `TypeError` instead of `BadSyntax`.
- [x] `uv run pytest -q` -> 1141 passed, 22 skipped, 14 xfailed (up from
      1136/22/15 on master: one xfail flipped to pass, net +5 tests).
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` clean.
- [x] `uv run mypy src` clean.

Fixes #239