### PR TITLE
Add record-level chaining convenience methods

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 
 2.5.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
+* New record-level chaining convenience methods (#154):
+  ``ProvEntity.wasRevisionOf()``, ``.wasQuotedFrom()``, ``.hadPrimarySource()``,
+  ``.mentionOf()``, and ``.wasInfluencedBy()`` on ``ProvEntity``,
+  ``ProvActivity`` and ``ProvAgent`` — mirroring the existing
+  ``e1.wasDerivedFrom(e2)`` style for the remaining relation types
 * The PROV-XML deserializer now raises ``ProvXMLException`` when a record's
   child element carries only unrecognised XML attributes, instead of leaking a
   raw ``UnboundLocalError`` or silently reusing the previous attribute's value

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -896,6 +896,127 @@ class ProvEntity(ProvElement):
         self._bundle.membership(self, entity)
         return self
 
+    def wasRevisionOf(
+        self,
+        usedEntity: EntityRef,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvEntity:
+        """Create a new revision record for this entity from a used entity.
+
+        Args:
+            usedEntity: The original entity (or its string identifier).
+            activity: The activity (or its string identifier) involved in the
+                revision (default: ``None``).
+            generation: Optional generation record qualifying the derivation
+                (default: ``None``).
+            usage: Optional usage record qualifying the derivation
+                (default: ``None``).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This entity (to allow chaining).
+        """
+        self._bundle.revision(
+            self, usedEntity, activity, generation, usage, other_attributes=attributes
+        )
+        return self
+
+    def wasQuotedFrom(
+        self,
+        usedEntity: EntityRef,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvEntity:
+        """Create a new quotation record for this entity from a quoted entity.
+
+        Args:
+            usedEntity: The quoted entity (or its string identifier).
+            activity: The activity (or its string identifier) involved in the
+                quotation (default: ``None``).
+            generation: Optional generation record qualifying the derivation
+                (default: ``None``).
+            usage: Optional usage record qualifying the derivation
+                (default: ``None``).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This entity (to allow chaining).
+        """
+        self._bundle.quotation(
+            self, usedEntity, activity, generation, usage, other_attributes=attributes
+        )
+        return self
+
+    def hadPrimarySource(
+        self,
+        usedEntity: EntityRef,
+        activity: ActivityRef | None = None,
+        generation: GenrationRef | None = None,
+        usage: UsageRef | None = None,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvEntity:
+        """Create a new primary-source record for this entity.
+
+        Args:
+            usedEntity: The primary-source entity (or its string identifier).
+            activity: The activity (or its string identifier) involved
+                (default: ``None``).
+            generation: Optional generation record qualifying the derivation
+                (default: ``None``).
+            usage: Optional usage record qualifying the derivation
+                (default: ``None``).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This entity (to allow chaining).
+        """
+        self._bundle.primary_source(
+            self, usedEntity, activity, generation, usage, other_attributes=attributes
+        )
+        return self
+
+    def mentionOf(self, generalEntity: EntityRef, bundle: EntityRef) -> ProvEntity:
+        """Create a new mention record of this entity from a general entity.
+
+        Args:
+            generalEntity: The general entity (or its string identifier), the
+                relationship destination.
+            bundle: The bundle (or its string identifier) that the general
+                entity is described in.
+
+        Returns:
+            This entity (to allow chaining).
+        """
+        self._bundle.mention(self, generalEntity, bundle)
+        return self
+
+    def wasInfluencedBy(
+        self,
+        influencer: EntityRef | ActivityRef | AgentRef,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvEntity:
+        """Create a new influence record on this entity by an influencer.
+
+        Args:
+            influencer: The influencing entity, activity or agent (or its
+                string identifier).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This entity (to allow chaining).
+        """
+        self._bundle.influence(self, influencer, other_attributes=attributes)
+        return self
+
 
 class ProvActivity(ProvElement):
     """Provenance Activity element."""
@@ -1053,6 +1174,25 @@ class ProvActivity(ProvElement):
         self._bundle.association(self, agent, plan, other_attributes=attributes)
         return self
 
+    def wasInfluencedBy(
+        self,
+        influencer: EntityRef | ActivityRef | AgentRef,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvActivity:
+        """Create a new influence record on this activity by an influencer.
+
+        Args:
+            influencer: The influencing entity, activity or agent (or its
+                string identifier).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This activity (to allow chaining).
+        """
+        self._bundle.influence(self, influencer, other_attributes=attributes)
+        return self
+
 
 class ProvGeneration(ProvRelation):
     """Provenance Generation relationship."""
@@ -1157,6 +1297,25 @@ class ProvAgent(ProvElement):
         self._bundle.delegation(
             self, responsible, activity, other_attributes=attributes
         )
+        return self
+
+    def wasInfluencedBy(
+        self,
+        influencer: EntityRef | ActivityRef | AgentRef,
+        attributes: RecordAttributesArg | None = None,
+    ) -> ProvAgent:
+        """Create a new influence record on this agent by an influencer.
+
+        Args:
+            influencer: The influencing entity, activity or agent (or its
+                string identifier).
+            attributes: Optional extra attributes for the record, as a dict or
+                an iterable of ``(name, value)`` pairs (default: ``None``).
+
+        Returns:
+            This agent (to allow chaining).
+        """
+        self._bundle.influence(self, influencer, other_attributes=attributes)
         return self
 
 

--- a/src/prov/tests/test_chaining.py
+++ b/src/prov/tests/test_chaining.py
@@ -1,0 +1,85 @@
+"""Record-level chaining convenience methods added by #154.
+
+Each method must (a) produce a document equal to the one built via the
+corresponding ProvBundle factory and (b) return self for chaining.
+"""
+
+from prov.model import ProvDocument
+
+EX = "http://example.org/"
+
+
+def _doc():
+    document = ProvDocument()
+    document.add_namespace("ex", EX)
+    return document
+
+
+def test_entity_wasRevisionOf():
+    document = _doc()
+    e2 = document.entity("ex:e2")
+    assert e2.wasRevisionOf("ex:e1") is e2
+    expected = _doc()
+    expected.entity("ex:e2")
+    expected.revision("ex:e2", "ex:e1")
+    assert document == expected
+
+
+def test_entity_wasQuotedFrom():
+    document = _doc()
+    e2 = document.entity("ex:e2")
+    assert e2.wasQuotedFrom("ex:e1") is e2
+    expected = _doc()
+    expected.entity("ex:e2")
+    expected.quotation("ex:e2", "ex:e1")
+    assert document == expected
+
+
+def test_entity_hadPrimarySource():
+    document = _doc()
+    e2 = document.entity("ex:e2")
+    assert e2.hadPrimarySource("ex:e1") is e2
+    expected = _doc()
+    expected.entity("ex:e2")
+    expected.primary_source("ex:e2", "ex:e1")
+    assert document == expected
+
+
+def test_entity_mentionOf():
+    document = _doc()
+    e2 = document.entity("ex:e2")
+    assert e2.mentionOf("ex:e1", "ex:b") is e2
+    expected = _doc()
+    expected.entity("ex:e2")
+    expected.mention("ex:e2", "ex:e1", "ex:b")
+    assert document == expected
+
+
+def test_entity_wasInfluencedBy():
+    document = _doc()
+    e2 = document.entity("ex:e2")
+    assert e2.wasInfluencedBy("ex:e1") is e2
+    expected = _doc()
+    expected.entity("ex:e2")
+    expected.influence("ex:e2", "ex:e1")
+    assert document == expected
+
+
+def test_activity_wasInfluencedBy():
+    document = _doc()
+    a2 = document.activity("ex:a2")
+    assert a2.wasInfluencedBy("ex:a1") is a2
+    expected = _doc()
+    expected.activity("ex:a2")
+    expected.influence("ex:a2", "ex:a1")
+    assert document == expected
+
+
+def test_agent_wasInfluencedBy():
+    document = _doc()
+    ag2 = document.agent("ex:ag2")
+    assert ag2.wasInfluencedBy("ex:ag1") is ag2
+    expected = _doc()
+    expected.agent("ex:ag2")
+    expected.influence("ex:ag2", "ex:ag1")
+    assert document == expected


### PR DESCRIPTION
## Summary

Implements Task 5 of the prov 2.5.0 release plan: adds five missing chaining convenience methods to provenance records.

- `ProvEntity.wasRevisionOf()`, `.wasQuotedFrom()`, `.hadPrimarySource()`, `.mentionOf()`
- `wasInfluencedBy()` on `ProvEntity`, `ProvActivity`, and `ProvAgent`

Each method delegates to the corresponding `ProvBundle` factory and returns `self` for chainability, mirroring the existing `e1.wasDerivedFrom(e2)` style.

## Acceptance Criteria

- [x] Each new method produces a document equal to one built via the corresponding factory and returns `self` (chainable)
- [x] Docstrings in napoleon style matching sibling methods
- [x] mypy --strict clean; `dir(prov.model)` unchanged
- [x] Full suite green: 1151 passed / 22 skipped / 14 xfailed

## Testing

- Created `src/prov/tests/test_chaining.py` with 7 tests (one per method)
- All existing tests still pass
- Public API smoke test passes (no breaking changes)

Fixes #154