### PR TITLE
Prepare release 2.5.1

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,10 @@
+---
+exclude_paths:
+  - "src/prov/tests/malformed/**"
+engines:
+  bandit:
+    exclude_paths:
+      - "src/prov/tests/**"
+  markdownlint:
+    exclude_paths:
+      - "docs/superpowers/**"

--- a/.codacy/.gitignore
+++ b/.codacy/.gitignore
@@ -1,0 +1,2 @@
+generated/
+configure-codacy-summary.json

--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -1,0 +1,6195 @@
+{
+  "version": 1,
+  "metadata": {
+    "source": "auto",
+    "provider": null,
+    "organization": null,
+    "autoFilters": "Critical,High,Warning,Minor,AllSecurity,ErrorProne,Performance,BestPractice,UnusedCode,Compatibility,Complexity,Comprehensibility,CodeStyle,Documentation",
+    "repositoryId": null,
+    "repositoryName": null,
+    "createdAt": "2026-07-13T16:32:44.690Z",
+    "updatedAt": "2026-07-13T16:32:44.690Z",
+    "languages": [
+      "JSON",
+      "Markdown",
+      "Python",
+      "XML",
+      "YAML"
+    ]
+  },
+  "tools": [
+    {
+      "toolId": "jackson",
+      "patterns": [
+        {
+          "patternId": "jackson_duplicate-keys"
+        },
+        {
+          "patternId": "jackson_parse-error"
+        }
+      ]
+    },
+    {
+      "toolId": "markdownlint",
+      "patterns": [
+        {
+          "patternId": "markdownlint_MD001"
+        },
+        {
+          "patternId": "markdownlint_MD003"
+        },
+        {
+          "patternId": "markdownlint_MD004"
+        },
+        {
+          "patternId": "markdownlint_MD005"
+        },
+        {
+          "patternId": "markdownlint_MD007"
+        },
+        {
+          "patternId": "markdownlint_MD010"
+        },
+        {
+          "patternId": "markdownlint_MD011"
+        },
+        {
+          "patternId": "markdownlint_MD012"
+        },
+        {
+          "patternId": "markdownlint_MD014"
+        },
+        {
+          "patternId": "markdownlint_MD018"
+        },
+        {
+          "patternId": "markdownlint_MD019"
+        },
+        {
+          "patternId": "markdownlint_MD020"
+        },
+        {
+          "patternId": "markdownlint_MD021"
+        },
+        {
+          "patternId": "markdownlint_MD022"
+        },
+        {
+          "patternId": "markdownlint_MD023"
+        },
+        {
+          "patternId": "markdownlint_MD024"
+        },
+        {
+          "patternId": "markdownlint_MD025"
+        },
+        {
+          "patternId": "markdownlint_MD026"
+        },
+        {
+          "patternId": "markdownlint_MD027"
+        },
+        {
+          "patternId": "markdownlint_MD028"
+        },
+        {
+          "patternId": "markdownlint_MD029"
+        },
+        {
+          "patternId": "markdownlint_MD030"
+        },
+        {
+          "patternId": "markdownlint_MD032"
+        },
+        {
+          "patternId": "markdownlint_MD033"
+        },
+        {
+          "patternId": "markdownlint_MD034"
+        },
+        {
+          "patternId": "markdownlint_MD035"
+        },
+        {
+          "patternId": "markdownlint_MD036"
+        },
+        {
+          "patternId": "markdownlint_MD037"
+        },
+        {
+          "patternId": "markdownlint_MD038"
+        },
+        {
+          "patternId": "markdownlint_MD039"
+        },
+        {
+          "patternId": "markdownlint_MD042"
+        },
+        {
+          "patternId": "markdownlint_MD044"
+        },
+        {
+          "patternId": "markdownlint_MD045"
+        },
+        {
+          "patternId": "markdownlint_MD046"
+        },
+        {
+          "patternId": "markdownlint_MD048"
+        },
+        {
+          "patternId": "markdownlint_MD049"
+        },
+        {
+          "patternId": "markdownlint_MD050"
+        },
+        {
+          "patternId": "markdownlint_MD051"
+        },
+        {
+          "patternId": "markdownlint_MD052"
+        },
+        {
+          "patternId": "markdownlint_MD053"
+        },
+        {
+          "patternId": "markdownlint_MD054"
+        },
+        {
+          "patternId": "markdownlint_MD055"
+        },
+        {
+          "patternId": "markdownlint_MD056"
+        }
+      ],
+      "exclude": [
+        "docs/superpowers/**"
+      ]
+    },
+    {
+      "toolId": "Ruff",
+      "localConfigurationFile": "/Users/tdh/projects/ProvPy/prov/pyproject.toml",
+      "useLocalConfigurationFile": true,
+      "patterns": []
+    },
+    {
+      "toolId": "Trivy",
+      "patterns": [
+        {
+          "patternId": "Trivy_malicious_packages"
+        },
+        {
+          "patternId": "Trivy_secret"
+        },
+        {
+          "patternId": "Trivy_vulnerability_critical"
+        },
+        {
+          "patternId": "Trivy_vulnerability_high"
+        },
+        {
+          "patternId": "Trivy_vulnerability_medium"
+        },
+        {
+          "patternId": "Trivy_vulnerability_minor"
+        }
+      ]
+    },
+    {
+      "toolId": "Semgrep",
+      "patterns": [
+        {
+          "patternId": "Semgrep_ai.python.detect-openai.detect-openai"
+        },
+        {
+          "patternId": "Semgrep_codacy.generic.security.detect-invisible-unicode"
+        },
+        {
+          "patternId": "Semgrep_codacy.k8s.ingress.nginx.retirement.ingress-class"
+        },
+        {
+          "patternId": "Semgrep_codacy.k8s.ingress.nginx.retirement.ingress-resource"
+        },
+        {
+          "patternId": "Semgrep_codacy.k8s.ingress.nginx.retirement.workload"
+        },
+        {
+          "patternId": "Semgrep_codacy.python.openai.import-without-guardrails"
+        },
+        {
+          "patternId": "Semgrep_codacy.python.openai.non-guardrails-client-usage"
+        },
+        {
+          "patternId": "Semgrep_codacy.python.openai.non-guardrails-direct-call"
+        },
+        {
+          "patternId": "Semgrep_dockerfile.security.dockerd-socket-mount.dockerfile-dockerd-socket-mount"
+        },
+        {
+          "patternId": "Semgrep_generic.gradle.security.build-gradle-password-hardcoded.build-gradle-password-hardcoded"
+        },
+        {
+          "patternId": "Semgrep_generic_injection_rule-BiDiTrojanSource"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.adafruit-api-key.adafruit-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.adobe-client-id.adobe-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.adobe-client-secret.adobe-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.age-secret-key.age-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.airtable-api-key.airtable-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.algolia-api-key.algolia-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.alibaba-access-key-id.alibaba-access-key-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.alibaba-secret-key.alibaba-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.asana-client-id.asana-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.asana-client-secret.asana-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.atlassian-api-token.atlassian-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.authress-service-client-access-key.authress-service-client-access-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.aws-access-token.aws-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.beamer-api-token.beamer-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.bitbucket-client-id.bitbucket-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.bitbucket-client-secret.bitbucket-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.bittrex-access-key.bittrex-access-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.bittrex-secret-key.bittrex-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.clojars-api-token.clojars-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.cloudflare-api-key.cloudflare-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.cloudflare-global-api-key.cloudflare-global-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.cloudflare-origin-ca-key.cloudflare-origin-ca-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.codecov-access-token.codecov-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.coinbase-access-token.coinbase-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.confluent-access-token.confluent-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.confluent-secret-key.confluent-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.contentful-delivery-api-token.contentful-delivery-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.databricks-api-token.databricks-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.datadog-access-token.datadog-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.defined-networking-api-token.defined-networking-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.digitalocean-access-token.digitalocean-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.digitalocean-pat.digitalocean-pat"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.digitalocean-refresh-token.digitalocean-refresh-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.discord-api-token.discord-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.discord-client-id.discord-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.discord-client-secret.discord-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.doppler-api-token.doppler-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.droneci-access-token.droneci-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.dropbox-api-token.dropbox-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.dropbox-long-lived-api-token.dropbox-long-lived-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.dropbox-short-lived-api-token.dropbox-short-lived-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.duffel-api-token.duffel-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.dynatrace-api-token.dynatrace-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.easypost-api-token.easypost-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.easypost-test-api-token.easypost-test-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.etsy-access-token.etsy-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.facebook-access-token.facebook-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.facebook.facebook"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.facebook-page-access-token.facebook-page-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.facebook-secret.facebook-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.fastly-api-token.fastly-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.finicity-api-token.finicity-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.finicity-client-secret.finicity-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.finnhub-access-token.finnhub-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.flickr-access-token.flickr-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.flutterwave-encryption-key.flutterwave-encryption-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.flutterwave-public-key.flutterwave-public-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.flutterwave-secret-key.flutterwave-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.frameio-api-token.frameio-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.freshbooks-access-token.freshbooks-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gcp-api-key.gcp-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.generic-api-key.generic-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.github-app-token.github-app-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.github-fine-grained-pat.github-fine-grained-pat"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.github-oauth.github-oauth"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.github-pat.github-pat"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.github-refresh-token.github-refresh-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gitlab-pat.gitlab-pat"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gitlab-ptt.gitlab-ptt"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gitlab-rrt.gitlab-rrt"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gitter-access-token.gitter-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.gocardless-api-token.gocardless-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.grafana-api-key.grafana-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.grafana-cloud-api-token.grafana-cloud-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.grafana-service-account-token.grafana-service-account-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.harness-api-key.harness-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.hashicorp-tf-api-token.hashicorp-tf-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.heroku-api-key.heroku-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.hubspot-api-key.hubspot-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.huggingface-access-token.huggingface-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.huggingface-organization-api-token.huggingface-organization-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.infracost-api-token.infracost-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.intercom-api-key.intercom-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.intra42-client-secret.intra42-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.jfrog-api-key.jfrog-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.jfrog-identity-token.jfrog-identity-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.jwt-base64.jwt-base64"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.jwt.jwt"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.kraken-access-token.kraken-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.kucoin-access-token.kucoin-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.kucoin-secret-key.kucoin-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.launchdarkly-access-token.launchdarkly-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.linear-api-key.linear-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.linear-client-secret.linear-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.linkedin-client-id.linkedin-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.linkedin-client-secret.linkedin-client-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.lob-api-key.lob-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.lob-pub-api-key.lob-pub-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mailchimp-api-key.mailchimp-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mailgun-private-api-token.mailgun-private-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mailgun-pub-key.mailgun-pub-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mailgun-signing-key.mailgun-signing-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mapbox-api-token.mapbox-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.mattermost-access-token.mattermost-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.messagebird-api-token.messagebird-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.messagebird-client-id.messagebird-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.microsoft-teams-webhook.microsoft-teams-webhook"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.netlify-access-token.netlify-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.new-relic-browser-api-token.new-relic-browser-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.new-relic-insert-key.new-relic-insert-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.new-relic-user-api-id.new-relic-user-api-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.new-relic-user-api-key.new-relic-user-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.npm-access-token.npm-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.nytimes-access-token.nytimes-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.okta-access-token.okta-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.openai-api-key.openai-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.plaid-api-token.plaid-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.plaid-client-id.plaid-client-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.plaid-secret-key.plaid-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.planetscale-api-token.planetscale-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.planetscale-oauth-token.planetscale-oauth-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.planetscale-password.planetscale-password"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.postman-api-token.postman-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.prefect-api-token.prefect-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.private-key.private-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.pulumi-api-token.pulumi-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.pypi-upload-token.pypi-upload-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.rapidapi-access-token.rapidapi-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.readme-api-token.readme-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.rubygems-api-token.rubygems-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.scalingo-api-token.scalingo-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sendbird-access-id.sendbird-access-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sendbird-access-token.sendbird-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sendgrid-api-token.sendgrid-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sendinblue-api-token.sendinblue-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sentry-access-token.sentry-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.shippo-api-token.shippo-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.shopify-access-token.shopify-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.shopify-custom-access-token.shopify-custom-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.shopify-private-app-access-token.shopify-private-app-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.shopify-shared-secret.shopify-shared-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sidekiq-secret.sidekiq-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sidekiq-sensitive-url.sidekiq-sensitive-url"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-app-token.slack-app-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-bot-token.slack-bot-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-config-access-token.slack-config-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-config-refresh-token.slack-config-refresh-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-legacy-bot-token.slack-legacy-bot-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-legacy-token.slack-legacy-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-legacy-workspace-token.slack-legacy-workspace-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-user-token.slack-user-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.slack-webhook-url.slack-webhook-url"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.snyk-api-token.snyk-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.square-access-token.square-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.squarespace-access-token.squarespace-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.stripe-access-token.stripe-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sumologic-access-id.sumologic-access-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.sumologic-access-token.sumologic-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.telegram-bot-api-token.telegram-bot-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.travisci-access-token.travisci-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twilio-api-key.twilio-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitch-api-token.twitch-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitter-access-secret.twitter-access-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitter-access-token.twitter-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitter-api-key.twitter-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitter-api-secret.twitter-api-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.twitter-bearer-token.twitter-bearer-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.typeform-api-token.typeform-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.vault-batch-token.vault-batch-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.vault-service-token.vault-service-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.yandex-access-token.yandex-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.yandex-api-key.yandex-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.yandex-aws-access-token.yandex-aws-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.gitleaks.zendesk-secret-key.zendesk-secret-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-amazon-mws-auth-token.detected-amazon-mws-auth-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-artifactory-password.detected-artifactory-password"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-artifactory-token.detected-artifactory-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-aws-account-id.detected-aws-account-id"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-aws-appsync-graphql-key.detected-aws-appsync-graphql-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-aws-session-token.detected-aws-session-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-codeclimate.detected-codeclimate"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-etc-shadow.detected-etc-shadow"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-facebook-access-token.detected-facebook-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-facebook-oauth.detected-facebook-oauth"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-generic-api-key.detected-generic-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-generic-secret.detected-generic-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-github-token.detected-github-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-google-api-key.detected-google-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-google-cloud-api-key.detected-google-cloud-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-google-gcm-service-account.detected-google-gcm-service-account"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-google-oauth.detected-google-oauth-url"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-heroku-api-key.detected-heroku-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-hockeyapp.detected-hockeyapp"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-jwt-token.detected-jwt-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-kolide-api-key.detected-kolide-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-mailchimp-api-key.detected-mailchimp-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-mailgun-api-key.detected-mailgun-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-onfido-live-api-token.detected-onfido-live-api-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-outlook-team.detected-outlook-team"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-paypal-braintree-access-token.detected-paypal-braintree-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-picatic-api-key.detected-picatic-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-private-key.detected-private-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-sauce-token.detected-sauce-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-sendgrid-api-key.detected-sendgrid-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-slack-token.detected-slack-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-slack-webhook.detected-slack-webhook"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-snyk-api-key.detected-snyk-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-softlayer-api-key.detected-softlayer-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-square-access-token.detected-square-access-token"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-square-oauth-secret.detected-square-oauth-secret"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-ssh-password.detected-ssh-password"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-stripe-restricted-api-key.detected-stripe-restricted-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-twilio-api-key.detected-twilio-api-key"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.detected-username-and-password-in-uri.detected-username-and-password-in-uri"
+        },
+        {
+          "patternId": "Semgrep_generic.secrets.security.google-maps-apikeyleak.google-maps-apikeyleak"
+        },
+        {
+          "patternId": "Semgrep_generic.unicode.security.bidi.contains-bidirectional-characters"
+        },
+        {
+          "patternId": "Semgrep_json.aws.security.public-s3-bucket.public-s3-bucket"
+        },
+        {
+          "patternId": "Semgrep_json.aws.security.public-s3-policy-statement.public-s3-policy-statement"
+        },
+        {
+          "patternId": "Semgrep_json.aws.security.wildcard-assume-role.wildcard-assume-role"
+        },
+        {
+          "patternId": "Semgrep_json.npm.security.package-dependencies-check.package-dependencies-check"
+        },
+        {
+          "patternId": "Semgrep_properties_spring_rule-SpringActuatorFullyEnabled"
+        },
+        {
+          "patternId": "Semgrep_python.airflow.security.audit.formatted-string-bashoperator.formatted-string-bashoperator"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dangerous-system-call.dangerous-system-call"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.mysql-sqli.mysql-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.psycopg-sqli.psycopg-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.pymssql-sqli.pymssql-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.pymysql-sqli.pymysql-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.tainted-code-exec.tainted-code-exec"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.tainted-html-response.tainted-html-response"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.tainted-html-string.tainted-html-string"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization"
+        },
+        {
+          "patternId": "Semgrep_python.aws-lambda.security.tainted-sql-string.tainted-sql-string"
+        },
+        {
+          "patternId": "Semgrep_python_bind-all-interfaces_rule-general-bindall-interfaces"
+        },
+        {
+          "patternId": "Semgrep_python.boto3.security.hardcoded-token.hardcoded-token"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.empty-aes-key.empty-aes-key"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size"
+        },
+        {
+          "patternId": "Semgrep_python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-cipher-modes"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-cipher-blowfish"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-cipher-des"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-cipher-rc2"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-cipher-rc4"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-cipher-xor"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-encrypt-dsa-rsa"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-encrypt-ec"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-hash-md5"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-hash-sha1"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-hazmat-cipher-arc4"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-hazmat-cipher-blowfish"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto-hazmat-cipher-idea"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto.hazmat-hash-md5"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-crypto.hazmat-hash-sha1"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-hashlib-new-insecure-functions"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-hash-md2"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-hash-md4"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-hash-md5"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-hash-sha1"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-HTTPConnectionPool"
+        },
+        {
+          "patternId": "Semgrep_python_crypto_rule-import-pycrypto"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-cpickle"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-dill"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-marshal"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-pickle"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-shelve"
+        },
+        {
+          "patternId": "Semgrep_python_deserialization_rule-yaml-load"
+        },
+        {
+          "patternId": "Semgrep_python.distributed.security.require-encryption"
+        },
+        {
+          "patternId": "Semgrep_python_django_rule-django-extra-used"
+        },
+        {
+          "patternId": "Semgrep_python_django_rule-django-rawsql-used"
+        },
+        {
+          "patternId": "Semgrep_python_django_rule-django-raw-used"
+        },
+        {
+          "patternId": "Semgrep_python.docker.security.audit.docker-arbitrary-container-run.docker-arbitrary-container-run"
+        },
+        {
+          "patternId": "Semgrep_python_escaping_rule-django"
+        },
+        {
+          "patternId": "Semgrep_python_escaping_rule-jinja2-autoescape-false"
+        },
+        {
+          "patternId": "Semgrep_python_escaping_rule-use-of-mako-templates"
+        },
+        {
+          "patternId": "Semgrep_python_eval_rule-eval"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-exec-used"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-os-path"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-os-popen2"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-start-process-partial-path"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-start-process-path"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-start-process-with-no-shell"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-subprocess-call"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-subprocess-call-array"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-subprocess-popen-shell-true"
+        },
+        {
+          "patternId": "Semgrep_python_exec_rule-subprocess-shell-TRUE"
+        },
+        {
+          "patternId": "Semgrep_python_file-permissions_rule-general-bad-permission"
+        },
+        {
+          "patternId": "Semgrep_python_files_rule-tarfile-unsafe-members"
+        },
+        {
+          "patternId": "Semgrep_python_flask_rule-app-debug"
+        },
+        {
+          "patternId": "Semgrep_python_flask_rule-flask-open-redirect"
+        },
+        {
+          "patternId": "Semgrep_python_flask_rule-path-traversal-open"
+        },
+        {
+          "patternId": "Semgrep_python_flask_rule-tainted-sql-string"
+        },
+        {
+          "patternId": "Semgrep_python_ftp_rule-ftplib"
+        },
+        {
+          "patternId": "Semgrep_python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled"
+        },
+        {
+          "patternId": "Semgrep_python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled"
+        },
+        {
+          "patternId": "Semgrep_python_jwt_rule-jwt-none-alg"
+        },
+        {
+          "patternId": "Semgrep_python.jwt.security.audit.jwt-exposed-data.jwt-python-exposed-data"
+        },
+        {
+          "patternId": "Semgrep_python.jwt.security.jwt-exposed-credentials.jwt-python-exposed-credentials"
+        },
+        {
+          "patternId": "Semgrep_python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret"
+        },
+        {
+          "patternId": "Semgrep_python.jwt.security.jwt-none-alg.jwt-python-none-alg"
+        },
+        {
+          "patternId": "Semgrep_python.jwt.security.unverified-jwt-decode.unverified-jwt-decode"
+        },
+        {
+          "patternId": "Semgrep_python.lang.correctness.tempfile.mktemp.tempfile-insecure"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.conn_recv.multiprocessing-recv"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-annotations-usage.dangerous-annotations-usage"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-create-exec-audit.dangerous-asyncio-create-exec-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-create-exec-tainted-env-args.dangerous-asyncio-create-exec-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-exec-audit.dangerous-asyncio-exec-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-shell-audit.dangerous-asyncio-shell-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-code-run-audit.dangerous-interactive-code-run-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-os-exec-audit.dangerous-os-exec-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-spawn-process-audit.dangerous-spawn-process-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-subinterpreters-run-string-audit.dangerous-subinterpreters-run-string-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-testcapi-run-in-subinterp-audit.dangerous-testcapi-run-in-subinterp-audit"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.eval-detected.eval-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.exec-detected.exec-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.formatted-sql-query.formatted-sql-query"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.httpsconnection-detected.httpsconnection-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-file-permissions.insecure-file-permissions"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.ftplib.use-ftp-tls.use-ftp-tls"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.ssl.no-set-ciphers.no-set-ciphers"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open-ftp.insecure-openerdirector-open-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-openerdirector-open.insecure-openerdirector-open"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-request-object-ftp.insecure-request-object-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-request-object.insecure-request-object"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open-ftp.insecure-urlopener-open-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-open.insecure-urlopener-open"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve-ftp.insecure-urlopener-retrieve-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopener-retrieve.insecure-urlopener-retrieve"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopen-ftp.insecure-urlopen-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve-ftp.insecure-urlretrieve-ftp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.insecure-transport.urllib.insecure-urlretrieve.insecure-urlretrieve"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.logging.listeneval.listen-eval"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.mako-templates-detected.mako-templates-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.marshal.marshal-usage"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.md5-used-as-password.md5-used-as-password"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.network.http-not-https-connection.http-not-https-connection"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.non-literal-import.non-literal-import"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.paramiko-implicit-trust-host-key.paramiko-implicit-trust-host-key"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.paramiko.paramiko-exec-command.paramiko-exec-command"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.python-reverse-shell.python-reverse-shell"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.regex-dos.regex_dos"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.sqli.aiopg-sqli.aiopg-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.sqli.asyncpg-sqli.asyncpg-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.sqli.pg8000-sqli.pg8000-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.sqli.psycopg-sqli.psycopg-sqli"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.subprocess-shell-true.subprocess-shell-true"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.system-wildcard-detected.system-wildcard-detected"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.telnetlib.telnetlib"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.audit.weak-ssl-version.weak-ssl-version"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-code-run.dangerous-interactive-code-run"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-globals-use.dangerous-globals-use"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-os-exec.dangerous-os-exec"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-spawn-process.dangerous-spawn-process"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-system-call.dangerous-system-call"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.avoid-jsonpickle.avoid-jsonpickle"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.pickle.avoid-cpickle"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.pickle.avoid-dill"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.pickle.avoid-pickle"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.deserialization.pickle.avoid-shelve"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.insecure-hash-function.insecure-hash-function"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.insecure-uuid-version.insecure-uuid-version"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.unverified-ssl-context.unverified-ssl-context"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.use-defusedcsv.use-defusedcsv"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.use-defused-xml-parse.use-defused-xml-parse"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.use-defused-xmlrpc.use-defused-xmlrpc"
+        },
+        {
+          "patternId": "Semgrep_python.lang.security.use-defused-xml.use-defused-xml"
+        },
+        {
+          "patternId": "Semgrep_python_log_rule-logging-config-insecure-listen"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size"
+        },
+        {
+          "patternId": "Semgrep_python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.csrf-check-disabled.pyramid-csrf-check-disabled"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_python_pyramid_rule-pyramid-csrf-origin-check"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response"
+        },
+        {
+          "patternId": "Semgrep_python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection"
+        },
+        {
+          "patternId": "Semgrep_python_random_rule-random"
+        },
+        {
+          "patternId": "Semgrep_python_requests_rule-request-without-timeout"
+        },
+        {
+          "patternId": "Semgrep_python.requests.security.disabled-cert-validation.disabled-cert-validation"
+        },
+        {
+          "patternId": "Semgrep_python.requests.security.no-auth-over-http.no-auth-over-http"
+        },
+        {
+          "patternId": "Semgrep_python.sh.security.string-concat.string-concat"
+        },
+        {
+          "patternId": "Semgrep_python_snmp_rule-insecure-snmp-version"
+        },
+        {
+          "patternId": "Semgrep_python_snmp_rule-snmp-weak-cryptography"
+        },
+        {
+          "patternId": "Semgrep_python_sql_rule-hardcoded-sql-expression"
+        },
+        {
+          "patternId": "Semgrep_python_ssh_rule-ssh-nohost-key-verification"
+        },
+        {
+          "patternId": "Semgrep_python_ssl_rule-req-no-certvalid"
+        },
+        {
+          "patternId": "Semgrep_python_ssl_rule-ssl-no-version"
+        },
+        {
+          "patternId": "Semgrep_python_ssl_rule-ssl-with-bad-version"
+        },
+        {
+          "patternId": "Semgrep_python_ssl_rule-unverified-context"
+        },
+        {
+          "patternId": "Semgrep_python_telnet_rule-import-telnib"
+        },
+        {
+          "patternId": "Semgrep_python_tmpdir_rule-hardcodedtmp"
+        },
+        {
+          "patternId": "Semgrep_python_tmpdir_rule-mktemp-q"
+        },
+        {
+          "patternId": "Semgrep_python.twilio.security.twiml-injection.twiml-injection"
+        },
+        {
+          "patternId": "Semgrep_python_urlopen_rule-urllib-urlopen"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-celement"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-element"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-etree"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-expatbuilder"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-expatreader"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-minidom"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-pulldom"
+        },
+        {
+          "patternId": "Semgrep_python_xml_rule-sax"
+        },
+        {
+          "patternId": "Semgrep_yaml.argo.security.argo-workflow-parameter-command-injection.argo-workflow-parameter-command-injection"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.exposing-docker-socket-volume.exposing-docker-socket-volume"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.no-new-privileges.no-new-privileges"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.privileged-service.privileged-service"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.seccomp-confinement-disabled.seccomp-confinement-disabled"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.selinux-separation-disabled.selinux-separation-disabled"
+        },
+        {
+          "patternId": "Semgrep_yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.allowed-unsecure-commands.allowed-unsecure-commands"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.curl-eval.curl-eval"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.github-script-injection.github-script-injection"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.run-shell-injection.run-shell-injection"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha"
+        },
+        {
+          "patternId": "Semgrep_yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.allow-privilege-escalation.allow-privilege-escalation"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.allow-privilege-escalation-no-securitycontext.allow-privilege-escalation-no-securitycontext"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.allow-privilege-escalation-true.allow-privilege-escalation-true"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.env.flask-debugging-enabled.flask-debugging-enabled"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.exposing-docker-socket-hostpath.exposing-docker-socket-hostpath"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.hostipc-pod.hostipc-pod"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.hostnetwork-pod.hostnetwork-pod"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.hostpid-pod.hostpid-pod"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.legacy-api-clusterrole-excessive-permissions.legacy-api-clusterrole-excessive-permissions"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.privileged-container.privileged-container"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.run-as-non-root-container-level-missing-security-context.run-as-non-root-container-level-missing-security-context"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.run-as-non-root-container-level.run-as-non-root-container-level"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.run-as-non-root.run-as-non-root"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.run-as-non-root-security-context-pod-level.run-as-non-root-security-context-pod-level"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.run-as-non-root-unsafe-value.run-as-non-root-unsafe-value"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.seccomp-confinement-disabled.seccomp-confinement-disabled"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.secrets-in-config-file.secrets-in-config-file"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.skip-tls-verify-cluster.skip-tls-verify-cluster"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.skip-tls-verify-service.skip-tls-verify-service"
+        },
+        {
+          "patternId": "Semgrep_yaml.kubernetes.security.writable-filesystem-container.writable-filesystem-container"
+        },
+        {
+          "patternId": "Semgrep_yaml.openapi.security.api-key-in-query-parameter.api-key-in-query-parameter"
+        },
+        {
+          "patternId": "Semgrep_yaml.openapi.security.openai-consequential-action-false.openai-consequential-action-false"
+        },
+        {
+          "patternId": "Semgrep_yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication"
+        },
+        {
+          "patternId": "Semgrep_yaml_spring_rule-SpringActuatorFullyEnabled"
+        }
+      ]
+    },
+    {
+      "toolId": "Bandit",
+      "localConfigurationFile": "/Users/tdh/projects/ProvPy/prov/pyproject.toml",
+      "useLocalConfigurationFile": true,
+      "patterns": [],
+      "exclude": [
+        "src/prov/tests/**"
+      ]
+    },
+    {
+      "toolId": "PyLintPython3",
+      "useLocalConfigurationFile": false,
+      "patterns": [
+        {
+          "patternId": "PyLintPython3_E0203"
+        },
+        {
+          "patternId": "PyLintPython3_E0102"
+        },
+        {
+          "patternId": "PyLintPython3_E1102"
+        },
+        {
+          "patternId": "PyLintPython3_E1121"
+        },
+        {
+          "patternId": "PyLintPython3_W1301"
+        },
+        {
+          "patternId": "PyLintPython3_C0200"
+        },
+        {
+          "patternId": "PyLintPython3_E0241"
+        },
+        {
+          "patternId": "PyLintPython3_C0123"
+        },
+        {
+          "patternId": "PyLintPython3_W0101"
+        },
+        {
+          "patternId": "PyLintPython3_W0604"
+        },
+        {
+          "patternId": "PyLintPython3_E0107"
+        },
+        {
+          "patternId": "PyLintPython3_E0202"
+        },
+        {
+          "patternId": "PyLintPython3_E1003"
+        },
+        {
+          "patternId": "PyLintPython3_E0302"
+        },
+        {
+          "patternId": "PyLintPython3_E1306"
+        },
+        {
+          "patternId": "PyLintPython3_E0113"
+        },
+        {
+          "patternId": "PyLintPython3_E0301"
+        },
+        {
+          "patternId": "PyLintPython3_W0711"
+        },
+        {
+          "patternId": "PyLintPython3_E0108"
+        },
+        {
+          "patternId": "PyLintPython3_E0604"
+        },
+        {
+          "patternId": "PyLintPython3_W0102"
+        },
+        {
+          "patternId": "PyLintPython3_E0603"
+        },
+        {
+          "patternId": "PyLintPython3_W0150"
+        },
+        {
+          "patternId": "PyLintPython3_E0240"
+        },
+        {
+          "patternId": "PyLintPython3_E0101"
+        },
+        {
+          "patternId": "PyLintPython3_E0110"
+        },
+        {
+          "patternId": "PyLintPython3_E0112"
+        },
+        {
+          "patternId": "PyLintPython3_E0117"
+        },
+        {
+          "patternId": "PyLintPython3_E0211"
+        },
+        {
+          "patternId": "PyLintPython3_R0203"
+        },
+        {
+          "patternId": "PyLintPython3_E1303"
+        },
+        {
+          "patternId": "PyLintPython3_E0106"
+        },
+        {
+          "patternId": "PyLintPython3_E1300"
+        },
+        {
+          "patternId": "PyLintPython3_W1305"
+        },
+        {
+          "patternId": "PyLintPython3_E0105"
+        },
+        {
+          "patternId": "PyLintPython3_E1200"
+        },
+        {
+          "patternId": "PyLintPython3_W0107"
+        },
+        {
+          "patternId": "PyLintPython3_W0109"
+        },
+        {
+          "patternId": "PyLintPython3_W1306"
+        },
+        {
+          "patternId": "PyLintPython3_E0236"
+        },
+        {
+          "patternId": "PyLintPython3_E0712"
+        },
+        {
+          "patternId": "PyLintPython3_E0710"
+        },
+        {
+          "patternId": "PyLintPython3_E1301"
+        },
+        {
+          "patternId": "PyLintPython3_W0105"
+        },
+        {
+          "patternId": "PyLintPython3_E0104"
+        },
+        {
+          "patternId": "PyLintPython3_E0702"
+        },
+        {
+          "patternId": "PyLintPython3_E1132"
+        },
+        {
+          "patternId": "PyLintPython3_W0221"
+        },
+        {
+          "patternId": "PyLintPython3_E0701"
+        },
+        {
+          "patternId": "PyLintPython3_E1206"
+        },
+        {
+          "patternId": "PyLintPython3_W0104"
+        },
+        {
+          "patternId": "PyLintPython3_E0238"
+        },
+        {
+          "patternId": "PyLintPython3_E1126"
+        },
+        {
+          "patternId": "PyLintPython3_E0114"
+        },
+        {
+          "patternId": "PyLintPython3_W0702"
+        },
+        {
+          "patternId": "PyLintPython3_E0100"
+        },
+        {
+          "patternId": "PyLintPython3_W0106"
+        },
+        {
+          "patternId": "PyLintPython3_E0601"
+        },
+        {
+          "patternId": "PyLintPython3_W1307"
+        },
+        {
+          "patternId": "PyLintPython3_E1302"
+        },
+        {
+          "patternId": "PyLintPython3_C0303"
+        },
+        {
+          "patternId": "PyLintPython3_W0120"
+        },
+        {
+          "patternId": "PyLintPython3_W0612"
+        },
+        {
+          "patternId": "PyLintPython3_E1125"
+        },
+        {
+          "patternId": "PyLintPython3_W0622"
+        },
+        {
+          "patternId": "PyLintPython3_E1111"
+        },
+        {
+          "patternId": "PyLintPython3_E1305"
+        },
+        {
+          "patternId": "PyLintPython3_R0202"
+        },
+        {
+          "patternId": "PyLintPython3_E0103"
+        },
+        {
+          "patternId": "PyLintPython3_W0124"
+        },
+        {
+          "patternId": "PyLintPython3_W0404"
+        },
+        {
+          "patternId": "PyLintPython3_W0410"
+        },
+        {
+          "patternId": "PyLintPython3_E0115"
+        },
+        {
+          "patternId": "PyLintPython3_W0611"
+        },
+        {
+          "patternId": "PyLintPython3_E1304"
+        },
+        {
+          "patternId": "PyLintPython3_E1123"
+        },
+        {
+          "patternId": "PyLintPython3_W0108"
+        },
+        {
+          "patternId": "PyLintPython3_W0233"
+        },
+        {
+          "patternId": "PyLintPython3_W1303"
+        },
+        {
+          "patternId": "PyLintPython3_W0199"
+        },
+        {
+          "patternId": "PyLintPython3_W0705"
+        },
+        {
+          "patternId": "PyLintPython3_E1124"
+        },
+        {
+          "patternId": "PyLintPython3_E0704"
+        },
+        {
+          "patternId": "PyLintPython3_W0601"
+        },
+        {
+          "patternId": "PyLintPython3_E0239"
+        },
+        {
+          "patternId": "PyLintPython3_E1120"
+        },
+        {
+          "patternId": "PyLintPython3_W1302"
+        },
+        {
+          "patternId": "PyLintPython3_W0222"
+        },
+        {
+          "patternId": "PyLintPython3_E0711"
+        },
+        {
+          "patternId": "PyLintPython3_W1300"
+        },
+        {
+          "patternId": "PyLintPython3_E1205"
+        },
+        {
+          "patternId": "PyLintPython3_E1201"
+        },
+        {
+          "patternId": "PyLintPython3_W0602"
+        },
+        {
+          "patternId": "PyLintPython3_W0122"
+        },
+        {
+          "patternId": "PyLintPython3_E1127"
+        }
+      ]
+    },
+    {
+      "toolId": "Checkov",
+      "patterns": [
+        {
+          "patternId": "Checkov_CKV2_ADO_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_ANSIBLE_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_10"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_11"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_12"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_14"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_15"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_16"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_18"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_19"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_20"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_21"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_22"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_23"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_27"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_28"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_29"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_30"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_31"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_32"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_33"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_34"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_35"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_36"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_37"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_38"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_39"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_40"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_41"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_42"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_43"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_44"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_45"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_46"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_47"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_48"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_49"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_50"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_51"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_52"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_53"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_54"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_55"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_56"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_57"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_58"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_59"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_60"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_61"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_62"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_63"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_64"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_65"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_66"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_68"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_69"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_7"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_70"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_71"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_72"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_73"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_74"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_75"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_76"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_77"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_78"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_8"
+        },
+        {
+          "patternId": "Checkov_CKV2_AWS_9"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_10"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_11"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_12"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_13"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_14"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_15"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_16"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_17"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_19"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_20"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_21"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_22"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_23"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_24"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_25"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_26"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_27"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_28"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_29"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_30"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_31"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_32"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_33"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_34"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_35"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_36"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_37"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_38"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_39"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_40"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_41"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_42"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_43"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_44"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_45"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_46"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_47"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_48"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_49"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_50"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_51"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_52"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_53"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_54"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_55"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_56"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_57"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_7"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_8"
+        },
+        {
+          "patternId": "Checkov_CKV2_AZURE_9"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_10"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_11"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_12"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_13"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_14"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_15"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_16"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_17"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_7"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_8"
+        },
+        {
+          "patternId": "Checkov_CKV2_DOCKER_9"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_10"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_11"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_12"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_13"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_14"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_15"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_16"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_17"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_18"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_19"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_20"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_21"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_22"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_23"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_24"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_25"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_26"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_27"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_28"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_29"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_30"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_31"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_32"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_33"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_34"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_35"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_36"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_37"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_38"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_7"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_8"
+        },
+        {
+          "patternId": "Checkov_CKV2_GCP_9"
+        },
+        {
+          "patternId": "Checkov_CKV2_GHA_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_GIT_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_IBM_7"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_K8S_6"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_1"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_2"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_3"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_4"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_5"
+        },
+        {
+          "patternId": "Checkov_CKV2_OCI_6"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_1"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_10"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_11"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_12"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_13"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_14"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_15"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_16"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_17"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_18"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_19"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_2"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_20"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_21"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_22"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_23"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_24"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_25"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_26"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_27"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_28"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_29"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_3"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_30"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_31"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_32"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_33"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_35"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_36"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_37"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_38"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_4"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_41"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_42"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_43"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_44"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_5"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_6"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_7"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_8"
+        },
+        {
+          "patternId": "Checkov_CKV_ALI_9"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_1"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_2"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_3"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_4"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_5"
+        },
+        {
+          "patternId": "Checkov_CKV_ANSIBLE_6"
+        },
+        {
+          "patternId": "Checkov_CKV_ARGO_1"
+        },
+        {
+          "patternId": "Checkov_CKV_ARGO_2"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_1"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_10"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_100"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_101"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_102"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_103"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_104"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_105"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_106"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_107"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_108"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_109"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_11"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_110"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_111"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_112"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_113"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_114"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_115"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_116"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_117"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_118"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_119"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_12"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_120"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_121"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_122"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_123"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_124"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_126"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_127"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_129"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_13"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_130"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_131"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_133"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_134"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_135"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_136"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_137"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_138"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_139"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_14"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_140"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_141"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_142"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_143"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_144"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_145"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_146"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_147"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_148"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_149"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_15"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_150"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_152"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_153"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_154"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_155"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_156"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_157"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_158"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_159"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_16"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_160"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_161"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_162"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_163"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_164"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_165"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_166"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_167"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_168"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_169"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_17"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_170"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_171"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_172"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_173"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_174"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_175"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_176"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_177"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_178"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_179"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_18"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_180"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_181"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_182"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_183"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_184"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_185"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_186"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_187"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_189"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_19"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_190"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_191"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_192"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_193"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_194"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_195"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_196"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_197"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_198"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_199"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_2"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_20"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_200"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_201"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_202"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_203"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_204"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_205"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_206"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_207"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_208"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_209"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_21"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_210"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_211"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_212"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_213"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_214"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_215"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_216"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_217"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_218"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_219"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_22"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_220"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_221"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_222"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_223"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_224"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_225"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_226"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_227"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_228"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_229"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_23"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_230"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_231"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_232"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_233"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_234"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_235"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_236"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_237"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_238"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_239"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_24"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_240"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_241"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_242"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_243"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_244"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_245"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_246"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_247"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_248"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_249"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_25"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_250"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_251"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_252"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_253"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_254"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_255"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_256"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_257"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_258"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_259"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_26"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_260"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_261"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_262"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_263"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_264"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_265"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_266"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_267"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_268"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_269"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_27"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_270"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_271"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_272"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_273"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_274"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_275"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_276"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_277"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_278"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_279"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_28"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_280"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_281"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_282"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_283"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_284"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_285"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_286"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_287"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_288"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_289"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_29"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_290"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_291"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_292"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_293"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_294"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_295"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_296"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_297"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_298"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_3"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_30"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_300"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_301"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_302"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_303"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_304"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_305"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_306"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_307"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_308"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_309"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_31"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_310"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_311"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_312"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_313"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_314"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_315"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_316"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_317"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_318"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_319"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_32"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_320"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_321"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_322"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_323"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_324"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_325"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_326"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_327"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_328"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_329"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_33"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_330"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_331"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_332"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_333"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_334"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_335"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_336"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_337"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_338"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_339"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_34"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_340"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_341"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_342"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_343"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_344"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_345"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_346"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_347"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_348"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_349"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_35"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_350"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_351"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_352"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_353"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_354"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_355"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_356"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_357"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_358"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_359"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_36"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_360"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_361"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_362"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_363"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_364"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_365"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_366"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_367"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_368"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_369"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_37"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_370"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_371"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_372"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_373"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_374"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_375"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_376"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_377"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_378"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_379"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_38"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_380"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_381"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_382"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_383"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_384"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_385"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_386"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_387"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_388"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_389"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_39"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_390"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_391"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_392"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_40"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_41"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_42"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_43"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_44"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_45"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_46"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_47"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_48"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_49"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_5"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_50"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_51"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_53"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_54"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_55"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_56"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_57"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_58"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_59"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_6"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_60"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_61"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_62"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_63"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_64"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_65"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_66"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_67"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_68"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_69"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_7"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_70"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_71"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_72"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_73"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_74"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_75"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_76"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_77"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_78"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_79"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_8"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_80"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_81"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_82"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_83"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_84"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_85"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_86"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_87"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_88"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_89"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_9"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_90"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_91"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_92"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_93"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_94"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_95"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_96"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_97"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_98"
+        },
+        {
+          "patternId": "Checkov_CKV_AWS_99"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_1"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_10"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_100"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_101"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_102"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_103"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_104"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_105"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_106"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_107"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_108"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_109"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_11"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_110"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_111"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_112"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_113"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_114"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_115"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_116"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_117"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_118"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_119"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_12"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_120"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_121"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_122"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_123"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_124"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_125"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_126"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_127"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_128"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_129"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_13"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_130"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_131"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_132"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_133"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_134"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_135"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_136"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_137"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_138"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_139"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_14"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_140"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_141"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_142"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_143"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_144"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_145"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_146"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_147"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_148"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_149"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_15"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_150"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_151"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_152"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_153"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_154"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_155"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_156"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_157"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_158"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_159"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_16"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_160"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_161"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_162"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_163"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_164"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_165"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_166"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_167"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_168"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_169"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_17"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_170"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_171"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_172"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_173"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_174"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_175"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_176"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_177"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_178"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_179"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_18"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_180"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_181"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_182"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_183"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_184"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_185"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_186"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_187"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_188"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_189"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_19"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_190"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_191"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_192"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_193"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_194"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_195"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_196"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_197"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_198"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_199"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_2"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_20"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_200"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_201"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_202"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_203"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_204"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_205"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_206"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_207"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_208"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_209"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_21"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_210"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_211"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_212"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_213"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_214"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_215"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_216"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_217"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_218"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_219"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_22"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_220"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_221"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_222"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_223"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_224"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_225"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_226"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_227"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_228"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_229"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_23"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_230"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_231"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_232"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_233"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_234"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_235"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_236"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_237"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_238"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_239"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_24"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_240"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_241"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_242"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_243"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_244"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_245"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_246"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_247"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_248"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_249"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_25"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_250"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_251"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_26"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_27"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_28"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_29"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_3"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_30"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_31"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_32"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_33"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_34"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_35"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_36"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_37"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_38"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_39"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_4"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_40"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_41"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_42"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_43"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_44"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_45"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_47"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_48"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_49"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_5"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_50"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_52"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_53"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_54"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_55"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_56"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_57"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_58"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_59"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_6"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_61"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_62"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_63"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_64"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_65"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_66"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_67"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_68"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_69"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_7"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_70"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_71"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_72"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_73"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_74"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_75"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_76"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_77"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_78"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_79"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_8"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_80"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_81"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_82"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_83"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_84"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_85"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_86"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_87"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_88"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_89"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_9"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_91"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_92"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_93"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_94"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_95"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_96"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_97"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_98"
+        },
+        {
+          "patternId": "Checkov_CKV_AZURE_99"
+        },
+        {
+          "patternId": "Checkov_CKV_AZUREPIPELINES_1"
+        },
+        {
+          "patternId": "Checkov_CKV_AZUREPIPELINES_2"
+        },
+        {
+          "patternId": "Checkov_CKV_AZUREPIPELINES_3"
+        },
+        {
+          "patternId": "Checkov_CKV_AZUREPIPELINES_5"
+        },
+        {
+          "patternId": "Checkov_CKV_BCW_1"
+        },
+        {
+          "patternId": "Checkov_CKV_BITBUCKET_1"
+        },
+        {
+          "patternId": "Checkov_CKV_BITBUCKETPIPELINES_1"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_1"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_2"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_3"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_4"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_5"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_6"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_7"
+        },
+        {
+          "patternId": "Checkov_CKV_CIRCLECIPIPELINES_8"
+        },
+        {
+          "patternId": "Checkov_CKV_DIO_1"
+        },
+        {
+          "patternId": "Checkov_CKV_DIO_2"
+        },
+        {
+          "patternId": "Checkov_CKV_DIO_3"
+        },
+        {
+          "patternId": "Checkov_CKV_DIO_4"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_1"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_10"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_11"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_2"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_3"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_4"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_5"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_6"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_7"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_8"
+        },
+        {
+          "patternId": "Checkov_CKV_DOCKER_9"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_10"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_100"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_101"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_102"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_103"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_104"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_105"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_106"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_107"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_108"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_109"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_11"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_110"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_111"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_112"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_113"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_114"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_115"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_116"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_117"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_118"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_119"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_12"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_120"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_121"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_122"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_123"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_124"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_125"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_126"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_127"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_13"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_14"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_15"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_16"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_17"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_18"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_20"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_21"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_22"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_23"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_24"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_25"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_26"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_27"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_28"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_29"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_30"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_31"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_32"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_33"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_34"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_35"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_36"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_37"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_38"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_39"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_4"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_40"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_41"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_42"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_43"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_44"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_45"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_46"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_47"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_48"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_49"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_50"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_51"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_52"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_53"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_54"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_55"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_56"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_57"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_58"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_59"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_6"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_60"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_61"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_62"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_63"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_64"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_65"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_66"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_68"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_69"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_7"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_70"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_71"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_72"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_73"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_74"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_75"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_76"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_77"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_78"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_79"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_8"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_80"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_81"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_82"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_83"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_84"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_85"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_86"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_87"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_88"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_89"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_9"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_90"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_91"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_92"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_93"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_94"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_95"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_96"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_97"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_98"
+        },
+        {
+          "patternId": "Checkov_CKV_GCP_99"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_4"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_5"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_6"
+        },
+        {
+          "patternId": "Checkov_CKV_GHA_7"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_4"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_5"
+        },
+        {
+          "patternId": "Checkov_CKV_GIT_6"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_10"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_11"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_12"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_13"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_14"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_15"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_16"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_17"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_18"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_19"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_20"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_21"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_22"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_23"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_26"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_27"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_28"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_4"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_5"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_6"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_7"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_8"
+        },
+        {
+          "patternId": "Checkov_CKV_GITHUB_9"
+        },
+        {
+          "patternId": "Checkov_CKV_GITLAB_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GITLABCI_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GITLABCI_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GITLABCI_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GLB_1"
+        },
+        {
+          "patternId": "Checkov_CKV_GLB_2"
+        },
+        {
+          "patternId": "Checkov_CKV_GLB_3"
+        },
+        {
+          "patternId": "Checkov_CKV_GLB_4"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_1"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_10"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_100"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_102"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_104"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_105"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_106"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_107"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_108"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_11"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_110"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_111"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_112"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_113"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_114"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_115"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_116"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_117"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_118"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_119"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_12"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_121"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_13"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_138"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_139"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_14"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_140"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_141"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_143"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_144"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_145"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_146"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_147"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_148"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_149"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_15"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_151"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_152"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_153"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_154"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_155"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_156"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_157"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_158"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_159"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_16"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_17"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_18"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_19"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_2"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_20"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_21"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_22"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_23"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_24"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_25"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_26"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_27"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_28"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_29"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_3"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_30"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_31"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_32"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_33"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_34"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_35"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_36"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_37"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_38"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_39"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_4"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_40"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_41"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_42"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_43"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_44"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_45"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_49"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_5"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_6"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_68"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_69"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_7"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_70"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_71"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_72"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_73"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_74"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_75"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_77"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_78"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_79"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_8"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_80"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_81"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_82"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_83"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_84"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_85"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_86"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_88"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_89"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_9"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_90"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_91"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_92"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_93"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_94"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_95"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_96"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_97"
+        },
+        {
+          "patternId": "Checkov_CKV_K8S_99"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_1"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_2"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_3"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_4"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_5"
+        },
+        {
+          "patternId": "Checkov_CKV_LIN_6"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_1"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_10"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_11"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_12"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_13"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_14"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_15"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_16"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_18"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_19"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_2"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_20"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_22"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_23"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_24"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_25"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_26"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_3"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_4"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_5"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_6"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_7"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_8"
+        },
+        {
+          "patternId": "Checkov_CKV_NCP_9"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_1"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_10"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_11"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_12"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_13"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_14"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_15"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_16"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_17"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_18"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_19"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_2"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_20"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_21"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_22"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_23"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_3"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_4"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_5"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_6"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_7"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_8"
+        },
+        {
+          "patternId": "Checkov_CKV_OCI_9"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_1"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_10"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_11"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_12"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_13"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_14"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_15"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_16"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_17"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_18"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_19"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_2"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_20"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_21"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_3"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_4"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_5"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_6"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_7"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_8"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENAPI_9"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENSTACK_1"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENSTACK_2"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENSTACK_3"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENSTACK_4"
+        },
+        {
+          "patternId": "Checkov_CKV_OPENSTACK_5"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_1"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_10"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_11"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_12"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_13"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_14"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_15"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_16"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_17"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_2"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_3"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_4"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_5"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_6"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_7"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_8"
+        },
+        {
+          "patternId": "Checkov_CKV_PAN_9"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_1"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_11"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_12"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_13"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_14"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_15"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_16"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_17"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_18"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_19"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_2"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_3"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_4"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_5"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_6"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_7"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_8"
+        },
+        {
+          "patternId": "Checkov_CKV_SECRET_9"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_1"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_10"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_11"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_12"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_13"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_14"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_2"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_3"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_4"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_5"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_6"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_7"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_8"
+        },
+        {
+          "patternId": "Checkov_CKV_TC_9"
+        },
+        {
+          "patternId": "Checkov_CKV_TF_1"
+        },
+        {
+          "patternId": "Checkov_CKV_TF_2"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_1"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_10"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_11"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_12"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_13"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_14"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_15"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_16"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_17"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_18"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_19"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_2"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_20"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_21"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_22"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_23"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_24"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_3"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_4"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_5"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_6"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_7"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_8"
+        },
+        {
+          "patternId": "Checkov_CKV_YC_9"
+        }
+      ]
+    },
+    {
+      "toolId": "Lizard",
+      "patterns": [
+        {
+          "patternId": "Lizard_ccn-medium",
+          "parameters": {
+            "threshold": "15"
+          }
+        },
+        {
+          "patternId": "Lizard_parameter-count-medium"
+        }
+      ]
+    },
+    {
+      "toolId": "PMD7",
+      "patterns": [
+        {
+          "patternId": "PMD7_category_xml_errorprone_MistypedCDATASection"
+        }
+      ]
+    },
+    {
+      "toolId": "Agentlinter",
+      "patterns": []
+    },
+    {
+      "toolId": "Prospector",
+      "patterns": [
+        {
+          "patternId": "Prospector_dodgy"
+        },
+        {
+          "patternId": "Prospector_profile-validator"
+        }
+      ]
+    }
+  ],
+  "exclude": [
+    "src/prov/tests/malformed/**"
+  ]
+}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-2.5.1 (unreleased)
+2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^
 * ``prov.read()`` polish following 2.5.0's #239: seekable streams are now
   rewound between auto-detection attempts (so e.g. a PROV-XML stream

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 __all__ = ["Error", "model", "read"]
 


### PR DESCRIPTION
Cuts the 2.5.1 patch release: version bump to 2.5.1 and the HISTORY 2.5.1 section (the `prov.read()` polish and howto refreshes merged post-2.5.0 in #269) dated 2026-07-13.

Also adds the Codacy configuration: `.codacy.yaml` (file exclusions Codacy Cloud reads from the default branch — malformed parser fixtures, the pytest suite for Bandit, internal docs/superpowers for markdownlint) and the matching tuned local-analysis config `.codacy/codacy.config.json`, which has already been imported to Codacy Cloud.