### PR TITLE
Document the prov:type idiom with QualifiedNames, not strings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,10 @@ History
   documentation always advertised; and input that no deserializer can
   meaningfully parse (e.g. an empty file) now raises ``TypeError`` instead of
   silently returning an empty document
+* Documentation: the agent-subtype idiom now correctly uses qualified names
+  (``PROV["Person"]``) for ``prov:type`` values; the previously documented
+  string form asserted a plain string, which does not denote the pre-defined
+  PROV type (#236)
 
 2.4.0 (2026-07-06)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/explanation/prov-dm.md
+++ b/docs/explanation/prov-dm.md
@@ -110,8 +110,11 @@ Who is responsible for what, and the most general relation of all — influence.
 
 PROV-DM also defines agent *subtypes* — Person, Organization, and SoftwareAgent — and the
 Plan entity subtype used with associations. These are not separate classes or factories in
-`prov`; you express them by adding a `prov:type` attribute (for example,
-`agent("ag", {prov.PROV_TYPE: "prov:Person"})`).
+`prov`; you express them by adding a `prov:type` attribute whose value is the pre-defined
+*qualified name* (for example, `agent("ag", {prov.PROV_TYPE: prov.PROV["Person"]})`).
+Note that the value must be a qualified name: a plain string such as `"prov:Person"` is
+stored (and serialized) as just that string, which per PROV-DM §5.7.2.4 does not denote
+the pre-defined type at all.
 
 ### Component 4 — Bundles
 

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -123,7 +123,7 @@ as an entity subtype used with associations. `prov` has no dedicated classes or 
 agent subtypes — you express them with `agent("ag", {PROV_TYPE: PROV["Person"]})` — while Plan
 needs no special handling at all, since it is just an entity passed as the `plan=` argument to
 `association()`. This is a documented, intentional design choice
-(`docs/explanation/prov-dm.md:111-116`), not a defect; see finding log for the audit note.
+(`docs/explanation/prov-dm.md:111-117`), not a defect; see finding log for the audit note.
 Convenience factories for the three agent subtypes (together with `EmptyCollection`, see
 Component 6) are now tracked as
 [#260](https://github.com/trungdong/prov/issues/260).

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -120,10 +120,10 @@ output from this library always uses the base `wasDerivedFrom` form.
 
 **Finding:** PROV-DM defines Person, Organization, and SoftwareAgent as agent subtypes, and Plan
 as an entity subtype used with associations. `prov` has no dedicated classes or factories for the
-agent subtypes — you express them with `agent("ag", {PROV_TYPE: "prov:Person"})` — while Plan
+agent subtypes — you express them with `agent("ag", {PROV_TYPE: PROV["Person"]})` — while Plan
 needs no special handling at all, since it is just an entity passed as the `plan=` argument to
 `association()`. This is a documented, intentional design choice
-(`docs/explanation/prov-dm.md:111-114`), not a defect; see finding log for the audit note.
+(`docs/explanation/prov-dm.md:111-116`), not a defect; see finding log for the audit note.
 Convenience factories for the three agent subtypes (together with `EmptyCollection`, see
 Component 6) are now tracked as
 [#260](https://github.com/trungdong/prov/issues/260).
@@ -168,7 +168,7 @@ attribute a bundle to an agent as a first-class PROV statement. Tracked as
 **Finding:** like collections, `EmptyCollection` is a real PROV-DM type with a real
 `ADDITIONAL_N_MAP`/`PROV_BASE_CLS` entry in `constants.py`, so the round-trip machinery
 understands it — but there is no `empty_collection()` factory or `empty=` flag on `collection()`
-to set the type for you; you would add `prov:type: "prov:EmptyCollection"` by hand via
+to set the type for you; you would add `prov:type: PROV["EmptyCollection"]` by hand via
 `other_attributes`. Tracked (together with the agent-subtype factories, see Component 3) as
 [#260](https://github.com/trungdong/prov/issues/260).
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -49,7 +49,7 @@ a1 = document.activity("a1", "2024-07-09T16:39:38", None, {prov.PROV_TYPE: "edit
 # Pass extra attributes with the ``other_attributes`` keyword.
 document.wasGeneratedBy(e2, a1, other_attributes={"ex:fct": "save"})
 document.wasAssociatedWith("a1", "ag2", None, None, {prov.PROV_ROLE: "author"})
-document.agent("ag2", {prov.PROV_TYPE: "prov:Person", "ex:name": "Bob"})
+document.agent("ag2", {prov.PROV_TYPE: prov.PROV["Person"], "ex:name": "Bob"})
 ```
 
 That is a complete provenance document. Print it in PROV-N, the human-readable notation
@@ -68,7 +68,7 @@ document
   activity(a1, 2024-07-09T16:39:38, -, [prov:type="edit"])
   wasGeneratedBy(e2, a1, -, [ex:fct="save"])
   wasAssociatedWith(a1, ag2, -, [prov:role="author"])
-  agent(ag2, [prov:type="prov:Person", ex:name="Bob"])
+  agent(ag2, [prov:type='prov:Person', ex:name="Bob"])
 endDocument
 ```
 

--- a/src/prov/tests/examples.py
+++ b/src/prov/tests/examples.py
@@ -263,7 +263,7 @@ def w3c_publication_1():
 
     g.entity("tr:WD-prov-dm-20111018", {"prov:type": "rec54:WD"})
     g.entity("tr:WD-prov-dm-20111215", {"prov:type": "rec54:WD"})
-    g.entity("process:rec-advance", {"prov:type": "prov:Plan"})
+    g.entity("process:rec-advance", {"prov:type": PROV["Plan"]})
 
     g.entity("chairs:2011OctDec/0004", {"prov:type": "trans:transreq"})
     g.entity("email:2011Oct/0141", {"prov:type": "trans:pubreq"})


### PR DESCRIPTION
## Summary

PROV-DM's pre-defined agent/entity subtypes (Person, Organization, SoftwareAgent, Plan,
EmptyCollection) must be asserted as a `prov:type` value holding a `QualifiedName`
(e.g. `PROV["Person"]`); a plain string such as `"prov:Person"` is stored and serialized
as just that string and does not denote the pre-defined type at all.

- `docs/explanation/prov-dm.md`: the agent-subtype passage now uses `prov.PROV["Person"]`
  and explicitly calls out that a quoted string stays a string (PROV-DM §5.7.2.4).
- `docs/tutorial/getting-started.md`: the walkthrough's agent example uses
  `prov.PROV["Person"]`; the shown PROV-N output block is updated to match
  (`prov:type='prov:Person'`, single-quoted since it's now a qualified name).
- `docs/reference/conformance.md`: the Component-3 and Component-6 findings' example
  snippets now show `PROV["Person"]` / `PROV["EmptyCollection"]`.
- `src/prov/tests/examples.py`: the one remaining stringly-typed `"prov:Plan"` value in
  the shared examples corpus is now `PROV["Plan"]`.
- `HISTORY.rst`: changelog bullet under `2.5.0 (unreleased)`.

Fixes #236

## Test plan
- [x] `uv run pytest -q` → 1144 passed, 22 skipped, 14 xfailed
- [x] `uv run ruff check src/` clean
- [x] `uv run ruff format --check src/` clean
- [x] `uv run mypy src` clean
- [x] `uv run --group docs --extra rdf --extra xml sphinx-build -b html docs docs/_build/html` builds with 0 warnings (also verified with `-W`)
- [x] Every tutorial code block re-run end-to-end in order; PROV-N output block updated verbatim from actual output