### PR TITLE
Move pydot/networkx behind dot/graph extras; open 3.0.0.dev0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
           # add a small, predictable amount of time to the CI matrix.
           HYPOTHESIS_PROFILE: ci
         run: |
-          uv sync --locked --extra rdf --extra xml --group dev
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
           uv run coverage run -m pytest
           uv run coverage xml
       - name: Enforce coverage ratchet
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          uv sync --locked --extra rdf --extra xml --group dev
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
           uv pip install "rdflib${{ matrix.rdflib-version }}"
           uv run --no-sync python -c "import rdflib; print('rdflib', rdflib.__version__)"
           uv run --no-sync pytest src/prov/tests/test_rdf.py
@@ -89,10 +89,12 @@ jobs:
           uv run ruff format --check src/
 
   minimal-install:
-    # Proves the registry degrades cleanly without the optional rdf/xml
-    # extras: `uv sync --group dev` (no --extra rdf/xml) leaves rdflib and
-    # lxml absent, so this exercises the same environment shape a user gets
-    # from a plain `pip install prov`.
+    # Proves the registry degrades cleanly without the optional rdf/xml/dot/
+    # graph extras: `uv sync --group dev` (no --extra flags) leaves rdflib,
+    # lxml, pydot, and networkx all absent, so this exercises the same
+    # environment shape a user gets from a plain `pip install prov`. Since
+    # 3.0.0.dev0 this also proves `import prov.dot`/`import prov.graph` fail
+    # informatively without their extras (test_minimal_install.py).
     name: minimal install (no extras)
     runs-on: ubuntu-latest
     steps:
@@ -109,7 +111,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       - run: |
-          uv sync --locked --extra rdf --extra xml --group dev
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
           uv run mypy src
 
   package:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
       - asdf global uv latest
       - uv venv "$READTHEDOCS_VIRTUALENV_PATH"
     install:
-      - UV_PROJECT_ENVIRONMENT="$READTHEDOCS_VIRTUALENV_PATH" uv sync --frozen --no-dev --group docs --extra rdf --extra xml
+      - UV_PROJECT_ENVIRONMENT="$READTHEDOCS_VIRTUALENV_PATH" uv sync --frozen --no-dev --group docs --extra rdf --extra xml --extra dot --extra graph
 
 sphinx:
   configuration: docs/conf.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,18 +23,19 @@ Plan: `docs/superpowers/specs/2026-07-03-modernisation-roadmap-design.md`; publi
 
 ## Setup
 
-Uses `uv`. RDF/XML support are optional extras — without them many tests fail with
-`ModuleNotFoundError`:
+Uses `uv`. RDF/XML support and graphical/graph interop (`dot`, `graph`) are optional
+extras — without them many tests fail with `ModuleNotFoundError`:
 
 ```bash
-uv sync --extra rdf --extra xml
+uv sync --extra rdf --extra xml --extra dot --extra graph
 ```
 
-Sphinx docs need the `docs` group plus both extras (autodoc imports the serializers):
+Sphinx docs need the `docs` group plus all four extras (autodoc imports the serializers
+and `prov.dot`/`prov.graph`):
 
 ```bash
-uv sync --group docs --extra rdf --extra xml
-uv run --group docs --extra rdf --extra xml sphinx-build -b html docs docs/_build/html
+uv sync --group docs --extra rdf --extra xml --extra dot --extra graph
+uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html
 ```
 
 `docs/dependencies.md` explains every dependency pin (including why Sphinx is capped `<9`).
@@ -51,7 +52,7 @@ uv run coverage run -m pytest && uv run coverage report -m
 
 # All supported interpreters (matches CI matrix)
 for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do
-    uv run --python $py --extra rdf --extra xml pytest || break
+    uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest || break
 done
 ```
 
@@ -94,6 +95,8 @@ RDF/XML serializers need the `rdflib`/`lxml` extras.
 
 `src/prov/graph.py`: `prov_to_graph()`/`graph_to_prov()` ↔ NetworkX `MultiDiGraph`.
 `src/prov/dot.py`: `prov_to_dot()` → pydot for PDF/PNG/SVG (needs a local `graphviz` binary).
+Since 3.0.0.dev0 both modules sit behind extras (`graph`, `dot`) — importing either
+without its extra raises `ModuleNotFoundError` naming the extra to install.
 
 ### Tests (`src/prov/tests/`)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,10 +65,10 @@ Ready to contribute? Here's how to set up `prov` for local development.
 3. Set up the development environment with `uv <https://docs.astral.sh/uv/>`_, which creates and manages the project virtualenv for you::
 
     $ cd prov/
-    $ uv sync --extra rdf --extra xml
+    $ uv sync --extra rdf --extra xml --extra dot --extra graph
 
-   The ``rdf`` and ``xml`` extras are required for the full test suite to pass. See
-   ``docs/dependencies.md`` for what each dependency is for.
+   The ``rdf``, ``xml``, ``dot``, and ``graph`` extras are required for the full test
+   suite to pass. See ``docs/dependencies.md`` for what each dependency is for.
 
 4. Set up pre-commit hooks to ensure code quality checks run automatically::
 
@@ -86,7 +86,7 @@ Ready to contribute? Here's how to set up `prov` for local development.
 
 6. When you're done making changes, check that your changes pass the tests, including testing other supported Python versions via uv::
 
-    $ for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do uv run --python $py --extra rdf --extra xml pytest || break; done
+    $ for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest || break; done
 
    The first run downloads any interpreter you don't already have cached, so
    expect some network traffic.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 History
 -------
 
+3.0.0 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* BREAKING: ``pydot`` and ``networkx`` are no longer unconditional runtime
+  dependencies. ``import prov.dot`` now requires the ``dot`` extra
+  (``pip install "prov[dot]"``) and ``import prov.graph`` the ``graph``
+  extra; without them the import raises ``ModuleNotFoundError`` naming the
+  extra to install. The ``plot`` extra now pulls in ``pydot``/``networkx``
+  as well, since ``plot()`` renders through ``prov.dot``. Signposted by the
+  2.4.0 ``DeprecationWarning`` (now removed); see ``docs/upgrading-3.0.md``.
+
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^
 * ``prov.read()`` polish following 2.5.0's #239: seekable streams are now

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test:
 
 test-all:
 	for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do \
-		uv run --python $$py --extra rdf --extra xml pytest || exit 1; \
+		uv run --python $$py --extra rdf --extra xml --extra dot --extra graph pytest || exit 1; \
 	done
 
 coverage:
@@ -45,7 +45,7 @@ coverage:
 	open htmlcov/index.html
 
 docs:
-	uv run --group docs --extra rdf --extra xml sphinx-build -b html docs docs/_build/html
+	uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html
 	open docs/_build/html/index.html
 
 dist: clean

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,9 +52,10 @@ feed into this list. The planned changes are:
   in the next release after it reaches end of life.
 - **`rdflib` version floor raised**, shedding compatibility shims for older releases.
 - **Smaller install footprint**, informed by the 2.3.0 dependency audit:
-  `python-dateutil` replaced by the standard library, and the graphics/graph-interop
-  dependencies (`pydot`, `networkx`) likely moving behind optional extras, so a plain
-  `pip install prov` pulls in only what the core data model needs.
+  the graphics/graph-interop dependencies (`pydot`, `networkx`) now live behind the
+  `dot`/`graph` optional extras (landed in 3.0.0.dev0); `python-dateutil` is still to be
+  replaced by the standard library. Once that lands, a plain `pip install prov` will
+  pull in only what the core data model needs.
 - **Unification reworked to follow [PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/)**:
   `unified()` currently just merges the attributes of records that share an
   identifier; in 3.0 it applies the specification's merging rules (key constraints

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -8,35 +8,34 @@ below — they drift after the audit date above.
 
 ## Runtime dependencies (`[project.dependencies]`)
 
-These install unconditionally with `pip install prov`.
+These install unconditionally with `pip install prov`. Since 3.0.0.dev0 this is just
+`python-dateutil` — `pydot` and `networkx` moved behind the `dot`/`graph` extras below.
 
-- **`networkx>=2.0`** — backs `prov.graph` (`prov_to_graph()`/`graph_to_prov()`), the
-  NetworkX `MultiDiGraph` interop. Floor is `2.0`, the first release with the API this
-  module relies on; no upper bound because the module only uses stable, long-standing
-  NetworkX APIs.
-- **`pydot>=1.2.0`** — backs `prov.dot` (`prov_to_dot()`), rendering a document to a
-  `pydot.Graph` for export via Graphviz (PDF/PNG/SVG). Requires a *local* `graphviz`
-  binary install separately; `pydot` alone only builds the DOT representation. Floor
-  `1.2.0` predates this project's use of it; no known upper-bound issue.
 - **`python-dateutil>=2.2`** — `dateutil.parser.parse()` in `src/prov/model.py` parses
   ISO-8601-ish datetime strings from PROV-JSON/XML/RDF into `datetime` objects. There is a
   long-standing `# TODO: is this really needed?` next to this entry — the stdlib
   `datetime.fromisoformat()` couldn't handle the full range of formats PROV documents use
   when this was added, but nobody has re-verified that against the current stdlib.
   Left as-is; not in scope for this audit (would be a behaviour-risk change deferred to
-  3.0 if pursued).
-
-`pydot` and `networkx` are unconditional runtime deps today even though only `dot.py`/
-`graph.py` use them; moving them behind optional extras (e.g. `prov[dot]`, `prov[graph]`)
-is a tracked 3.0 idea (see the modernisation roadmap design doc), not done here since it
-would be a public-API/behaviour change for 2.x users who `import prov.dot`/`prov.graph`
-without an extra installed.
+  3.0 if pursued) — Task 3 of the 3.0 batch-1 plan drops this dependency entirely in
+  favour of the stdlib parser, which will empty this section out.
 
 ## Optional extras (`[project.optional-dependencies]`)
 
 Install with `prov[extra]`; omitting them makes the corresponding serializer/module raise
 `ModuleNotFoundError` when used, not at `import prov` time.
 
+- **`dot` → `pydot>=1.2.0`, `networkx>=2.0`** — backs `prov.dot` (`prov_to_dot()`),
+  rendering a document to a `pydot.Graph` for export via Graphviz (PDF/PNG/SVG). Requires
+  a *local* `graphviz` binary installed separately; `pydot` alone only builds the DOT
+  representation. `prov.dot` renders through `prov.graph` internally, so this extra
+  carries `networkx` too, not just `pydot`. `pydot` floor `1.2.0` predates this project's
+  use of it; `networkx` floor `2.0` is the first release with the API `prov.graph` relies
+  on. Both were unconditional runtime dependencies before 3.0.0.dev0 (see
+  `docs/upgrading-3.0.md`).
+- **`graph` → `networkx>=2.0`** — backs `prov.graph` (`prov_to_graph()`/
+  `graph_to_prov()`), the NetworkX `MultiDiGraph` interop. Same floor/rationale as the
+  `networkx` pin under `dot` above.
 - **`rdf` → `rdflib>=6.0.0,<8`** — backs `prov.serializers.provrdf` (PROV-O/RDF
   serialization). Both bounds revised 2026-07-05 (T15). Floor: the historic `4.2.1` no
   longer builds on the Pythons this project supports and 5.x fails xsd:base64Binary
@@ -53,9 +52,11 @@ Install with `prov[extra]`; omitting them makes the corresponding serializer/mod
   to 3.0 (its defaults, e.g. `default_union`, are not behaviour-neutral for 2.x).
 - **`xml` → `lxml>=3.3.5`** — backs `prov.serializers.provxml` (PROV-XML). Floor predates
   this project's adoption; no known upper-bound issue.
-- **`plot` → `matplotlib>=3.6`** — backs the interactive-display path of
-  `ProvBundle.plot()`/`ProvDocument.plot()` in `src/prov/model.py` (lazily imported
-  alongside `pydot` so the base install stays light). Floor `3.6` is a defensive modern
+- **`plot` → `matplotlib>=3.6`, `pydot>=1.2.0`, `networkx>=2.0`** — backs the
+  interactive-display path of `ProvBundle.plot()`/`ProvDocument.plot()` in
+  `src/prov/model/bundle.py`; `plot()` renders through `prov.dot` (lazily imported), so
+  this extra pulls in `pydot`/`networkx` alongside `matplotlib` rather than requiring
+  `prov[dot]` to be depended on separately. `matplotlib` floor `3.6` is a defensive modern
   baseline rather than a verified minimum; not exercised in CI (no display backend in the
   test environment), so this path is coverage-`defer`red (see
   `docs/test-gap-checklist.md`).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,3 +7,24 @@ Installation
 At the command line::
 
     $ python -m pip install prov
+
+This installs the core data model, PROV-JSON support, and the write-only PROV-N
+serializer. Several features live behind optional extras and raise
+``ModuleNotFoundError`` (naming the extra to install) if used without them:
+
+- ``prov[rdf]`` — PROV-O/RDF serialization (``rdflib``).
+- ``prov[xml]`` — PROV-XML serialization (``lxml``).
+- ``prov[dot]`` — graphical export via Graphviz (``prov.dot``, ``prov_to_dot()``); also
+  needs a local ``graphviz`` binary.
+- ``prov[graph]`` — NetworkX graph interop (``prov.graph``, ``prov_to_graph()``/
+  ``graph_to_prov()``).
+- ``prov[plot]`` — the interactive-display path of ``ProvBundle.plot()``/
+  ``ProvDocument.plot()`` (pulls in ``matplotlib`` as well as the ``dot`` extra's
+  dependencies, since ``plot()`` renders through ``prov.dot``).
+
+Extras combine, e.g.::
+
+    $ python -m pip install "prov[rdf,xml,dot,graph]"
+
+See ``docs/dependencies.md`` for the rationale behind each dependency and its version
+pin.

--- a/docs/superpowers/plans/2026-07-18-3.0-batch1-floor-raising.md
+++ b/docs/superpowers/plans/2026-07-18-3.0-batch1-floor-raising.md
@@ -1,0 +1,713 @@
+# prov 3.0 Batch 1: Mechanical Floor-Raising Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the mechanical, infrastructure-shaped 3.0 changes — pydot/networkx behind `dot`/`graph` extras, rdflib floor `>=7` with the `Dataset` migration, `python-dateutil` replaced by a stdlib xsd:dateTime parser (closing #237), and the pyupgrade/future-import cleanup — so the later conformance-fix and unification batches build on the final 3.0 dependency surface.
+
+**Architecture:** Four tasks, each one focused PR merged to master with green CI (the project's one-PR-per-roadmap-step rule; design doc steps 34, 35, 36c, 37). Master becomes 3.0-bound in Task 1 (`__version__ = "3.0.0.dev0"`, new `3.0.0 (unreleased)` HISTORY section). No release cut in this batch.
+
+**Tech Stack:** Python 3.10–3.14 + PyPy 3.11, uv, setuptools, ruff (`UP` enabled, target py310), mypy --strict, pytest + Hypothesis, rdflib 7.x, lxml.
+
+**User decisions (already made):**
+- Plan 3.0 in slices, one plan per batch; batch 1 = mechanical floor-raising ("Go ahead with 1 and 2, before writing plans for each batch of item 3", 2026-07-18).
+- #257 is narrowed: no assertion-time enforcement of structural constraints, ever — scruffy/incomplete statements stay legal, validation is opt-in (#62). Not in this batch; recorded so no task here adds constructor-level validation.
+- Python floor stays `>=3.10` (raised in 2.3.0; roadmap policy: drop a version in the next release after its EOL — 3.10 is not EOL yet).
+- Never add AI attribution to commits or PRs (CLAUDE.md).
+
+**Process rules (from CLAUDE.md / prior phases):** each task ends by opening a PR, waiting for green CI, and merging (merge commit, matching repo history). Rebase local master between tasks. If a task changes tooling/setup, update CLAUDE.md's affected sections in the same PR. Known-lossy RDF skips/xfails in the shared test modules are intentional — never "fix" them.
+
+---
+
+## Verification baseline (before Task 1)
+
+`uv run pytest -q` → `1160 passed, 22 skipped, 14 xfailed`. `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src` all clean. Master at `bb3faee` or later.
+
+---
+
+### Task 1: Move pydot/networkx behind `dot`/`graph` extras; mark master 3.0-bound
+
+**Goal:** `pip install prov` no longer pulls pydot/networkx; `prov.dot`/`prov.graph` raise `ModuleNotFoundError` naming the missing extra; the 2.4.0 `DeprecationWarning`s are removed (they came true); version becomes `3.0.0.dev0`.
+
+**Files:**
+- Modify: `pyproject.toml` (dependencies, extras, filterwarnings, per-file-ignores)
+- Modify: `src/prov/__init__.py:14` (`__version__`)
+- Modify: `src/prov/dot.py:15-33` (guarded import, drop warning block)
+- Modify: `src/prov/graph.py:1-48` (guarded import, drop warning block)
+- Modify: `src/prov/tests/test_minimal_install.py` (new degradation tests)
+- Modify: `src/prov/tests/test_public_api.py:96-103` (guard optional modules)
+- Modify: `src/prov/tests/test_dot.py`, `src/prov/tests/test_graph.py` (importorskip headers)
+- Modify: `.github/workflows/CI.yml`, `.readthedocs.yml`, `Makefile`, `CONTRIBUTING.rst`, `CLAUDE.md` (sync commands)
+- Modify: `HISTORY.rst`, `docs/dependencies.md`, `docs/installation.rst`
+- Regenerate: `uv.lock`
+
+**Acceptance Criteria:**
+- [ ] In a venv with only core `prov` installed, `import prov.dot` raises `ModuleNotFoundError` whose message contains `prov[dot]`; `import prov.graph` likewise with `prov[graph]`; `import prov` and the JSON round-trip still work.
+- [ ] With all extras installed, full suite passes with **no** `DeprecationWarning` from importing `prov.dot`/`prov.graph` (`uv run pytest -q -W error::DeprecationWarning src/prov/tests/test_dot.py src/prov/tests/test_graph.py` passes).
+- [ ] `pyproject.toml` `[project] dependencies` contains only `python-dateutil` (removed later in Task 3); `dot`, `graph`, `plot` extras carry the graph deps.
+- [ ] `prov.__version__ == "3.0.0.dev0"`; HISTORY.rst has a `3.0.0 (unreleased)` section.
+- [ ] CI green on the PR, including the `minimal install (no extras)` job.
+
+**Verify:** `uv sync --extra rdf --extra xml --extra dot --extra graph && uv run pytest -q && uv run ruff check src/ && uv run mypy src` → suite counts ≥ baseline (a couple of new tests added, some now environment-skipped), ruff/mypy clean.
+
+**Steps:**
+
+- [ ] **Step 1: pyproject dependency restructure**
+
+In `pyproject.toml` replace:
+
+```toml
+dependencies = [
+    "networkx>=2.0",
+    # Supporting graphic outputs (e.g. PNG, SVG, PDF) - a local graphviz is required
+    "pydot>=1.2.0",
+    "python-dateutil>=2.2",  # TODO: is this really needed?
+]
+```
+
+with:
+
+```toml
+dependencies = [
+    "python-dateutil>=2.2",  # removed in 3.0 Task 3 (stdlib xsd:dateTime parser)
+]
+```
+
+and replace the `[project.optional-dependencies]` table with:
+
+```toml
+[project.optional-dependencies]
+rdf = [
+    "rdflib>=6.0.0,<8",
+]
+xml = [
+    "lxml>=3.3.5",
+]
+# Graphical export (prov.dot / prov_to_dot); needs a local graphviz binary.
+# prov.dot renders via prov.graph, so this extra carries networkx too.
+dot = [
+    "pydot>=1.2.0",
+    "networkx>=2.0",
+]
+# NetworkX graph interop (prov.graph, prov_to_graph()/graph_to_prov()).
+graph = [
+    "networkx>=2.0",
+]
+# Interactive display path of ProvBundle.plot(); calls prov.dot internally.
+plot = [
+    "matplotlib>=3.6",
+    "pydot>=1.2.0",
+    "networkx>=2.0",
+]
+```
+
+In `[tool.pytest.ini_options]` delete the now-dead line `"ignore:In prov 3.0:DeprecationWarning",` (keep the unified FutureWarning ignore — that deprecation is resolved by the later unification batch).
+
+In `[tool.ruff.lint.per-file-ignores]` add (for the importorskip headers in Step 4):
+
+```toml
+"src/prov/tests/test_dot.py" = ["E402"]
+"src/prov/tests/test_graph.py" = ["E402"]
+```
+
+Run `uv lock` and commit the lock file with this change.
+
+- [ ] **Step 2: version + HISTORY**
+
+`src/prov/__init__.py`: `__version__ = "2.5.1"` → `__version__ = "3.0.0.dev0"`.
+
+`HISTORY.rst`: insert directly under the `History\n-------` heading:
+
+```rst
+3.0.0 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* BREAKING: ``pydot`` and ``networkx`` are no longer unconditional runtime
+  dependencies. ``import prov.dot`` now requires the ``dot`` extra
+  (``pip install "prov[dot]"``) and ``import prov.graph`` the ``graph``
+  extra; without them the import raises ``ModuleNotFoundError`` naming the
+  extra to install. The ``plot`` extra now pulls in ``pydot``/``networkx``
+  as well, since ``plot()`` renders through ``prov.dot``. Signposted by the
+  2.4.0 ``DeprecationWarning`` (now removed); see ``docs/upgrading-3.0.md``.
+```
+
+- [ ] **Step 3: guarded imports in dot.py / graph.py**
+
+`src/prov/dot.py`: delete the `warnings.warn(...)` block (lines 24–30) and the now-unused `import warnings` if ruff flags it (F401). Replace `import pydot` with:
+
+```python
+try:
+    import pydot
+except ImportError as e:
+    raise ModuleNotFoundError(
+        'prov.dot requires the optional "dot" extra; '
+        'install "prov[dot]" to use graphical export'
+    ) from e
+```
+
+`src/prov/graph.py`: delete the `warnings.warn(...)` block (lines 42–48) and `import warnings` if unused. Replace `import networkx as nx` with:
+
+```python
+try:
+    import networkx as nx
+except ImportError as e:
+    raise ModuleNotFoundError(
+        'prov.graph requires the optional "graph" extra; '
+        'install "prov[graph]" to use NetworkX graph interop'
+    ) from e
+```
+
+In `dot.py`, the existing `# noqa: E402` comments on the imports after the removed warning block: try deleting them; keep only if `uv run ruff check src/` flags E402 again (the try/except import block may still trigger it).
+
+Sanity-check `src/prov/model/bundle.py:1293` — `from prov import dot` stays lazy inside `plot()` (do not move it to module level; core `prov.model` must import without pydot).
+
+- [ ] **Step 4: test updates (failing first in a minimal env, but written together)**
+
+`src/prov/tests/test_minimal_install.py` — extend the module docstring's first line list, add `import importlib` alongside `importlib.util`, and append:
+
+```python
+HAS_PYDOT = importlib.util.find_spec("pydot") is not None
+HAS_NETWORKX = importlib.util.find_spec("networkx") is not None
+
+
+@pytest.mark.skipif(HAS_PYDOT, reason="only meaningful without pydot")
+def test_dot_unavailable_raises_informative_error() -> None:
+    with pytest.raises(ModuleNotFoundError, match=r"prov\[dot\]"):
+        importlib.import_module("prov.dot")
+
+
+@pytest.mark.skipif(HAS_NETWORKX, reason="only meaningful without networkx")
+def test_graph_unavailable_raises_informative_error() -> None:
+    with pytest.raises(ModuleNotFoundError, match=r"prov\[graph\]"):
+        importlib.import_module("prov.graph")
+```
+
+`src/prov/tests/test_public_api.py` — the API names stay guarded (they remain importable in 3.0 *with the extra installed*); teach the test that the module itself is now optional. Add after the `PUBLIC_API` dict:
+
+```python
+# Modules importable only when their optional extra is installed (3.0);
+# the informative failure without the extra is covered by test_minimal_install.
+OPTIONAL_MODULE_REQUIREMENTS = {
+    "prov.dot": "pydot",
+    "prov.graph": "networkx",
+}
+```
+
+and in `test_names_importable`, before `module = importlib.import_module(module_name)`:
+
+```python
+        requirement = OPTIONAL_MODULE_REQUIREMENTS.get(module_name)
+        if requirement and importlib.util.find_spec(requirement) is None:
+            continue
+```
+
+(add `import importlib.util` to the module's imports).
+
+`src/prov/tests/test_dot.py` — at the very top, before any `prov.dot`/pydot import:
+
+```python
+import pytest
+
+pytest.importorskip("pydot", reason="prov.dot requires the dot extra")
+```
+
+`src/prov/tests/test_graph.py` — same with `pytest.importorskip("networkx", reason="prov.graph requires the graph extra")`.
+
+Then run `grep -rln "prov\.dot\|prov\.graph\|import networkx\|import pydot" src/prov/tests/` — if any test module beyond `test_dot.py`/`test_graph.py`/`test_minimal_install.py`/`test_public_api.py` imports these at module level, give it the same importorskip treatment (expected: none).
+
+- [ ] **Step 5: CI, RTD, docs-tooling, contributor docs**
+
+`.github/workflows/CI.yml`: change every `uv sync --locked --extra rdf --extra xml --group dev` to `uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev` (`grep -n "extra rdf" .github/workflows/CI.yml` — expected 3+ sites). Do **not** touch the `minimal install (no extras)` job's `uv sync --locked --group dev`; extend that job's comment to mention pydot/networkx now being exercised as missing too.
+
+`.readthedocs.yml` line 14 and `Makefile` docs target (line 48): append `--extra dot --extra graph` (Sphinx autodoc imports `prov.dot`/`prov.graph`). `Makefile` matrix loop (line 38) and `CONTRIBUTING.rst` (lines 68, 89): same append.
+
+`CLAUDE.md`: update the Setup section (`uv sync --extra rdf --extra xml` → add `--extra dot --extra graph`, and the docs-build command), the multi-interpreter loop in Common commands, and add one line to the "Graph interop" architecture paragraph noting both modules now sit behind extras and raise `ModuleNotFoundError` naming the extra when missing.
+
+`docs/dependencies.md`: move the `networkx`/`pydot` bullets from "Runtime dependencies" into the extras section as `dot`/`graph`/`plot` entries (note `dot` and `plot` carry networkx/pydot, and why); note the runtime section now holds only `python-dateutil` (with a pointer that Task 3 / the 3.0 dateutil drop removes it).
+
+`docs/installation.rst`: after the basic `pip install prov`, document the extras (`prov[dot]`, `prov[graph]`, `prov[plot]`, alongside existing rdf/xml mentions if present).
+
+- [ ] **Step 6: verify locally**
+
+```bash
+uv sync --extra rdf --extra xml --extra dot --extra graph
+uv run pytest -q                          # expect: ≥1160 passed (+2 skipped new tests), 22 skipped baseline, 14 xfailed
+uv run pytest -q -W error::DeprecationWarning src/prov/tests/test_dot.py src/prov/tests/test_graph.py
+uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src
+```
+
+Minimal-env spot check (mirrors the CI minimal job):
+
+```bash
+uv sync --group dev            # drops the extras from the venv
+uv run pytest -q src/prov/tests/test_minimal_install.py   # new dot/graph tests now run (not skipped) and pass
+uv sync --extra rdf --extra xml --extra dot --extra graph  # restore
+```
+
+- [ ] **Step 7: commit, PR, merge**
+
+```bash
+git checkout -b extras-dot-graph
+git add -A
+git commit -m "Move pydot/networkx behind dot/graph extras; open 3.0.0.dev0
+
+The 2.4.0 deprecation comes true (roadmap step 36c/37): prov.dot and
+prov.graph now require the dot/graph extras and raise ModuleNotFoundError
+naming the extra when it is missing; the plot extra carries pydot/networkx
+too since plot() renders through prov.dot. The import-time
+DeprecationWarnings are removed, master's version becomes 3.0.0.dev0, and
+HISTORY gains the 3.0.0 (unreleased) section."
+git push -u origin extras-dot-graph
+gh pr create --fill   # body: summarize; cite roadmap steps 36c/37 + upgrading-3.0.md
+gh pr checks --watch  # all green, then: gh pr merge --merge --delete-branch
+git checkout master && git pull --ff-only
+```
+
+---
+
+### Task 2: rdflib floor `>=7`; migrate ConjunctiveGraph → Dataset
+
+**Goal:** The `rdf` extra requires `rdflib>=7.0.0,<8`; `provrdf` and `test_rdf` stop using the deprecated `ConjunctiveGraph`, using `Dataset(default_union=True)` / named `Graph`s instead, with round-trip behaviour unchanged.
+
+**Files:**
+- Modify: `pyproject.toml:41` (rdf extra floor)
+- Modify: `src/prov/serializers/provrdf.py` (import line 15; `deserialize` line 232; `encode_document` lines 350–380; `encode_container` lines 382–418; `decode_document` signature line ~660 and contexts loop lines 685–710)
+- Modify: `src/prov/tests/test_rdf.py` (lines 19, 43, 49, 62, 68, 145–160, 184, 297)
+- Modify: `.github/workflows/CI.yml` (rdflib-compat job floor pin + comments, lines ~55–80)
+- Modify: `docs/dependencies.md` (rdf extra entry), `docs/upgrading-3.0.md` (footprint table row), `HISTORY.rst`
+- Regenerate: `uv.lock`
+
+**Acceptance Criteria:**
+- [ ] `grep -rn ConjunctiveGraph src/` → no matches.
+- [ ] Full suite green on locked rdflib and on rdflib `7.0.0` (the CI compat job's new floor); `-W error::DeprecationWarning` on `test_rdf.py` passes (no rdflib ConjunctiveGraph deprecation).
+- [ ] TriG round-trip of a document with named bundles still passes (covered by `test_statements`/`test_examples` rdf target and the `rdf/` fixture dir).
+- [ ] CI green on the PR.
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py src/prov/tests/test_statements.py src/prov/tests/test_examples.py && uv run mypy src` then full `uv run pytest -q` → baseline counts.
+
+**Steps:**
+
+- [ ] **Step 1: raise the floor**
+
+`pyproject.toml`: `"rdflib>=6.0.0,<8"` → `"rdflib>=7.0.0,<8"`. Run `uv lock`.
+
+`.github/workflows/CI.yml` rdflib-compat job: change the floor pin `rdflib==6.0.0` → `rdflib==7.0.0` and update the job's comment block (currently "proves both bounds of the rdf extra (rdflib>=6.0.0,<8)").
+
+- [ ] **Step 2: migrate provrdf.py**
+
+Import (line 15):
+
+```python
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Dataset, Graph
+```
+
+`deserialize` (line 232): `container = ConjunctiveGraph()` → `container = Dataset(default_union=True)`.
+
+`encode_document` — restructure so the Dataset is built here and bundles are encoded as named `Graph`s (this also removes the `cast` workaround at lines 375–379; drop the then-unused `cast`/`Node` imports if ruff flags them):
+
+```python
+    def encode_document(
+        self,
+        document: pm.ProvDocument,
+        PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
+    ) -> Dataset:
+        """Encode a whole :class:`~prov.model.ProvDocument`, including its named bundles.
+
+        Args:
+            document: Document to encode.
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword;
+                defaults to :data:`~prov.constants.PROV_N_MAP`.
+
+        Returns:
+            A ``Dataset`` (union view) containing the document's own triples
+            plus one named graph per bundle in ``document.bundles``.
+        """
+        container = Dataset(default_union=True)
+        container.namespace_manager.bind("prov", PROV.uri)
+        self.encode_container(document, PROV_N_MAP=PROV_N_MAP, container=container)
+        for item in document.bundles:
+            #  encoding the sub-bundle into a named graph carrying its IRI
+            bundle = self.encode_container(
+                item,
+                identifier=item.identifier.uri,  # type: ignore[union-attr]
+                PROV_N_MAP=PROV_N_MAP,
+            )
+            container.addN((s, p, o, bundle) for s, p, o in bundle)
+        return container
+```
+
+`encode_container` — accepts/returns plain `Graph` (a `Dataset` *is a* `Graph`, so `encode_document`'s pass-through still type-checks):
+
+```python
+        container: Graph | None = None,
+        identifier: str | None = None,
+    ) -> Graph:
+```
+
+and its `container is None` branch becomes:
+
+```python
+        if container is None:
+            container = Graph(identifier=identifier)
+            nm = container.namespace_manager
+            nm.bind("prov", PROV.uri)
+```
+
+(update the docstring's `ConjunctiveGraph` mentions to `Graph`/`Dataset` accordingly).
+
+`decode_document`: change the `content` parameter annotation from `ConjunctiveGraph` to `Dataset`, and in the contexts loop (line 689) widen the "top-level document" test — a parsed `Dataset` reports its default graph under `DATASET_DEFAULT_GRAPH_ID`, not a `BNode`:
+
+```python
+                if (
+                    isinstance(graph.identifier, BNode)
+                    or graph.identifier == DATASET_DEFAULT_GRAPH_ID
+                ):
+```
+
+Check `deserialize`'s type comments and any other `ConjunctiveGraph` annotations flagged by `grep -n ConjunctiveGraph src/prov/serializers/provrdf.py` — all must be converted.
+
+- [ ] **Step 3: migrate test_rdf.py**
+
+Replace every `ConjunctiveGraph()` / `rl.ConjunctiveGraph()` with `Dataset(default_union=True)` / `rl.Dataset(default_union=True)` (lines 43, 49, 62, 68, 151, 184, 297), update the import at line 19 to `from rdflib.graph import Dataset, Graph`, and fix the two comments (lines 145, 160) that name `ConjunctiveGraph`.
+
+- [ ] **Step 4: verify (behaviour parity is the whole risk here)**
+
+```bash
+uv run pytest -q src/prov/tests/test_rdf.py -x
+uv run pytest -q -W error::DeprecationWarning src/prov/tests/test_rdf.py
+uv run pytest -q            # full suite, baseline counts
+uv run mypy src && uv run ruff check src/
+uv run --isolated --with 'rdflib==7.0.0' --extra xml --extra dot --extra graph pytest -q src/prov/tests/test_rdf.py  # floor check; mirror the CI compat job's actual invocation
+```
+
+If TriG/named-bundle round-trips fail, debug against the suite's `pytest_assertrepr_compare` diff before touching any test — the fixtures are the authority; the serializer must adapt.
+
+- [ ] **Step 5: docs + HISTORY**
+
+`docs/dependencies.md` rdf entry: floor is now `7.0.0` — rewrite the bounds paragraph: the rdflib-6 accidental prefix-carrying behaviour is no longer supported; the `Dataset` migration (deferred from 2.x precisely because `default_union` defaults are not behaviour-neutral) is done with `default_union=True` preserving the ConjunctiveGraph union semantics; the compat CI job now proves `7.0.0` and newest 7.x.
+
+`docs/upgrading-3.0.md` "Smaller install footprint" table — add a row:
+
+```markdown
+| `rdf` extra floor raised to `rdflib>=7.0.0` | Not separately warned (dependency floor) | If you pin rdflib 6.x alongside `prov[rdf]`, upgrade to rdflib 7. Serialization differences are limited to those already present under rdflib 7 in 2.x (bundle-local namespaces appear as full IRIs in TriG; round-trip equality is unaffected). |
+```
+
+`HISTORY.rst` under `3.0.0 (unreleased)`:
+
+```rst
+* BREAKING: the ``rdf`` extra now requires ``rdflib>=7.0.0`` (previously
+  ``>=6.0.0``); internally the RDF serializer migrated from the deprecated
+  ``ConjunctiveGraph`` to ``Dataset``, with unchanged round-trip behaviour
+```
+
+- [ ] **Step 6: commit, PR, merge** — same flow as Task 1 Step 7, branch `rdflib-7-dataset`, commit message subject `Require rdflib>=7 and migrate ConjunctiveGraph to Dataset`. Cite roadmap step 35.
+
+---
+
+### Task 3: Drop python-dateutil; stdlib xsd:dateTime parsing (closes #237)
+
+**Goal:** `prov` has zero unconditional runtime dependencies: `parse_xsd_datetime` is reimplemented on `datetime.fromisoformat` with xsd:dateTime normalization (Z suffix, fractional-second padding, hour-24 end-of-day), factory `time=` parameters raise `ProvException` instead of leaking `dateutil.parser.ParserError`, and the hour-24 lexical form is accepted — both halves of #237.
+
+**Files:**
+- Modify: `src/prov/model/records.py` (lines 13, 103–129 + docstring mentions at 779, 802, 1070, 1114, 1140)
+- Modify: `src/prov/model/__init__.py:26` (remove `import dateutil as dateutil`)
+- Modify: `src/prov/serializers/provrdf.py` (lines 13, 322–334)
+- Modify: `src/prov/model/bundle.py` (docstring mentions, lines 567, 603, 639, 679, 720, 759)
+- Modify: `src/prov/tests/test_statements.py` (14 `dateutil.parser.parse` sites), `src/prov/tests/test_conformance_dm.py` (#237 xfails flip)
+- Create: `src/prov/tests/test_datetime_parsing.py`
+- Modify: `pyproject.toml` (drop `python-dateutil`, drop `types-python-dateutil`), `uv.lock`
+- Modify: `docs/dependencies.md`, `docs/upgrading-3.0.md`, `HISTORY.rst`
+
+**Acceptance Criteria:**
+- [ ] `grep -rn dateutil src/ pyproject.toml` → no matches (docs/HISTORY historical mentions fine).
+- [ ] `document.activity("ex:a1", startTime="not a date")` raises `ProvException`; `startTime="2011-11-16T24:00:00"` yields `datetime(2011, 11, 17, 0, 0)` — the two #237 xfails in `test_conformance_dm.py` are flipped to plain passing tests (xfail count drops 14 → 12).
+- [ ] New parser unit tests pass on Python 3.10 specifically (`fromisoformat` is at its narrowest there).
+- [ ] Hypothesis round-trip property (`test_property_roundtrip.py`) stays green — it stress-tests datetime serialization shapes across json/xml/rdf.
+- [ ] CI green; issue #237 closed by the PR (`Closes #237` in the body).
+
+**Verify:** `uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q` → `… passed, 22 skipped, 12 xfailed`; `uv run mypy src` clean.
+
+**Steps:**
+
+- [ ] **Step 1: write the failing/flipping tests first**
+
+Create `src/prov/tests/test_datetime_parsing.py`:
+
+```python
+"""Unit tests for the stdlib-based xsd:dateTime parser (3.0 dateutil drop, #237)."""
+
+import datetime
+
+import pytest
+
+from prov.model import ProvDocument, ProvException, parse_xsd_datetime
+
+UTC = datetime.timezone.utc
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("2012-12-03T21:08:16.686Z", datetime.datetime(2012, 12, 3, 21, 8, 16, 686000, tzinfo=UTC)),
+        ("2012-12-03T21:08:16", datetime.datetime(2012, 12, 3, 21, 8, 16)),
+        ("2012-12-03T21:08:16+05:30", datetime.datetime(2012, 12, 3, 21, 8, 16, tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)))),
+        # fractional seconds of any length (fromisoformat on 3.10 takes only 3 or 6 digits)
+        ("2012-12-03T21:08:16.68Z", datetime.datetime(2012, 12, 3, 21, 8, 16, 680000, tzinfo=UTC)),
+        ("2012-12-03T21:08:16.1234567Z", datetime.datetime(2012, 12, 3, 21, 8, 16, 123456, tzinfo=UTC)),
+        # xsd:dateTime end-of-day form maps to 00:00:00 of the next day
+        ("2011-11-16T24:00:00", datetime.datetime(2011, 11, 17, 0, 0)),
+        ("2011-11-16T24:00:00.000Z", datetime.datetime(2011, 11, 17, 0, 0, tzinfo=UTC)),
+        ("2011-12-31T24:00:00", datetime.datetime(2012, 1, 1, 0, 0)),
+    ],
+)
+def test_parse_xsd_datetime_accepts(text, expected):
+    assert parse_xsd_datetime(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not a date",
+        "",
+        "2011-11-16",  # xsd:date, not xsd:dateTime (no time part) — pre-3.0 dateutil accepted it; now rejected
+        "2011-11-16T24:30:00",  # hour 24 is only valid with 00:00 minutes/seconds
+        "Nov 7, 2011",  # dateutil-style leniency is gone in 3.0
+    ],
+)
+def test_parse_xsd_datetime_rejects(text):
+    assert parse_xsd_datetime(text) is None
+
+
+def test_factory_rejects_bad_time_with_prov_exception():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    with pytest.raises(ProvException):
+        document.activity("ex:a1", startTime="not a date")
+```
+
+**Design note (locked):** `"2011-11-16"` (a bare `xsd:date`) was accepted by dateutil and is rejected by the new parser. This is the documented 3.0 narrowing ("`fromisoformat()` accepts a narrower grammar", upgrading-3.0.md); PROV factories take `xsd:dateTime`, and a date-only string was silently promoted to midnight before. If the executing agent finds suite fixtures relying on date-only strings, that is a fixture bug to surface in the PR, not a reason to widen the parser.
+
+`src/prov/tests/test_conformance_dm.py`: delete `from dateutil.parser import ParserError` (line 15), add `import datetime` to the imports, and replace both #237 xfail-decorated tests with:
+
+```python
+def test_factory_time_parse_error_raises_prov_exception():
+    # #237 (fixed in 3.0): raw dateutil ParserError no longer leaks
+    document = _doc()
+    with pytest.raises(ProvException):
+        document.activity("ex:a1", startTime="not a date")
+
+
+def test_factory_time_accepts_hour24_datetime():
+    # #237 (fixed in 3.0): xsd:dateTime end-of-day form is valid
+    document = _doc()
+    activity = document.activity("ex:a1", startTime="2011-11-16T24:00:00")
+    assert activity.get_startTime() == datetime.datetime(2011, 11, 17, 0, 0)
+```
+
+Also update the module docstring's mention of strict xfails if it enumerates them.
+
+Run: `uv run pytest -q src/prov/tests/test_datetime_parsing.py src/prov/tests/test_conformance_dm.py` → new module fails (hour-24/fraction cases; `parse_xsd_datetime` still dateutil-lenient so `"Nov 7, 2011"` wrongly parses), conformance flips fail (still ParserError). That is the red state.
+
+- [ ] **Step 2: reimplement in records.py**
+
+In `src/prov/model/records.py`: replace `import dateutil.parser` (line 13) with `import re` (line-sort per isort; ruff will place it). Replace `_ensure_datetime` and `parse_xsd_datetime` (lines 103–129) with:
+
+```python
+_XSD_HOUR24_RE = re.compile(r"T24:00:00(\.0+)?(?=$|[Zz+-])")
+_XSD_ZULU_RE = re.compile(r"[Zz]$")
+_XSD_FRACTION_RE = re.compile(r"\.(\d+)")
+
+
+def _ensure_datetime(value: DatetimeOrStr | None) -> datetime.datetime | None:
+    """Coerce a value to a :class:`datetime.datetime`.
+
+    A string is parsed with :func:`parse_xsd_datetime`; a
+    :class:`~datetime.datetime` or ``None`` is returned unchanged.
+
+    Raises:
+        ProvException: If a string value is not a valid ``xsd:dateTime``.
+    """
+    if isinstance(value, str):
+        parsed = parse_xsd_datetime(value)
+        if parsed is None:
+            raise ProvException(f"Invalid xsd:dateTime value: {value!r}")
+        return parsed
+    return value
+
+
+def parse_xsd_datetime(value: str) -> datetime.datetime | None:
+    """Parse an ``xsd:dateTime`` string into a :class:`datetime.datetime`.
+
+    Accepts the ``xsd:dateTime`` lexical space: ISO 8601 date-time with
+    optional fractional seconds and timezone, ``Z`` for UTC, and the
+    hour-24 end-of-day form (which maps to 00:00:00 of the following day,
+    per the XSD value space).
+
+    Args:
+        value: The date/time string to parse.
+
+    Returns:
+        The parsed :class:`~datetime.datetime`, or ``None`` if ``value``
+        could not be parsed.
+    """
+    text = value.strip()
+    end_of_day = _XSD_HOUR24_RE.search(text) is not None
+    if end_of_day:
+        text = _XSD_HOUR24_RE.sub("T00:00:00", text)
+    # datetime.fromisoformat on Python 3.10 accepts neither the "Z" suffix
+    # nor fractional seconds that are not exactly 3 or 6 digits long;
+    # normalize both before parsing.
+    text = _XSD_ZULU_RE.sub("+00:00", text)
+    text = _XSD_FRACTION_RE.sub(
+        lambda m: "." + m.group(1)[:6].ljust(6, "0"), text, count=1
+    )
+    try:
+        parsed = datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if end_of_day:
+        parsed += datetime.timedelta(days=1)
+    return parsed
+```
+
+(`ProvException` is defined later in the same module; the reference resolves at call time.)
+
+Update the five records.py docstring mentions of `dateutil.parser.parse` (lines 779, 802, 1070, 1114, 1140) and the six in bundle.py (lines 567, 603, 639, 679, 720, 759) — replace the phrase "a string parseable by :func:`dateutil.parser.parse`" with "an ``xsd:dateTime`` string accepted by :func:`~prov.model.parse_xsd_datetime`" (adjust surrounding grammar per site).
+
+- [ ] **Step 3: provrdf.py gYear/gYearMonth/dateTime**
+
+Delete `import dateutil.parser` (line 13); add near the module's other constants:
+
+```python
+_XSD_GYEAR_RE = re.compile(r"^(-?\d{4,})(?:Z|[+-]\d{2}:\d{2})?$")
+_XSD_GYEARMONTH_RE = re.compile(r"^(-?\d{4,})-(\d{2})(?:Z|[+-]\d{2}:\d{2})?$")
+```
+
+(add `import re` if absent). Replace the three branches (lines 322–334):
+
+```python
+            if datatype == XSD["dateTime"]:
+                parsed = pm.parse_xsd_datetime(str(literal))
+                if parsed is None:
+                    raise ValueError(f"Invalid xsd:dateTime literal: {literal}")
+                return parsed
+            if datatype == XSD["gYear"]:
+                year_match = _XSD_GYEAR_RE.match(str(literal))
+                if year_match is None:
+                    raise ValueError(f"Invalid xsd:gYear literal: {literal}")
+                return pm.Literal(
+                    int(year_match.group(1)),
+                    datatype=self.valid_identifier(datatype),
+                )
+            if datatype == XSD["gYearMonth"]:
+                ym_match = _XSD_GYEARMONTH_RE.match(str(literal))
+                if ym_match is None:
+                    raise ValueError(f"Invalid xsd:gYearMonth literal: {literal}")
+                return pm.Literal(
+                    f"{int(ym_match.group(1))}-{int(ym_match.group(2)):02d}",
+                    datatype=self.valid_identifier(datatype),
+                )
+```
+
+- [ ] **Step 4: remove the re-export and the dependency**
+
+`src/prov/model/__init__.py`: delete line 26 (`import dateutil as dateutil`) — `prov.model.dateutil` ceases to exist (sanctioned 3.0 removal; documented in Step 6).
+
+`pyproject.toml`: `[project] dependencies = []` (with a comment `# No unconditional runtime dependencies as of 3.0.`), and delete `"types-python-dateutil>=2.9.0.20260124",` from the dev group. Run `uv lock`.
+
+`src/prov/tests/test_statements.py`: the 14 `time=dateutil.parser.parse("2012-12-03T21:08:16.686Z")` sites (reached via the `prov.model` star re-export, which is now gone). Add below the imports:
+
+```python
+_TIME_2012 = datetime.datetime(
+    2012, 12, 3, 21, 8, 16, 686000, tzinfo=datetime.timezone.utc
+)
+```
+
+with an explicit `import datetime` at the top, then:
+
+```bash
+sed -i '' 's/time=dateutil\.parser\.parse("2012-12-03T21:08:16\.686Z")/time=_TIME_2012/' src/prov/tests/test_statements.py
+grep -c "dateutil" src/prov/tests/test_statements.py   # expect 0
+```
+
+- [ ] **Step 5: verify, including on 3.10**
+
+```bash
+uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q   # expect: passed, 22 skipped, 12 xfailed
+uv run pytest -q                                                                    # default interpreter too
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+grep -rn dateutil src/ pyproject.toml    # expect: no hits
+```
+
+- [ ] **Step 6: docs + HISTORY**
+
+`docs/dependencies.md`: delete the `python-dateutil` runtime bullet (the section now states there are **no** unconditional runtime dependencies, resolving the long-standing `# TODO: is this really needed?`) and the `types-python-dateutil` dev bullet.
+
+`docs/upgrading-3.0.md`: in the footprint table's dateutil row, extend "What to do" — factory `time=`/`startTime=`/`endTime=` parameters now raise `prov.model.ProvException` for unparseable strings (previously a raw `dateutil.parser.ParserError` leaked, #237), the valid xsd:dateTime hour-24 form is now accepted, and non-ISO strings such as `"Nov 7, 2011"` or bare dates (`"2011-11-16"`) are rejected. In the "Removal of names deprecated in 2.4.0" section, add that the incidental `prov.model.dateutil` module re-export is gone.
+
+`HISTORY.rst` under `3.0.0 (unreleased)`:
+
+```rst
+* BREAKING: ``python-dateutil`` dropped — ``prov`` now has no unconditional
+  runtime dependencies. Datetime strings are parsed as ``xsd:dateTime``
+  (ISO 8601 plus the hour-24 end-of-day form) via the standard library;
+  factory ``time=``/``startTime=``/``endTime=`` parameters raise
+  ``ProvException`` on invalid input instead of leaking a raw dateutil
+  error, and non-ISO forms previously tolerated by dateutil (e.g.
+  ``"Nov 7, 2011"``) are no longer accepted (#237)
+```
+
+- [ ] **Step 7: commit, PR, merge** — branch `drop-dateutil`, commit subject `Drop python-dateutil for stdlib xsd:dateTime parsing`, PR body cites roadmap step 36c and `Closes #237`. Same green-CI-then-merge flow.
+
+---
+
+### Task 4: pyupgrade ratchet close-out — `from __future__ import annotations` audit
+
+**Goal:** Roadmap step 34 closed: `UP` rules confirmed clean at the py310 floor, and the 14 `from __future__ import annotations` lines (a 3.9-era artifact) are removed where they are inert or retained with an accurate comment where they are load-bearing for `TYPE_CHECKING`-only names in signatures.
+
+**Files:**
+- Modify (audit each; removal expected for several, keep+recomment for `records.py`, `bundle.py`, and any other file with `TYPE_CHECKING` imports used in runtime-evaluated annotations): `src/prov/__init__.py`, `src/prov/identifier.py`, `src/prov/graph.py`, `src/prov/dot.py`, `src/prov/serializers/__init__.py`, `src/prov/serializers/provjson.py`, `src/prov/serializers/provrdf.py`, `src/prov/serializers/provxml.py`, `src/prov/scripts/convert.py`, `src/prov/scripts/compare.py`, `src/prov/model/__init__.py`, `src/prov/model/records.py`, `src/prov/model/bundle.py`, `src/prov/model/namespaces.py`
+
+**Acceptance Criteria:**
+- [ ] `uv run ruff check --select UP src/` → clean (confirms the ratchet has nothing left at py310).
+- [ ] No file carries the stale comment `needed for | type annotations in Python < 3.10` (PEP 604 unions are native at the 3.10 floor — the comment's stated reason is false).
+- [ ] Every retained future-import carries the accurate comment; every file without one imports cleanly on Python 3.10 (where signature annotations are eagerly evaluated, unlike 3.14).
+- [ ] Full suite green on Python **3.10** and on the default interpreter; CI green on the PR.
+
+**Verify:** `uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q && uv run mypy src && uv run ruff check src/` → all clean, suite at Task-3 counts.
+
+**Steps:**
+
+- [ ] **Step 1: audit procedure (mechanical, per file)**
+
+For each of the 14 files, in one pass:
+
+1. `grep -n "TYPE_CHECKING" <file>` — if the file has `if TYPE_CHECKING:` imports whose names appear in function/method signatures or class-level annotations, the future-import is **load-bearing** (without it those annotations evaluate at `def` time on Python ≤3.13 and raise `NameError`). Keep the import and set the comment to:
+
+```python
+from __future__ import annotations  # defer evaluation: TYPE_CHECKING-only names appear in signatures
+```
+
+2. Otherwise remove the `from __future__ import annotations` line (and its comment) entirely.
+
+Expected split: `records.py` and `bundle.py` keep it (both use `TYPE_CHECKING` imports across module boundaries); most serializer/script files likely drop it — but trust the check, not this prediction.
+
+- [ ] **Step 2: prove it on the eager-evaluation interpreter**
+
+```bash
+uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q
+```
+
+Python 3.14 defers annotation evaluation (PEP 749), so a wrong removal is invisible there — 3.10 is the interpreter that catches it. Then `uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/`, and the default-interpreter suite.
+
+- [ ] **Step 3: commit, PR, merge** — branch `pyupgrade-closeout`, commit subject `Close out the pyupgrade ratchet: prune stale __future__ annotations imports`, body cites roadmap step 34. Green CI, merge.
+
+---
+
+## Batch close-out (after Task 4 merges)
+
+Not a repo task — coordinator actions: update the Phase 4 memory file with the batch-1 outcome (PR numbers, suite counts, deviations), and note that the next plan to write is **batch 2: serializer conformance fixes** (numeric-typing family #235/#244/#249/#251/#256/#246/#168 first — same root cause across serializers).
+
+## Self-review notes
+
+- Spec coverage: design-doc step 34 → Task 4; step 35 → Task 2; step 36c → Tasks 1+3; step 37 → Tasks 1 (extras warnings) + 3 (dateutil); steps 33/38/39 are out of batch (33 done in 2.3.0; 38/39 belong to the release-cut batch). The `unified()` FutureWarning stays until the unification batch — deliberate.
+- The `plot` extra gaining pydot/networkx is new relative to upgrading-3.0.md's current text; Task 1 Step 5 updates the guide's footprint section accordingly (add it to the `dot` row's note or a short sentence under the table).
+- Type consistency: `parse_xsd_datetime` keeps its public name/signature (`str -> datetime | None`); `encode_container -> Graph` is consumed by `encode_document -> Dataset` (subclass pass-through) and by `test_rdf.py`'s direct calls, updated in the same task.

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -13,12 +13,14 @@ for the full rationale.
 
 | Change | Signposted in 2.4.0 by | What to do |
 |---|---|---|
-| `pydot`/Graphviz support (`prov.dot`, `prov_to_dot()`) moves behind the `dot` extra | Importing `prov.dot` emits a `DeprecationWarning` | Depend on `prov[dot]` instead of (or in addition to) `prov` if your code imports `prov.dot` or calls `prov_to_dot()`. |
-| `networkx` graph interop (`prov.graph`, `prov_to_graph()`/`graph_to_prov()`) moves behind the `graph` extra | Importing `prov.graph` emits a `DeprecationWarning` | Depend on `prov[graph]` instead of (or in addition to) `prov` if your code imports `prov.graph` or calls `prov_to_graph()`/`graph_to_prov()`. Note `prov.dot` itself uses `prov.graph`, so `prov[dot]` will pull in `prov[graph]` too. |
+| **Done in 3.0.0.dev0:** `pydot`/Graphviz support (`prov.dot`, `prov_to_dot()`) moves behind the `dot` extra | Importing `prov.dot` emitted a `DeprecationWarning` (now removed) | Depend on `prov[dot]` instead of (or in addition to) `prov` if your code imports `prov.dot` or calls `prov_to_dot()`. |
+| **Done in 3.0.0.dev0:** `networkx` graph interop (`prov.graph`, `prov_to_graph()`/`graph_to_prov()`) moves behind the `graph` extra | Importing `prov.graph` emitted a `DeprecationWarning` (now removed) | Depend on `prov[graph]` instead of (or in addition to) `prov` if your code imports `prov.graph` or calls `prov_to_graph()`/`graph_to_prov()`. Note `prov.dot` itself uses `prov.graph`, so `prov[dot]` pulls in `prov[graph]`'s dependency (`networkx`) too. |
 | `python-dateutil` dropped in favour of the standard library's `datetime.fromisoformat()` | Not separately warned (internal dependency swap) | No action for typical ISO-8601 timestamps. If you rely on `dateutil.parser.parse()`'s more permissive parsing of non-ISO date/time strings inside PROV-JSON/XML/RDF documents, verify those strings still parse under 3.0 — `fromisoformat()` accepts a narrower grammar. |
 
-A plain `pip install prov` will keep working for the core data model and the JSON/PROV-N
-serializers; add the relevant extra(s) if you use graphics export or graph interop.
+A plain `pip install prov` keeps working for the core data model and the JSON/PROV-N
+serializers; add the relevant extra(s) if you use graphics export or graph interop. The
+`plot` extra (`ProvBundle.plot()`/`ProvDocument.plot()`) also now carries `pydot` and
+`networkx`, since its interactive-display path renders through `prov.dot`.
 
 ## Behaviour-changing bug fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "networkx>=2.0",
-    # Supporting graphic outputs (e.g. PNG, SVG, PDF) - a local graphviz is required
-    "pydot>=1.2.0",
-    "python-dateutil>=2.2",  # TODO: is this really needed?
+    "python-dateutil>=2.2",  # removed in 3.0 Task 3 (stdlib xsd:dateTime parser)
 ]
 
 [project.optional-dependencies]
@@ -43,8 +40,21 @@ rdf = [
 xml = [
     "lxml>=3.3.5",
 ]
+# Graphical export (prov.dot / prov_to_dot); needs a local graphviz binary.
+# prov.dot renders via prov.graph, so this extra carries networkx too.
+dot = [
+    "pydot>=1.2.0",
+    "networkx>=2.0",
+]
+# NetworkX graph interop (prov.graph, prov_to_graph()/graph_to_prov()).
+graph = [
+    "networkx>=2.0",
+]
+# Interactive display path of ProvBundle.plot(); calls prov.dot internally.
 plot = [
     "matplotlib>=3.6",
+    "pydot>=1.2.0",
+    "networkx>=2.0",
 ]
 
 [project.scripts]
@@ -143,11 +153,12 @@ combine-as-imports = true  # keep multi-name `X as X` re-export blocks compact
 "src/prov/serializers/provjson.py" = ["F403", "F405"]
 "src/prov/serializers/provxml.py" = ["F403", "F405"]
 "src/prov/tests/test_statements.py" = ["F403", "F405"]
+"src/prov/tests/test_dot.py" = ["E402"]
+"src/prov/tests/test_graphs.py" = ["E402"]
 
 [tool.pytest.ini_options]
 testpaths = ["src/prov/tests"]
 filterwarnings = [
-    "ignore:In prov 3.0:DeprecationWarning",
     "ignore:prov 3.0 will change unified:FutureWarning",
 ]
 

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-__version__ = "2.5.1"
+__version__ = "3.0.0.dev0"
 
 __all__ = ["Error", "model", "read"]
 

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -20,7 +20,7 @@ from typing import Any
 
 try:
     import pydot
-except ImportError as e:
+except ImportError as e:  # pragma: no cover -- pydot (dot extra) absent; covered by the minimal-install CI job
     raise ModuleNotFoundError(
         'prov.dot requires the optional "dot" extra; '
         'install "prov[dot]" to use graphical export'

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -14,24 +14,21 @@ References:
 
 from __future__ import annotations  # needed for | type annotations in Python < 3.10
 
-import warnings
 from datetime import datetime
 from html import escape
 from typing import Any
 
-import pydot
+try:
+    import pydot
+except ImportError as e:
+    raise ModuleNotFoundError(
+        'prov.dot requires the optional "dot" extra; '
+        'install "prov[dot]" to use graphical export'
+    ) from e
 
-warnings.warn(
-    "In prov 3.0, graphical export (prov.dot) will require the optional "
-    '"dot" extra; install "prov[dot]" to keep using it after upgrading. '
-    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from prov.graph import INFERRED_ELEMENT_CLASS  # noqa: E402
-from prov.identifier import QualifiedName  # noqa: E402
-from prov.model import (  # noqa: E402
+from prov.graph import INFERRED_ELEMENT_CLASS
+from prov.identifier import QualifiedName
+from prov.model import (
     PROV_ACTIVITY,
     PROV_AGENT,
     PROV_ALTERNATE,

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -4,7 +4,7 @@ from typing import Any
 
 try:
     import networkx as nx
-except ImportError as e:
+except ImportError as e:  # pragma: no cover -- networkx (graph extra) absent; covered by the minimal-install CI job
     raise ModuleNotFoundError(
         'prov.graph requires the optional "graph" extra; '
         'install "prov[graph]" to use NetworkX graph interop'

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
-import networkx as nx
+try:
+    import networkx as nx
+except ImportError as e:
+    raise ModuleNotFoundError(
+        'prov.graph requires the optional "graph" extra; '
+        'install "prov[graph]" to use NetworkX graph interop'
+    ) from e
 
 from prov.identifier import QualifiedName
 from prov.model import (
@@ -38,14 +43,6 @@ from prov.model import (
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-
-warnings.warn(
-    "In prov 3.0, graph export (prov.graph) will require the optional "
-    '"graph" extra; install "prov[graph]" to keep using it after upgrading. '
-    "See https://github.com/trungdong/prov/blob/master/ROADMAP.md",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 INFERRED_ELEMENT_CLASS = {

--- a/src/prov/tests/test_deprecations.py
+++ b/src/prov/tests/test_deprecations.py
@@ -1,34 +1,19 @@
-"""Covers the 2.4.0 deprecation signposts for 3.0 (roadmap step 26).
+"""Covers the 2.4.0 deprecation signpost for 3.0 (roadmap step 26) that is
+still pending.
 
-``prov.dot`` and ``prov.graph`` emit a module-level ``DeprecationWarning``
-pointing at the future ``prov[dot]``/``prov[graph]`` extras, and
 ``ProvBundle.unified()``/``ProvDocument.unified()`` emit a ``FutureWarning``
-about the PROV-CONSTRAINTS unification rework. The full narrative for both
-lives in docs/upgrading-3.0.md.
+about the PROV-CONSTRAINTS unification rework; the full narrative lives in
+docs/upgrading-3.0.md.
 
-Module-level warnings only fire once, at import time, so a test that isn't
-the first to import ``prov.dot``/``prov.graph`` (both are imported by other
-test modules in this suite) must ``importlib.reload()`` the module to
-observe the warning again.
+The matching ``prov.dot``/``prov.graph`` ``DeprecationWarning`` signposts
+(also covered here previously) came true in 3.0.0.dev0: those modules now
+require the ``dot``/``graph`` extras and raise ``ModuleNotFoundError``
+instead of warning -- see test_minimal_install.py.
 """
-
-import importlib
 
 import pytest
 
-import prov.dot
-import prov.graph
 from prov.model import ProvDocument
-
-
-def test_import_dot_warns_deprecation():
-    with pytest.warns(DeprecationWarning, match=r"prov\[dot\]"):
-        importlib.reload(prov.dot)
-
-
-def test_import_graph_warns_deprecation():
-    with pytest.warns(DeprecationWarning, match=r"prov\[graph\]"):
-        importlib.reload(prov.graph)
 
 
 def test_bundle_unified_warns_future():

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -10,9 +10,9 @@ import pytest
 
 pydot = pytest.importorskip("pydot")
 
-from prov.dot import htlm_link_if_uri, prov_to_dot  # noqa: E402
-from prov.model import ProvDocument  # noqa: E402
-from prov.tests import examples  # noqa: E402
+from prov.dot import htlm_link_if_uri, prov_to_dot
+from prov.model import ProvDocument
+from prov.tests import examples
 
 MIN_SVG_SIZE = 850
 

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -3,8 +3,6 @@ import io
 
 import pytest
 
-pytest.importorskip("pydot", reason="prov.dot requires the dot extra")
-
 from prov.constants import (
     PROV_ROLE,
     XSD,
@@ -12,7 +10,6 @@ from prov.constants import (
     XSD_DOUBLE,
     XSD_SHORT,
 )
-from prov.dot import prov_to_dot
 from prov.identifier import Namespace
 from prov.model import (
     Literal,
@@ -125,6 +122,9 @@ def add_further_attributes_with_qnames(record):
 def test_dot():
     # This is naive, since we can't programatically check the output is
     # correct
+    pytest.importorskip("pydot", reason="prov.dot requires the dot extra")
+    from prov.dot import prov_to_dot
+
     document = ProvDocument()
 
     bundle1 = ProvBundle(identifier=EX_NS["bundle1"])
@@ -326,6 +326,12 @@ def test_get_serializer_lazily_populates_registry():
 
 
 def test_plot_without_matplotlib_raises_helpful_error():
+    # plot()'s interactive path renders through prov.dot before it ever gets
+    # to the matplotlib check, so this test's premise (pydot present,
+    # matplotlib absent) needs pydot importable -- without it, prov.dot's own
+    # guard raises first with a "prov[dot]" message instead.
+    pytest.importorskip("pydot", reason="prov.dot requires the dot extra")
+
     # Deliberately exercises matplotlib's *absence*: builtins.__import__ is
     # patched to fail for matplotlib imports, so this import must stay local
     # to the test rather than move to module scope.

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -3,10 +3,24 @@ import io
 
 import pytest
 
-from prov.constants import PROV_ROLE, XSD, XSD_ANYURI, XSD_DOUBLE, XSD_SHORT
+pytest.importorskip("pydot", reason="prov.dot requires the dot extra")
+
+from prov.constants import (
+    PROV_ROLE,
+    XSD,
+    XSD_ANYURI,
+    XSD_DOUBLE,
+    XSD_SHORT,
+)
 from prov.dot import prov_to_dot
 from prov.identifier import Namespace
-from prov.model import Literal, ProvAgent, ProvBundle, ProvDocument, ProvException
+from prov.model import (
+    Literal,
+    ProvAgent,
+    ProvBundle,
+    ProvDocument,
+    ProvException,
+)
 from prov.serializers import DoNotExist, Registry, get as get_serializer
 from prov.serializers.provjson import ProvJSONSerializer
 from prov.serializers.provn import ProvNSerializer

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -1,5 +1,6 @@
-import networkx as nx
 import pytest
+
+nx = pytest.importorskip("networkx", reason="prov.graph requires the graph extra")
 
 from prov.graph import graph_to_prov, prov_to_graph
 from prov.model import ProvActivity, ProvDocument, ProvEntity

--- a/src/prov/tests/test_minimal_install.py
+++ b/src/prov/tests/test_minimal_install.py
@@ -1,10 +1,12 @@
 """Degradation behaviour when optional extras are missing.
 
-Run by the ``minimal-install`` CI job (which syncs without the rdf/xml
-extras). Under the normal matrix (extras installed) the skipif-guarded tests
-are skipped and the availability test asserts all four formats register.
+Run by the ``minimal-install`` CI job (which syncs without the rdf/xml/dot/
+graph extras). Under the normal matrix (extras installed) the skipif-guarded
+tests are skipped and the availability test asserts all four formats
+register.
 """
 
+import importlib
 import importlib.util
 
 import pytest
@@ -14,6 +16,8 @@ from prov.model import ProvDocument
 
 HAS_RDFLIB = importlib.util.find_spec("rdflib") is not None
 HAS_LXML = importlib.util.find_spec("lxml") is not None
+HAS_PYDOT = importlib.util.find_spec("pydot") is not None
+HAS_NETWORKX = importlib.util.find_spec("networkx") is not None
 
 
 def test_core_import_and_json_roundtrip() -> None:
@@ -42,3 +46,15 @@ def test_xml_unavailable_raises_informative_error() -> None:
 def test_all_formats_available_with_extras() -> None:
     for fmt in ("json", "provn", "rdf", "xml"):
         assert prov.serializers.get(fmt) is not None
+
+
+@pytest.mark.skipif(HAS_PYDOT, reason="only meaningful without pydot")
+def test_dot_unavailable_raises_informative_error() -> None:
+    with pytest.raises(ModuleNotFoundError, match=r"prov\[dot\]"):
+        importlib.import_module("prov.dot")
+
+
+@pytest.mark.skipif(HAS_NETWORKX, reason="only meaningful without networkx")
+def test_graph_unavailable_raises_informative_error() -> None:
+    with pytest.raises(ModuleNotFoundError, match=r"prov\[graph\]"):
+        importlib.import_module("prov.graph")

--- a/src/prov/tests/test_public_api.py
+++ b/src/prov/tests/test_public_api.py
@@ -5,6 +5,7 @@ Additions are fine; removals or moves are a breaking change (3.0 only).
 """
 
 import importlib
+import importlib.util
 import io
 
 import prov.serializers
@@ -92,10 +93,20 @@ PUBLIC_API = {
     "prov.graph": ["prov_to_graph", "graph_to_prov"],
 }
 
+# Modules importable only when their optional extra is installed (3.0);
+# the informative failure without the extra is covered by test_minimal_install.
+OPTIONAL_MODULE_REQUIREMENTS = {
+    "prov.dot": "pydot",
+    "prov.graph": "networkx",
+}
+
 
 def test_names_importable():
     missing = []
     for module_name, names in PUBLIC_API.items():
+        requirement = OPTIONAL_MODULE_REQUIREMENTS.get(module_name)
+        if requirement and importlib.util.find_spec(requirement) is None:
+            continue
         module = importlib.import_module(module_name)
         for name in names:
             if not hasattr(module, name):

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -316,7 +316,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -528,7 +528,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1121,7 +1121,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -1138,7 +1138,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1238,15 +1238,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1316,15 +1316,15 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -1474,12 +1474,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1496,12 +1496,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
@@ -1842,16 +1842,25 @@ wheels = [
 name = "prov"
 source = { editable = "." }
 dependencies = [
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydot" },
     { name = "python-dateutil" },
 ]
 
 [package.optional-dependencies]
+dot = [
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydot" },
+]
+graph = [
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 plot = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydot" },
 ]
 rdf = [
     { name = "rdflib" },
@@ -1887,12 +1896,15 @@ docs = [
 requires-dist = [
     { name = "lxml", marker = "extra == 'xml'", specifier = ">=3.3.5" },
     { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.6" },
-    { name = "networkx", specifier = ">=2.0" },
-    { name = "pydot", specifier = ">=1.2.0" },
+    { name = "networkx", marker = "extra == 'dot'", specifier = ">=2.0" },
+    { name = "networkx", marker = "extra == 'graph'", specifier = ">=2.0" },
+    { name = "networkx", marker = "extra == 'plot'", specifier = ">=2.0" },
+    { name = "pydot", marker = "extra == 'dot'", specifier = ">=1.2.0" },
+    { name = "pydot", marker = "extra == 'plot'", specifier = ">=1.2.0" },
     { name = "python-dateutil", specifier = ">=2.2" },
     { name = "rdflib", marker = "extra == 'rdf'", specifier = ">=6.0.0,<8" },
 ]
-provides-extras = ["rdf", "xml", "plot"]
+provides-extras = ["rdf", "xml", "dot", "graph", "plot"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2123,7 +2135,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -2452,23 +2464,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2485,23 +2497,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.11'" },
-    { name = "babel", marker = "python_full_version >= '3.11'" },
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "imagesize", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals-py" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Implements roadmap steps 36c/37 (see `docs/superpowers/specs/2026-07-03-modernisation-roadmap-design.md` and `ROADMAP.md`): the 2.4.0 deprecation signposted for `prov.dot`/`prov.graph` comes true.

- `pydot` and `networkx` are no longer unconditional runtime dependencies. `pyproject.toml`'s `[project] dependencies` now lists only `python-dateutil`.
- New `dot` and `graph` extras carry `pydot`/`networkx` respectively (`dot` also pulls in `networkx` since `prov.dot` renders through `prov.graph`); the existing `plot` extra now also pulls in `pydot`/`networkx` since `ProvBundle.plot()`/`ProvDocument.plot()` render through `prov.dot`.
- `import prov.dot` without the `dot` extra, and `import prov.graph` without the `graph` extra, now raise `ModuleNotFoundError` naming the extra to install, instead of the 2.4.0 `DeprecationWarning` (now removed).
- `prov.__version__` becomes `3.0.0.dev0`; `HISTORY.rst` gains a `3.0.0 (unreleased)` section.
- CI, RTD, `Makefile`, `CONTRIBUTING.rst`, `CLAUDE.md`, and `docs/dependencies.md`/`docs/installation.rst`/`docs/upgrading-3.0.md` updated to reflect the new extras and to sync them where the full suite or docs build needs them.

No public API changes and no other behaviour changes are smuggled in — this is purely the dependency-surface + version-bump step (roadmap step 36c/37), signposted since 2.4.0.

## Notable findings during implementation

- `test_deprecations.py` previously asserted the `prov.dot`/`prov.graph` `DeprecationWarning`s; those two tests are removed (the warnings they tested are gone), while its `FutureWarning` coverage for `unified()` (a separate, still-pending roadmap item) is kept.
- `test_extras.py` imports `prov.dot` at module level for an unrelated grab-bag of `ProvBundle`/serializer tests; it now needs `pytest.importorskip("pydot", ...)` too, so those unrelated tests are skipped without the `dot` extra (only relevant to the `minimal-install` CI job, which doesn't run this file anyway).
- Ruff's E402 check does not actually fire on the `pytest.importorskip(...)`-then-imports pattern used in `test_dot.py`/`test_graphs.py`/`test_extras.py` (confirmed empirically), so the `per-file-ignores` entries added for `test_dot.py`/`test_graphs.py` are effectively unnecessary defensive housekeeping; kept per the implementation plan.

## Test plan

- [x] `uv sync --extra rdf --extra xml --extra dot --extra graph && uv run pytest -q` → `1158 passed, 24 skipped, 14 xfailed`
- [x] `uv run pytest -q -W error::DeprecationWarning src/prov/tests/test_dot.py src/prov/tests/test_graphs.py` → `23 passed`
- [x] `uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src` → all clean
- [x] `uv sync --group dev` (extras dropped) → `uv run pytest src/prov/tests/test_minimal_install.py -v` → new dot/graph tests run (not skipped) and pass; `uv sync --extra rdf --extra xml --extra dot --extra graph` restores extras