### PR TITLE
Address Codacy findings: workflow hardening, pylint/bandit fixes, doc lint

### DIFF
--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -78,9 +78,6 @@
           "patternId": "markdownlint_MD023"
         },
         {
-          "patternId": "markdownlint_MD024"
-        },
-        {
           "patternId": "markdownlint_MD025"
         },
         {

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,11 @@ on:
     branches: [main, master, dev]
   workflow_dispatch:
 
+# Least privilege: every job only checks out code and reads/uploads coverage
+# to the external Coveralls service, so none needs more than read access.
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
@@ -18,8 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
-      - uses: astral-sh/setup-uv@v8.2.0
+        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
@@ -40,7 +45,7 @@ jobs:
         if: matrix.python-version == '3.12'
         run: uv run coverage report
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e  # v2
         # Advisory upload: a Coveralls outage must not fail the build (rule added
         # after the 2026-07-03 outage blocked PR #174; hotfixed on master in PR #176 —
         # keep continue-on-error on all coverage-upload steps in the rewrite)
@@ -64,7 +69,7 @@ jobs:
             label: "latest 7.x"
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: "3.12"
       - run: |
@@ -77,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - run: |
           uv sync --locked --group dev
           uv run ruff check src/
@@ -92,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - name: Sync without extras
         run: uv sync --locked --group dev
       - name: Degradation tests
@@ -102,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - run: |
           uv sync --locked --extra rdf --extra xml --group dev
           uv run mypy src
@@ -111,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - run: |
           uv build
           uvx twine check dist/*
@@ -122,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e  # v2
         continue-on-error: true
         with:
           parallel-finished: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - run: |
           uv build
           uvx twine check dist/*
@@ -43,7 +43,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -59,4 +59,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/docs/test-gap-checklist.md
+++ b/docs/test-gap-checklist.md
@@ -4,7 +4,7 @@ Audit date: 2026-07-04, measured on `master` @ `10b24db` with
 `uv run coverage run -m pytest && uv run coverage report -m` (branch coverage on,
 954 passed / 17 xfailed).
 
-**Measured totals**
+## Measured totals
 
 | Scope | Coverage |
 |---|---|
@@ -58,7 +58,7 @@ Same subprocess-only situation as `convert.py`.
 - [x] `--version` prints the version message and exits — **T11**
 - [ ] `__main__`/`TESTRUN`/`PROFILE` scaffolding — **defer** (same reason as convert.py)
 
-## src/prov/__init__.py — 39% (missed: 38–56, i.e. the whole body of `read()`)
+## `src/prov/__init__.py` — 39% (missed: 38–56, i.e. the whole body of `read()`)
 
 `prov.read()` is a documented public entry point with zero coverage.
 
@@ -80,7 +80,7 @@ gaps: 8 of the 9 non-equivalent surviving mutants live here.
 - [x] `graph_to_prov()` ignores graph nodes that are not `ProvRecord`s or whose `bundle` is `None` (mutmut: `and` → `or` survived) — **T12**
 - [x] `graph_to_prov()` ignores edges without a `"relation"` key in their edge data — **T12**
 
-## src/prov/serializers/__init__.py — 91% (missed: 10, 39, 48)
+## `src/prov/serializers/__init__.py` — 91% (missed: 10, 39, 48)
 
 - [x] `serializers.get()` on an unknown format raises `DoNotExist` with the format name in the message, chained from `KeyError` — **T12** (the chaining itself is already tested by `test_extras.py::test_get_serializer_for_unknown_format_chains_key_error` from T9 — extended in place with the format-name-in-message assertion, one module owns it)
 - [x] `serializers.get()` lazily populates `Registry.serializers` on first call (registry starts as `None`, holds exactly the four formats json/rdf/provn/xml) — **T12**

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -19,8 +19,6 @@ __all__ = ["Error", "model", "read"]
 class Error(Exception):
     """Base class for all errors in this package."""
 
-    pass
-
 
 def read(
     source: io.IOBase | IO[Any] | str | bytes | os.PathLike[str],
@@ -66,7 +64,8 @@ def read(
     from prov.serializers import Registry
 
     Registry.load_serializers()
-    assert Registry.serializers is not None  # populated by load_serializers()
+    if Registry.serializers is None:  # pragma: no cover -- populated above
+        raise AssertionError("Registry.serializers is not populated")
     serializers = Registry.serializers.keys()
 
     src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None = source
@@ -125,7 +124,9 @@ def read(
     try:
         for format in serializers:
             if start_pos is not None:
-                assert stream is not None
+                # start_pos is only ever set (above) when stream is not None.
+                if stream is None:  # pragma: no cover
+                    raise AssertionError("stream is None but start_pos is set")
                 try:
                     stream.seek(start_pos)
                 except Exception:

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -1293,10 +1293,12 @@ class ProvBundle:
         from prov import dot
 
         if filename:
-            format = str(os.path.splitext(filename)[-1]).lower().strip(os.path.extsep)
+            img_format = (
+                str(os.path.splitext(filename)[-1]).lower().strip(os.path.extsep)
+            )
         else:
-            format = "png"
-        format = format.lower()
+            img_format = "png"
+        img_format = img_format.lower()
         d = dot.prov_to_dot(
             self,
             show_nary=show_nary,
@@ -1304,9 +1306,9 @@ class ProvBundle:
             show_element_attributes=show_element_attributes,
             show_relation_attributes=show_relation_attributes,
         )
-        method = f"create_{format}"
+        method = f"create_{img_format}"
         if not hasattr(d, method):
-            raise ValueError(f"Format '{format}' cannot be saved.")
+            raise ValueError(f"Format '{img_format}' cannot be saved.")
         with io.BytesIO() as buf:
             buf.write(getattr(d, method)())
 
@@ -1499,7 +1501,10 @@ class ProvDocument(ProvBundle):
             if other.has_bundles():
                 for bundle in other.bundles:
                     bundle_id = bundle.identifier
-                    assert bundle_id is not None
+                    if (
+                        bundle_id is None
+                    ):  # pragma: no cover -- bundles are always named
+                        raise AssertionError("bundle has no identifier")
                     if bundle.identifier in self._bundles:
                         self._bundles[bundle.identifier].update(bundle)
                     else:

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -327,13 +327,9 @@ class Literal:
 class ProvException(Error):
     """Base class for PROV model exceptions."""
 
-    pass
-
 
 class ProvWarning(Warning):
     """Base class for PROV model warnings."""
-
-    pass
 
 
 class ProvExceptionInvalidQualifiedName(ProvException):

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -57,7 +57,6 @@ class Serializer(ABC):
             **args: Format-specific serialization options, passed through by
                 subclasses.
         """
-        pass  # pragma: no cover -- abstract body, never executed directly
 
     @abstractmethod
     def deserialize(self, stream: io.IOBase, **args: Any) -> ProvDocument:
@@ -74,13 +73,10 @@ class Serializer(ABC):
         Returns:
             The deserialized :class:`~prov.model.ProvDocument`.
         """
-        pass  # pragma: no cover -- abstract body, never executed directly
 
 
 class DoNotExist(Error):
     """Exception for the case a serializer is not available."""
-
-    pass
 
 
 class Registry:
@@ -153,7 +149,9 @@ def get(format_name: str) -> type[Serializer]:
     if Registry.serializers is None:
         Registry.load_serializers()
     serializers = Registry.serializers
-    assert serializers is not None  # load_serializers() always populates it
+    # load_serializers() (just above) always populates Registry.serializers.
+    if serializers is None:  # pragma: no cover
+        raise AssertionError("Registry.serializers is not populated")
     try:
         return serializers[format_name]
     except KeyError as e:

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -35,8 +35,6 @@ ProvJSONDict = dict[str, dict[str, Any]]
 class ProvJSONException(Error):
     """Raised when a PROV-JSON document contains a construct this package cannot decode."""
 
-    pass
-
 
 class AnonymousIDGenerator:
     """Assigns and caches stable blank-node identifiers for unidentified records."""

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -57,8 +57,6 @@ __email__ = "satra@mit.edu"
 class ProvRDFException(Error):
     """Raised when a PROV-RDF/PROV-O graph cannot be decoded by this package."""
 
-    pass
-
 
 class AnonymousIDGenerator:
     """Assigns and caches stable blank-node identifier strings for unidentified records."""

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -25,23 +25,21 @@ logger = logging.getLogger(__name__)
 # mapping.
 FULL_NAMES_MAP = dict(PROV_N_MAP)
 FULL_NAMES_MAP.update(ADDITIONAL_N_MAP)
-"""Maps every PROV record/subtype QualifiedName (including PROV-XML's
-top-level subtypes from :data:`~prov.constants.ADDITIONAL_N_MAP`) to its
-PROV-XML element name."""
+# Maps every PROV record/subtype QualifiedName (including PROV-XML's
+# top-level subtypes from ADDITIONAL_N_MAP in prov.constants) to its
+# PROV-XML element name.
 # Inverse mapping.
 FULL_PROV_RECORD_IDS_MAP = {
     FULL_NAMES_MAP[rec_type_id]: rec_type_id for rec_type_id in FULL_NAMES_MAP
 }
-"""Inverse of :data:`FULL_NAMES_MAP`: maps each PROV-XML element name back to
-its record/subtype QualifiedName."""
+# Inverse of FULL_NAMES_MAP: maps each PROV-XML element name back to its
+# record/subtype QualifiedName.
 
 XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 
 
 class ProvXMLException(prov.Error):
     """Raised when a PROV-XML document cannot be serialized or parsed by this package."""
-
-    pass
 
 
 class ProvXMLSerializer(Serializer):
@@ -335,8 +333,12 @@ class ProvXMLSerializer(Serializer):
 
             # Recursively read bundles.
             if qname.localname == "bundleContent":
-                assert isinstance(bundle, prov.model.ProvDocument)
-                assert prov_rec_id is not None
+                if not isinstance(bundle, prov.model.ProvDocument):
+                    # Only a document may directly contain named bundles;
+                    # nested bundleContent would mean a bundle-within-a-bundle.
+                    raise AssertionError("bundleContent found outside a ProvDocument")
+                if prov_rec_id is None:
+                    raise AssertionError("bundleContent element has no id")
                 b = bundle.bundle(identifier=prov_rec_id)
                 self.deserialize_subtree(element, b)
                 continue

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -47,7 +47,7 @@ def test_loading_all_json():
                     assert g1 == g2, (
                         f"Round-trip JSON encoding/decoding failed:  {filename}."
                     )
-                except:  # noqa: E722 -- intentionally broad to catch any failure
+                except Exception:  # intentionally broad to catch any failure
                     fails.append(filename)
 
     # Code for debugging the failed tests: reload the failed files so a real

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -39,14 +39,14 @@ def find_diff(g_rdf, g0_rdf):
     if len(g1) != len(g2):
         graphs_equal = False
     matching_indices = [[], []]
-    for idx in range(len(g1)):
-        g1_stmt = next(iter(rl.ConjunctiveGraph().parse(BytesIO(g1[idx]), format="nt")))
+    for idx, g1_line in enumerate(g1):
+        g1_stmt = next(iter(rl.ConjunctiveGraph().parse(BytesIO(g1_line), format="nt")))
         match_found = False
-        for idx2 in range(len(g2)):
+        for idx2, g2_line in enumerate(g2):
             if idx2 in matching_indices[1]:
                 continue
             g2_stmt = next(
-                iter(rl.ConjunctiveGraph().parse(BytesIO(g2[idx2]), format="nt"))
+                iter(rl.ConjunctiveGraph().parse(BytesIO(g2_line), format="nt"))
             )
             try:
                 all_match = all(g1_stmt[i].eq(g2_stmt[i]) for i in range(3))
@@ -66,9 +66,9 @@ def find_diff(g_rdf, g0_rdf):
         else:
             in_first2.parse(BytesIO(g1[idx]), format="nt")
     in_second2 = rl.ConjunctiveGraph()
-    for idx in range(len(g2)):
+    for idx, g2_line in enumerate(g2):
         if idx not in matching_indices[1]:
-            in_second2.parse(BytesIO(g2[idx]), format="nt")
+            in_second2.parse(BytesIO(g2_line), format="nt")
     return graphs_equal, in_both, in_first2, in_second2
 
 


### PR DESCRIPTION
Fixes the straightforward findings from the tuned Codacy configuration (66 issues on master after #270):

**Workflow security (Semgrep third-party-action-not-pinned-to-commit-sha, Checkov CKV2_GHA_1)**
- All third-party actions pinned to full-length commit SHAs, original refs kept as comments (ts-graphviz/setup-graphviz, astral-sh/setup-uv, coverallsapp/github-action, pypa/gh-action-pypi-publish)
- CI.yml gains a least-privilege top-level `permissions: contents: read` (matching release.yml)

**Python (pylint curated set + bandit)**
- W0107: redundant `pass` removed from docstring-only exception classes/abstract methods (incl. two byte-identical siblings not flagged by Codacy)
- B101: the 6 production-code `assert`s converted to explicit `raise AssertionError` so the invariant checks survive `python -O`; same exception type, identical behaviour otherwise (coverage unaffected — the project's `exclude_lines` already covers `raise AssertionError`)
- W0105: provxml module-level attribute-docstrings (not consumed by autodoc) converted to comments
- W0622: `plot()`'s local `format` variable renamed (`img_format`); the public `format=` keyword arguments are untouched
- C0200/W0702: test-only cleanups (enumerate; `except Exception` instead of bare except)

**Docs / config**
- test-gap-checklist.md: two headings had unbackticked `__init__.py` rendering as bold "init" (MD050) — now code spans; bold pseudo-heading promoted to a real heading (MD036)
- markdownlint MD024 dropped from the Codacy config: the flagged duplicate headings are the intentional per-command Synopsis/Options/Examples structure and Codacy exposes no `siblings_only` parameter

Verification: 1160 passed / 22 skipped / 14 xfailed; ruff check + format, mypy --strict, coverage 98% (no regression).

The remaining findings are intentional (to be ignored on Codacy with reasons: B112 auto-detect loop, lxml-by-design, constant-dict defaults, public `format=` kwargs, UP038 version-skew) or deferred refactors (Lizard complexity — 3.0 candidates, led by provrdf encode/decode_container CCN 81/66).