### PR TITLE
Polish read(): stream rewind, quiet auto-detect, path-typo hint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,19 @@
 History
 -------
 
+2.5.1 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* ``prov.read()`` polish following 2.5.0's #239: seekable streams are now
+  rewound between auto-detection attempts (so e.g. a PROV-XML stream
+  auto-detects instead of being consumed by the first candidate); rdflib's
+  "does not look like a valid URI" logger noise from swallowed candidate
+  attempts is suppressed during auto-detection; and when a ``str``/``bytes``
+  source that is not an existing file path fails to parse, the error now
+  carries a hint that it was treated as raw content
+* Documentation: the PROV-XML and PROV-JSON how-to pages no longer describe
+  the pre-2.5.0 ``read()`` auto-detection behaviour (exception whitelist,
+  "XML never auto-detects")
+
 2.5.0 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^
 * New record-level chaining convenience methods (#154):

--- a/docs/howto/provjson.md
+++ b/docs/howto/provjson.md
@@ -50,9 +50,9 @@ loaded = pm.ProvDocument.deserialize(content=json_str, format="json")
 ## Auto-detect the format with `prov.read()`
 
 {py:func}`prov.read` tries every registered deserializer in turn — PROV-JSON, then
-PROV-O/RDF, then PROV-N, then PROV-XML — until one succeeds, so it works without knowing
-the format up front. PROV-JSON is tried first, so valid PROV-JSON content always
-auto-detects correctly:
+PROV-O/RDF, then PROV-N, then PROV-XML — until one both succeeds and produces a non-empty
+document, so it works without knowing the format up front. PROV-JSON is tried first, so
+valid PROV-JSON content always auto-detects correctly:
 
 ```python
 import prov
@@ -80,11 +80,9 @@ except Exception as e:
 JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 ```
 
-Calling `prov.read()` without `format` on content that matches none of the registered
-formats only raises the documented fallback `TypeError` ("Could not read from the
-source...") if every deserializer it tries fails with one of `TypeError`, `ValueError`,
-`AttributeError`, or `KeyError` — those are the only exceptions `read()` catches while it
-tries formats in turn. In practice the RDF deserializer (tried before PROV-XML) usually
-raises an `rdflib` parser error first, which is *not* in that list, so it propagates
-immediately instead. Either way: pass `format=` explicitly if you want a predictable,
-format-specific error.
+Since 2.5.0, `prov.read()` swallows *every* candidate deserializer's failure during
+auto-detection — including a candidate that raises, and a candidate that parses
+successfully but yields an empty document (e.g. an empty file) — and always raises the
+fallback `TypeError` ("Could not read from the source...") once every registered format has
+been tried without success. Pass `format=` explicitly if you want a predictable,
+format-specific error instead of that generic `TypeError`.

--- a/docs/howto/provxml.md
+++ b/docs/howto/provxml.md
@@ -50,27 +50,30 @@ loaded = pm.ProvDocument.deserialize(content=xml_str, format="xml")
 
 ## Auto-detect the format with `prov.read()`
 
-`prov.read()` tries PROV-JSON, then PROV-O/RDF, then PROV-N, then PROV-XML, stopping at the
-first deserializer that succeeds. In practice this means **plain PROV-XML content almost
-never auto-detects**: the RDF (TriG) parser is tried before the XML one, and on real
-PROV-XML input it fails with an `rdflib` syntax error rather than one of the exception
-types `read()` catches (`TypeError`, `ValueError`, `AttributeError`, `KeyError`) — so that
-error propagates before PROV-XML ever gets a turn:
+`prov.read()` tries each registered deserializer in turn — PROV-JSON, then PROV-O/RDF, then
+PROV-N, then PROV-XML — treating any failure from a candidate as "not this format" and
+moving on to the next one, stopping at the first deserializer that both succeeds and
+produces a non-empty document. Valid PROV-XML therefore auto-detects, whether the source is
+a file path or raw content:
 
 ```python
 import prov
 
-try:
-    prov.read("document.xml")  # no format given
-except Exception as e:
-    print(f"{type(e).__name__}: autodetect did not reach the XML deserializer")
-
-loaded = prov.read("document.xml", format="xml")  # works
+loaded = prov.read("document.xml")  # no format given
 assert loaded == document
 ```
 
-Always pass `format="xml"` explicitly when reading PROV-XML; do not rely on autodetection
-for this format.
+A seekable stream source (an open file object, `io.StringIO`, `io.BytesIO`, ...) is rewound
+between auto-detection attempts, so it also auto-detects; a non-seekable stream is consumed
+by the first candidate, so pass `format="xml"` explicitly for those.
+
+Passing `format="xml"` explicitly skips the trial-and-error and gives the real traceback if
+the content is not valid PROV-XML:
+
+```python
+loaded = prov.read("document.xml", format="xml")
+assert loaded == document
+```
 
 ## Common errors
 

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -76,16 +76,6 @@ def read(
         # document content.
         content, src = src, None
 
-    # A stream source (as opposed to a path) is duck-typed on read(),
-    # matching ProvBundle.deserialize()'s own convention (#240). Only a
-    # seekable stream can be rewound between auto-detect attempts below.
-    stream: IO[Any] | None = (
-        cast(IO[Any], src) if src is not None and hasattr(src, "read") else None
-    )
-    start_pos: int | None = None
-    if stream is not None and hasattr(stream, "seekable") and stream.seekable():
-        start_pos = stream.tell()
-
     if format:
         try:
             return ProvDocument.deserialize(
@@ -102,12 +92,33 @@ def read(
                 )
             raise
 
+    # A stream source (as opposed to a path) is duck-typed on read(),
+    # matching ProvBundle.deserialize()'s own convention (#240). Only a
+    # seekable stream can be rewound between auto-detect attempts below;
+    # if the stream's own seekable()/tell() misbehave, degrade gracefully
+    # to the non-seekable behaviour (first candidate consumes the stream)
+    # rather than failing before any deserializer gets a chance.
+    stream: IO[Any] | None = (
+        cast(IO[Any], src) if src is not None and hasattr(src, "read") else None
+    )
+    start_pos: int | None = None
+    if stream is not None and hasattr(stream, "seekable"):
+        try:
+            if stream.seekable():
+                start_pos = stream.tell()
+        except Exception:
+            start_pos = None
+
     # Failed-candidate diagnostics (e.g. rdflib's "does not look like a
     # valid URI" logger warnings) are noise by definition here: every
     # candidate's exception is swallowed below, so nothing about a failed
     # attempt is ever surfaced to the caller anyway. Raise rdflib's logger
     # level for the duration of auto-detection only -- the explicit-format
-    # path above is unaffected and still shows real diagnostics.
+    # path above is unaffected and still shows real diagnostics. Note this
+    # mutation is process-global and not thread-safe: two concurrent
+    # auto-detecting read() calls can race on the level, but the impact is
+    # bounded to transient log noise, so a Filter/thread-local would be
+    # more machinery than warranted.
     rdflib_term_logger = logging.getLogger("rdflib.term")
     previous_level = rdflib_term_logger.level
     rdflib_term_logger.setLevel(logging.ERROR)
@@ -115,7 +126,12 @@ def read(
         for format in serializers:
             if start_pos is not None:
                 assert stream is not None
-                stream.seek(start_pos)
+                try:
+                    stream.seek(start_pos)
+                except Exception:
+                    # A seek that fails mid-loop degrades to no-rewind for
+                    # the remaining attempts rather than aborting detection.
+                    start_pos = None
             try:
                 document = ProvDocument.deserialize(
                     source=src, content=content, format=format

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
 import io
+import logging
 import os
-from typing import IO, TYPE_CHECKING, Any
+import warnings
+from typing import IO, TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from prov.model import ProvDocument
@@ -40,6 +42,12 @@ def read(
     ``format`` explicitly to get the actual traceback from the matching
     deserializer.
 
+    A seekable stream ``source`` (e.g. an open file object, ``io.StringIO``,
+    ``io.BytesIO``) is rewound to its starting position before each
+    auto-detection attempt, so every candidate format sees the full content.
+    A non-seekable stream is consumed by the first candidate; pass
+    ``format`` explicitly for those.
+
     Args:
         source: File-like stream, path to an existing file, or raw content.
         format: Serialization format to use (e.g. ``"json"``, ``"xml"``,
@@ -68,31 +76,74 @@ def read(
         # document content.
         content, src = src, None
 
-    if format:
-        return ProvDocument.deserialize(
-            source=src, content=content, format=format.lower()
-        )
+    # A stream source (as opposed to a path) is duck-typed on read(),
+    # matching ProvBundle.deserialize()'s own convention (#240). Only a
+    # seekable stream can be rewound between auto-detect attempts below.
+    stream: IO[Any] | None = (
+        cast(IO[Any], src) if src is not None and hasattr(src, "read") else None
+    )
+    start_pos: int | None = None
+    if stream is not None and hasattr(stream, "seekable") and stream.seekable():
+        start_pos = stream.tell()
 
-    for format in serializers:
+    if format:
         try:
-            document = ProvDocument.deserialize(
-                source=src, content=content, format=format
+            return ProvDocument.deserialize(
+                source=src, content=content, format=format.lower()
             )
         except Exception:
-            # Any failure from a candidate deserializer means "not this
-            # format" -- move on to the next candidate.
-            continue
-        if document.get_records() or document.has_bundles():
-            return document
-        # A parse producing a completely empty document (e.g. rdflib
-        # accepts empty input, or the xml deserializer walking a
-        # childless foreign root) is treated as not detected. Registered
-        # namespaces are deliberately not consulted: the rdf deserializer
-        # always copies rdflib's own default-bound namespace prefixes onto
-        # the document on every successful parse, so that signal is always
-        # truthy and would defeat this check for the rdf format.
-    raise TypeError(
+            if content is not None:
+                warnings.warn(
+                    "read() source is not a path to an existing file and "
+                    "was parsed as raw content; if you meant a file path, "
+                    "check that it exists",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            raise
+
+    # Failed-candidate diagnostics (e.g. rdflib's "does not look like a
+    # valid URI" logger warnings) are noise by definition here: every
+    # candidate's exception is swallowed below, so nothing about a failed
+    # attempt is ever surfaced to the caller anyway. Raise rdflib's logger
+    # level for the duration of auto-detection only -- the explicit-format
+    # path above is unaffected and still shows real diagnostics.
+    rdflib_term_logger = logging.getLogger("rdflib.term")
+    previous_level = rdflib_term_logger.level
+    rdflib_term_logger.setLevel(logging.ERROR)
+    try:
+        for format in serializers:
+            if start_pos is not None:
+                assert stream is not None
+                stream.seek(start_pos)
+            try:
+                document = ProvDocument.deserialize(
+                    source=src, content=content, format=format
+                )
+            except Exception:
+                # Any failure from a candidate deserializer means "not this
+                # format" -- move on to the next candidate.
+                continue
+            if document.get_records() or document.has_bundles():
+                return document
+            # A parse producing a completely empty document (e.g. rdflib
+            # accepts empty input, or the xml deserializer walking a
+            # childless foreign root) is treated as not detected. Registered
+            # namespaces are deliberately not consulted: the rdf deserializer
+            # always copies rdflib's own default-bound namespace prefixes onto
+            # the document on every successful parse, so that signal is always
+            # truthy and would defeat this check for the rdf format.
+    finally:
+        rdflib_term_logger.setLevel(previous_level)
+
+    message = (
         "Could not read from the source. To get a proper "
         "error message, specify the format with the 'format' "
         "parameter."
     )
+    if content is not None:
+        message += (
+            " Note: the source is not a path to an existing file and was "
+            "parsed as raw content."
+        )
+    raise TypeError(message)

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -202,6 +202,30 @@ def test_read_auto_detects_json_from_seekable_stream_still_works(document):
     assert result == document
 
 
+def test_read_explicit_format_with_broken_seekable_reaches_deserializer(document):
+    # A stream whose seekable() raises must not crash read() before the
+    # deserializer runs -- especially on the explicit-format path, which
+    # never needs to rewind at all.
+    class BrokenSeekable(io.StringIO):
+        def seekable(self):
+            raise OSError("seekable() not supported here")
+
+    stream = BrokenSeekable(document.serialize(format="json"))
+    assert prov.read(stream, format="json") == document
+
+
+def test_read_auto_detect_with_broken_tell_degrades_to_no_rewind(document):
+    # seekable() -> True but tell() raising must degrade to the
+    # non-seekable (first-candidate-only) behaviour, not crash; JSON is
+    # the first candidate, so JSON content still auto-detects.
+    class BrokenTell(io.StringIO):
+        def tell(self):
+            raise OSError("tell() not supported here")
+
+    stream = BrokenTell(document.serialize(format="json"))
+    assert prov.read(stream) == document
+
+
 # -- Fix B: rdflib logger noise is suppressed during auto-detect only ------
 
 

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -2,7 +2,10 @@
 ProvDocument.deserialize() with lazy format auto-detection."""
 
 import io
+import json
+import logging
 import pathlib
+import warnings
 from unittest import mock
 
 import pytest
@@ -171,3 +174,69 @@ def test_read_garbage_content_raises_type_error():
     # A str that is not an existing file path is treated as raw content.
     with pytest.raises(TypeError):
         prov.read("no/such/file.json")
+
+
+# -- Fix A: seekable streams are rewound between auto-detect attempts ------
+
+
+def test_read_auto_detects_xml_from_seekable_stringio(document):
+    xml_str = document.serialize(format="xml")
+    stream = io.StringIO(xml_str)
+    result = prov.read(stream)
+    assert result == document
+
+
+def test_read_auto_detects_xml_from_seekable_bytesio(document):
+    xml_bytes = document.serialize(format="xml").encode()
+    stream = io.BytesIO(xml_bytes)
+    result = prov.read(stream)
+    assert result == document
+
+
+def test_read_auto_detects_json_from_seekable_stream_still_works(document):
+    # Regression guard: json is the first candidate tried, so the rewind
+    # added for other formats must not break the already-working case.
+    json_str = document.serialize(format="json")
+    stream = io.StringIO(json_str)
+    result = prov.read(stream)
+    assert result == document
+
+
+# -- Fix B: rdflib logger noise is suppressed during auto-detect only ------
+
+
+def test_read_auto_detect_xml_produces_no_rdflib_term_warnings(
+    document, tmp_path, caplog
+):
+    path = _write(document, tmp_path, "xml", "auto-quiet.xml")
+    with caplog.at_level(logging.WARNING, logger="rdflib.term"):
+        result = prov.read(str(path))
+    assert result == document
+    assert [r for r in caplog.records if r.name == "rdflib.term"] == []
+
+
+# -- Fix C: diagnostic hint when a nonexistent-path string is parsed as ----
+# -- raw content -------------------------------------------------------------
+
+
+def test_read_explicit_format_nonexistent_path_warns_raw_content_hint():
+    with (
+        pytest.raises(json.JSONDecodeError),
+        pytest.warns(UserWarning, match="raw content"),
+    ):
+        prov.read("no/such/file.json", format="json")
+
+
+def test_read_explicit_format_valid_raw_content_emits_no_warning(document):
+    content = document.serialize(format="json")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert prov.read(content, format="json") == document
+
+
+def test_read_auto_detect_nonexistent_path_type_error_has_both_hints():
+    with pytest.raises(TypeError) as ctx:
+        prov.read("no/such/file.json")
+    message = str(ctx.value)
+    assert "specify the format" in message
+    assert "raw content" in message


### PR DESCRIPTION
## Summary

Four follow-up fixes from the 2.5.0 final release review of `prov.read()` (#239). All non-breaking: exception types are unchanged, and each fix only changes behaviour on a path that was already failing/broken.

- **Fix A**: seekable stream sources (an open file object, `io.StringIO`, `io.BytesIO`, ...) are now rewound to their starting position before each auto-detection candidate, so e.g. a PROV-XML stream auto-detects instead of being silently consumed by the first (json) candidate. Non-seekable streams are unaffected — they're still consumed by the first candidate, so `format=` must be passed explicitly for those.
- **Fix B**: rdflib's `rdflib.term` logger noise ("... does not look like a valid URI, trying to serialize this will break") from swallowed candidate deserializer attempts is now suppressed during auto-detection only (the logger's level is raised to `ERROR` for the loop and restored in a `finally`); the explicit-`format=` path is unaffected.
- **Fix C**: when a `str`/`bytes` source that is not an existing file path fails to parse, the resulting error now hints that it was parsed as raw content — a `UserWarning` (`stacklevel=2`) alongside the original exception for the explicit-`format=` path, and an extended message on the auto-detect exhaustion `TypeError` (the existing "specify the format" substring is preserved).
- **Fix D**: `docs/howto/provxml.md` and `docs/howto/provjson.md` are updated to describe the actual post-2.5.0 `read()` auto-detection behaviour (no more "PROV-XML almost never auto-detects", no more references to the removed exception whitelist); code/output blocks were re-run for real.

## Test plan

- [x] New tests added to `src/prov/tests/test_read.py`, TDD-first (watched fail before implementing)
- [x] `uv run pytest src/prov/tests/test_read.py -v` — all pass
- [x] `uv run pytest -q` — 1158 passed, 22 skipped, 14 xfailed
- [x] `uv run ruff check src/` / `uv run ruff format --check src/` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run --group docs --extra rdf --extra xml sphinx-build -b html -W docs docs/_build/html` — 0 warnings