### PR TITLE
Drop python-dateutil for stdlib xsd:dateTime parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,13 @@ History
 * BREAKING: the ``rdf`` extra now requires ``rdflib>=7.0.0`` (previously
   ``>=6.0.0``); internally the RDF serializer migrated from the deprecated
   ``ConjunctiveGraph`` to ``Dataset``, with unchanged round-trip behaviour
+* BREAKING: ``python-dateutil`` dropped — ``prov`` now has no unconditional
+  runtime dependencies. Datetime strings are parsed as ``xsd:dateTime``
+  (ISO 8601 plus the hour-24 end-of-day form) via the standard library;
+  factory ``time=``/``startTime=``/``endTime=`` parameters raise
+  ``ProvException`` on invalid input instead of leaking a raw dateutil
+  error, and non-ISO forms previously tolerated by dateutil (e.g.
+  ``"Nov 7, 2011"``) are no longer accepted (#237)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -8,17 +8,12 @@ below — they drift after the audit date above.
 
 ## Runtime dependencies (`[project.dependencies]`)
 
-These install unconditionally with `pip install prov`. Since 3.0.0.dev0 this is just
-`python-dateutil` — `pydot` and `networkx` moved behind the `dot`/`graph` extras below.
-
-- **`python-dateutil>=2.2`** — `dateutil.parser.parse()` in `src/prov/model.py` parses
-  ISO-8601-ish datetime strings from PROV-JSON/XML/RDF into `datetime` objects. There is a
-  long-standing `# TODO: is this really needed?` next to this entry — the stdlib
-  `datetime.fromisoformat()` couldn't handle the full range of formats PROV documents use
-  when this was added, but nobody has re-verified that against the current stdlib.
-  Left as-is; not in scope for this audit (would be a behaviour-risk change deferred to
-  3.0 if pursued) — Task 3 of the 3.0 batch-1 plan drops this dependency entirely in
-  favour of the stdlib parser, which will empty this section out.
+`prov` has **no unconditional runtime dependencies** as of 3.0.0.dev0. `pydot` and
+`networkx` moved behind the `dot`/`graph` extras (Task 1 of the 3.0 batch-1 plan);
+Task 3 dropped the last one, `python-dateutil` — datetime strings are now parsed by
+`prov.model.parse_xsd_datetime()`, a stdlib `datetime.fromisoformat()`-based `xsd:dateTime`
+parser, resolving the long-standing `# TODO: is this really needed?` that used to sit next
+to the `python-dateutil` entry here.
 
 ## Optional extras (`[project.optional-dependencies]`)
 
@@ -94,8 +89,6 @@ for end users.
 - **`types-networkx>=3.4.2.20250509`** — type stubs for `networkx`, needed for
   `mypy --strict` on `graph.py`. Pulls in `numpy` transitively (see the `numpy<2.5`
   constraint below).
-- **`types-python-dateutil>=2.9.0.20260124`** — type stubs for `python-dateutil`, needed
-  for `mypy --strict` on `model.py`'s datetime parsing.
 
 Previously in this group and removed by this audit: `bumpversion` (a release-time-only
 tool with no place in the routine dev loop — reintroduce as a dedicated group if release

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -9,11 +9,10 @@ below — they drift after the audit date above.
 ## Runtime dependencies (`[project.dependencies]`)
 
 `prov` has **no unconditional runtime dependencies** as of 3.0.0.dev0. `pydot` and
-`networkx` moved behind the `dot`/`graph` extras (Task 1 of the 3.0 batch-1 plan);
-Task 3 dropped the last one, `python-dateutil` — datetime strings are now parsed by
-`prov.model.parse_xsd_datetime()`, a stdlib `datetime.fromisoformat()`-based `xsd:dateTime`
-parser, resolving the long-standing `# TODO: is this really needed?` that used to sit next
-to the `python-dateutil` entry here.
+`networkx` moved behind the `dot`/`graph` extras, and `python-dateutil` was dropped in
+3.0 — datetime strings are now parsed by `prov.model.parse_xsd_datetime()`, a stdlib
+`datetime.fromisoformat()`-based `xsd:dateTime` parser, resolving the long-standing
+`# TODO: is this really needed?` that used to sit next to the `python-dateutil` entry here.
 
 ## Optional extras (`[project.optional-dependencies]`)
 

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -61,10 +61,6 @@ More caveats apply across many rows rather than to one:
 - **[#238](https://github.com/trungdong/prov/issues/238)** (JSON): `prov:QUALIFIED_NAME`-typed
   `Literal`s are stored opaquely by the model but resolved to `QualifiedName`s by the JSON
   decoder, so such a value mutates across a JSON round trip and breaks document equality.
-- **[#237](https://github.com/trungdong/prov/issues/237)** (model): every factory
-  `time=`/`startTime=`/`endTime=` parameter leaks a raw `dateutil` `ParserError` on
-  unparseable strings (instead of `ProvException`) and rejects the valid `xsd:dateTime`
-  hour-24 lexical form.
 - **[#259](https://github.com/trungdong/prov/issues/259)** (model): `Literal` language tags
   compare case-sensitively, diverging from RDF 1.1's case-insensitive language-tag value
   space (tags are never normalised, so values do survive round trips unchanged).

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -15,7 +15,7 @@ for the full rationale.
 |---|---|---|
 | **Done in 3.0.0.dev0:** `pydot`/Graphviz support (`prov.dot`, `prov_to_dot()`) moves behind the `dot` extra | Importing `prov.dot` emitted a `DeprecationWarning` (now removed) | Depend on `prov[dot]` instead of (or in addition to) `prov` if your code imports `prov.dot` or calls `prov_to_dot()`. |
 | **Done in 3.0.0.dev0:** `networkx` graph interop (`prov.graph`, `prov_to_graph()`/`graph_to_prov()`) moves behind the `graph` extra | Importing `prov.graph` emitted a `DeprecationWarning` (now removed) | Depend on `prov[graph]` instead of (or in addition to) `prov` if your code imports `prov.graph` or calls `prov_to_graph()`/`graph_to_prov()`. Note `prov.dot` itself uses `prov.graph`, so `prov[dot]` pulls in `prov[graph]`'s dependency (`networkx`) too. |
-| `python-dateutil` dropped in favour of the standard library's `datetime.fromisoformat()` | Not separately warned (internal dependency swap) | No action for typical ISO-8601 timestamps. If you rely on `dateutil.parser.parse()`'s more permissive parsing of non-ISO date/time strings inside PROV-JSON/XML/RDF documents, verify those strings still parse under 3.0 — `fromisoformat()` accepts a narrower grammar. |
+| `python-dateutil` dropped in favour of the standard library's `datetime.fromisoformat()` ([#237](https://github.com/trungdong/prov/issues/237)) | Not separately warned (internal dependency swap) | No action for typical ISO-8601 timestamps. If you rely on `dateutil.parser.parse()`'s more permissive parsing of non-ISO date/time strings inside PROV-JSON/XML/RDF documents, verify those strings still parse under 3.0 — `fromisoformat()` accepts a narrower grammar; bare `xsd:date` strings (e.g. `"2011-11-16"`) and free-form strings like `"Nov 7, 2011"` are no longer accepted. Two behaviour fixes ride along with the swap: factory `time=`/`startTime=`/`endTime=` parameters now raise `prov.model.ProvException` for unparseable strings (previously a raw `dateutil.parser.ParserError` leaked out), and the valid `xsd:dateTime` hour-24 end-of-day lexical form (e.g. `"2011-11-16T24:00:00"`) is now accepted instead of rejected. |
 | `rdf` extra floor raised to `rdflib>=7.0.0` | Not separately warned (dependency floor) | If you pin rdflib 6.x alongside `prov[rdf]`, upgrade to rdflib 7. Serialization differences are limited to those already present under rdflib 7 in 2.x (bundle-local namespaces appear as full IRIs in TriG; round-trip equality is unaffected). |
 
 A plain `pip install prov` keeps working for the core data model and the JSON/PROV-N
@@ -80,7 +80,9 @@ users will see it even without calling `unified()` themselves.
   extras above) — `import prov.dot` / `import prov.graph` will raise
   `ModuleNotFoundError` if the corresponding extra isn't installed, rather than working
   out of the box.
-- `python-dateutil` as a runtime dependency (superseded by the stdlib swap above).
+- `python-dateutil` as a runtime dependency (superseded by the stdlib swap above), along
+  with the incidental `prov.model.dateutil` module re-export that came from importing it
+  there.
 
 There are no other 2.4.0-introduced deprecations beyond these two extras moves; nothing
 else is scheduled for removal.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,8 @@ classifiers = [
     "Topic :: System :: Logging",
 ]
 requires-python = ">=3.10"
-dependencies = [
-    "python-dateutil>=2.2",  # removed in 3.0 Task 3 (stdlib xsd:dateTime parser)
-]
+# No unconditional runtime dependencies as of 3.0.
+dependencies = []
 
 [project.optional-dependencies]
 rdf = [
@@ -100,7 +99,6 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.20",
     "types-networkx>=3.4.2.20250509",
-    "types-python-dateutil>=2.9.0.20260124",
 ]
 docs = [
     "sphinx>=8.1.3,<9",

--- a/src/prov/model/__init__.py
+++ b/src/prov/model/__init__.py
@@ -23,8 +23,6 @@ from io import IOBase as IOBase
 from typing import Any as Any, Union as Union
 from urllib.parse import urlparse as urlparse
 
-import dateutil as dateutil
-
 from prov import Error as Error, serializers as serializers
 from prov.constants import *
 from prov.identifier import (

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -563,8 +563,8 @@ class ProvBundle:
 
         Args:
             identifier: The identifier for the new activity.
-            startTime: Optional start time, as a :class:`datetime.datetime` or a
-                string parseable by :func:`dateutil.parser.parse`
+            startTime: Optional start time, as a :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             endTime: Optional end time, in the same forms (default: ``None``).
             other_attributes: Optional attributes for the activity, as a dict or
@@ -599,8 +599,8 @@ class ProvBundle:
             activity: The activity (or its string identifier) involved in the
                 generation (default: ``None``).
             time: Optional time of the generation, as a
-                :class:`datetime.datetime` or a string parseable by
-                :func:`dateutil.parser.parse` (default: ``None``).
+                :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime` (default: ``None``).
             identifier: Optional identifier for the generation record
                 (default: ``None``).
             other_attributes: Optional extra attributes, as a dict or an
@@ -636,7 +636,8 @@ class ProvBundle:
             entity: The entity (or its string identifier) involved in the usage
                 relationship (default: ``None``).
             time: Optional time of the usage, as a :class:`datetime.datetime` or
-                a string parseable by :func:`dateutil.parser.parse`
+                an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             identifier: Optional identifier for the usage record
                 (default: ``None``).
@@ -676,7 +677,8 @@ class ProvBundle:
             starter: Optional activity qualifying the start, through which the
                 trigger entity is generated (default: ``None``).
             time: Optional time of the start, as a :class:`datetime.datetime` or
-                a string parseable by :func:`dateutil.parser.parse`
+                an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             identifier: Optional identifier for the start record
                 (default: ``None``).
@@ -716,8 +718,8 @@ class ProvBundle:
                 (default: ``None``).
             ender: Optional activity qualifying the end, through which the
                 trigger entity is generated (default: ``None``).
-            time: Optional time of the end, as a :class:`datetime.datetime` or a
-                string parseable by :func:`dateutil.parser.parse`
+            time: Optional time of the end, as a :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             identifier: Optional identifier for the end record
                 (default: ``None``).
@@ -755,8 +757,8 @@ class ProvBundle:
             activity: The activity (or its string identifier) involved in the
                 invalidation (default: ``None``).
             time: Optional time of the invalidation, as a
-                :class:`datetime.datetime` or a string parseable by
-                :func:`dateutil.parser.parse` (default: ``None``).
+                :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime` (default: ``None``).
             identifier: Optional identifier for the invalidation record
                 (default: ``None``).
             other_attributes: Optional extra attributes, as a dict or an

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -99,8 +99,8 @@ PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
 
 
 # Data Types
-_XSD_HOUR24_RE = re.compile(r"T24:00:00(\.0+)?(?=$|[Zz+-])")
-_XSD_ZULU_RE = re.compile(r"[Zz]$")
+_XSD_HOUR24_RE = re.compile(r"T24:00:00(\.0+)?(?=$|[Z+-])")
+_XSD_ZULU_RE = re.compile(r"Z$")
 _XSD_FRACTION_RE = re.compile(r"\.(\d+)")
 
 
@@ -154,10 +154,10 @@ def parse_xsd_datetime(value: str) -> datetime.datetime | None:
     )
     try:
         parsed = datetime.datetime.fromisoformat(text)
-    except ValueError:
+        if end_of_day:
+            parsed += datetime.timedelta(days=1)
+    except (ValueError, OverflowError):
         return None
-    if end_of_day:
-        parsed += datetime.timedelta(days=1)
     return parsed
 
 

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -5,12 +5,11 @@ from __future__ import annotations  # needed for | type annotations in Python < 
 import datetime
 import logging
 import os
+import re
 import typing  # noqa: F401 -- used by `# type: typing.TypeAlias` comments below
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Union
-
-import dateutil.parser
 
 from prov import Error
 from prov.constants import (
@@ -100,33 +99,66 @@ PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
 
 
 # Data Types
+_XSD_HOUR24_RE = re.compile(r"T24:00:00(\.0+)?(?=$|[Zz+-])")
+_XSD_ZULU_RE = re.compile(r"[Zz]$")
+_XSD_FRACTION_RE = re.compile(r"\.(\d+)")
+
+
 def _ensure_datetime(value: DatetimeOrStr | None) -> datetime.datetime | None:
     """Coerce a value to a :class:`datetime.datetime`.
 
-    A string is parsed with :func:`dateutil.parser.parse`; a
+    A string is parsed with :func:`parse_xsd_datetime`; a
     :class:`~datetime.datetime` or ``None`` is returned unchanged.
+
+    Raises:
+        ProvException: If a string value is not a valid ``xsd:dateTime``.
     """
     if isinstance(value, str):
-        return dateutil.parser.parse(value)
-    else:
-        return value
+        parsed = parse_xsd_datetime(value)
+        if parsed is None:
+            raise ProvException(f"Invalid xsd:dateTime value: {value!r}")
+        return parsed
+    return value
 
 
 def parse_xsd_datetime(value: str) -> datetime.datetime | None:
     """Parse an ``xsd:dateTime`` string into a :class:`datetime.datetime`.
 
+    Accepts the ``xsd:dateTime`` lexical space: ISO 8601 date-time with
+    optional fractional seconds and timezone, ``Z`` for UTC, and the
+    hour-24 end-of-day form (which maps to 00:00:00 of the following day,
+    per the XSD value space).
+
     Args:
         value: The date/time string to parse.
 
     Returns:
-        The parsed :class:`~datetime.datetime`, or ``None`` if ``value`` could
-        not be parsed.
+        The parsed :class:`~datetime.datetime`, or ``None`` if ``value``
+        could not be parsed.
     """
+    text = value.strip()
+    if "T" not in text:
+        # xsd:dateTime requires a literal "T" date/time separator; bare
+        # xsd:date strings (e.g. "2011-11-16") are a distinct, narrower
+        # datatype and are intentionally not accepted here (3.0 narrowing).
+        return None
+    end_of_day = _XSD_HOUR24_RE.search(text) is not None
+    if end_of_day:
+        text = _XSD_HOUR24_RE.sub("T00:00:00", text)
+    # datetime.fromisoformat on Python 3.10 accepts neither the "Z" suffix
+    # nor fractional seconds that are not exactly 3 or 6 digits long;
+    # normalize both before parsing.
+    text = _XSD_ZULU_RE.sub("+00:00", text)
+    text = _XSD_FRACTION_RE.sub(
+        lambda m: "." + m.group(1)[:6].ljust(6, "0"), text, count=1
+    )
     try:
-        return dateutil.parser.parse(value)
+        parsed = datetime.datetime.fromisoformat(text)
     except ValueError:
-        pass
-    return None
+        return None
+    if end_of_day:
+        parsed += datetime.timedelta(days=1)
+    return parsed
 
 
 def parse_boolean(value: str) -> bool | None:
@@ -775,8 +807,8 @@ class ProvEntity(ProvElement):
             activity: The activity (or its string identifier) involved in the
                 generation (default: ``None``).
             time: Optional time of the generation, as a
-                :class:`datetime.datetime` or a string parseable by
-                :func:`dateutil.parser.parse` (default: ``None``).
+                :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime` (default: ``None``).
             attributes: Optional extra attributes for the record, as a dict or
                 an iterable of ``(name, value)`` pairs (default: ``None``).
 
@@ -798,8 +830,8 @@ class ProvEntity(ProvElement):
             activity: The activity (or its string identifier) involved in the
                 invalidation; may be ``None``.
             time: Optional time of the invalidation, as a
-                :class:`datetime.datetime` or a string parseable by
-                :func:`dateutil.parser.parse` (default: ``None``).
+                :class:`datetime.datetime` or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime` (default: ``None``).
             attributes: Optional extra attributes for the record, as a dict or
                 an iterable of ``(name, value)`` pairs (default: ``None``).
 
@@ -1067,7 +1099,8 @@ class ProvActivity(ProvElement):
             entity: The entity (or its string identifier) involved in the
                 usage relationship.
             time: Optional time of the usage, as a :class:`datetime.datetime`
-                or a string parseable by :func:`dateutil.parser.parse`
+                or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             attributes: Optional extra attributes for the record, as a dict or
                 an iterable of ``(name, value)`` pairs (default: ``None``).
@@ -1111,7 +1144,8 @@ class ProvActivity(ProvElement):
             starter: Optional activity qualifying the start, through which the
                 trigger entity is generated (default: ``None``).
             time: Optional time of the start, as a :class:`datetime.datetime`
-                or a string parseable by :func:`dateutil.parser.parse`
+                or an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             attributes: Optional extra attributes for the record, as a dict or
                 an iterable of ``(name, value)`` pairs (default: ``None``).
@@ -1137,7 +1171,8 @@ class ProvActivity(ProvElement):
             ender: Optional activity qualifying the end, through which the
                 trigger entity is generated (default: ``None``).
             time: Optional time of the end, as a :class:`datetime.datetime` or
-                a string parseable by :func:`dateutil.parser.parse`
+                an ``xsd:dateTime`` string accepted by
+                :func:`~prov.model.parse_xsd_datetime`
                 (default: ``None``).
             attributes: Optional extra attributes for the record, as a dict or
                 an iterable of ``(name, value)`` pairs (default: ``None``).

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -5,12 +5,12 @@ from __future__ import annotations  # needed for | type annotations in Python < 
 import base64
 import datetime
 import io
+import re
 import warnings
 from collections import OrderedDict
 from collections.abc import Generator
 from typing import Any, cast
 
-import dateutil.parser
 from rdflib import RDF, RDFS, XSD
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Dataset, Graph
 from rdflib.term import BNode, Literal as RDFLiteral, Node, URIRef
@@ -84,6 +84,9 @@ class AnonymousIDGenerator:
             self._cache[obj] = f"_:{local_prefix}{self._count}"
         return self._cache[obj]
 
+
+_XSD_GYEAR_RE = re.compile(r"^(-?\d{4,})(?:Z|[+-]\d{2}:\d{2})?$")
+_XSD_GYEARMONTH_RE = re.compile(r"^(-?\d{4,})-(\d{2})(?:Z|[+-]\d{2}:\d{2})?$")
 
 # Reverse map for prov.model.XSD_DATATYPE_PARSERS
 LITERAL_XSDTYPE_MAP = {
@@ -320,16 +323,24 @@ class ProvRDFSerializer(Serializer):
             if datatype == XSD["QName"]:
                 return pm.Literal(literal, datatype=XSD_QNAME)
             if datatype == XSD["dateTime"]:
-                return dateutil.parser.parse(literal)
+                parsed = pm.parse_xsd_datetime(str(literal))
+                if parsed is None:
+                    raise ValueError(f"Invalid xsd:dateTime literal: {literal}")
+                return parsed
             if datatype == XSD["gYear"]:
+                year_match = _XSD_GYEAR_RE.match(str(literal))
+                if year_match is None:
+                    raise ValueError(f"Invalid xsd:gYear literal: {literal}")
                 return pm.Literal(
-                    dateutil.parser.parse(literal).year,
+                    int(year_match.group(1)),
                     datatype=self.valid_identifier(datatype),
                 )
             if datatype == XSD["gYearMonth"]:
-                parsed_info = dateutil.parser.parse(literal)
+                ym_match = _XSD_GYEARMONTH_RE.match(str(literal))
+                if ym_match is None:
+                    raise ValueError(f"Invalid xsd:gYearMonth literal: {literal}")
                 return pm.Literal(
-                    f"{parsed_info.year}-{parsed_info.month:02d}",
+                    f"{int(ym_match.group(1))}-{int(ym_match.group(2)):02d}",
                     datatype=self.valid_identifier(datatype),
                 )
             else:

--- a/src/prov/tests/test_conformance_dm.py
+++ b/src/prov/tests/test_conformance_dm.py
@@ -8,11 +8,11 @@ Audit authority: docs/superpowers/specs/2026-07-10-conformance-audit-findings.md
 section 2.
 """
 
+import datetime
 import os
 import tempfile
 
 import pytest
-from dateutil.parser import ParserError
 
 import prov
 from prov.model import (
@@ -61,32 +61,18 @@ def test_qualified_name_literal_roundtrip_equality():
     assert ProvDocument.deserialize(content=content, format="json") == document
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=ParserError,
-    reason=(
-        "#237: PROV-DM §5.7.3 — factory time parameters leak raw dateutil "
-        "ParserError instead of ProvException"
-    ),
-)
 def test_factory_time_parse_error_raises_prov_exception():
+    # #237 (fixed in 3.0): raw dateutil ParserError no longer leaks
     document = _doc()
     with pytest.raises(ProvException):
         document.activity("ex:a1", startTime="not a date")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=ParserError,
-    reason=(
-        "#237: PROV-DM §5.7.3 — the valid xsd:dateTime hour-24 lexical form is "
-        "rejected (dateutil ParserError)"
-    ),
-)
 def test_factory_time_accepts_hour24_datetime():
+    # #237 (fixed in 3.0): xsd:dateTime end-of-day form is valid
     document = _doc()
     activity = document.activity("ex:a1", startTime="2011-11-16T24:00:00")
-    assert activity.get_startTime() is not None
+    assert activity.get_startTime() == datetime.datetime(2011, 11, 17, 0, 0)
 
 
 def test_read_autodetects_prov_xml(tmp_path):

--- a/src/prov/tests/test_datetime_parsing.py
+++ b/src/prov/tests/test_datetime_parsing.py
@@ -42,6 +42,19 @@ UTC = datetime.timezone.utc
         ("2011-11-16T24:00:00", datetime.datetime(2011, 11, 17, 0, 0)),
         ("2011-11-16T24:00:00.000Z", datetime.datetime(2011, 11, 17, 0, 0, tzinfo=UTC)),
         ("2011-12-31T24:00:00", datetime.datetime(2012, 1, 1, 0, 0)),
+        # hour-24 combined with a non-Zulu numeric offset: the offset is
+        # attached to the rolled-over (next-day) datetime, not the original.
+        (
+            "2011-11-16T24:00:00+05:30",
+            datetime.datetime(
+                2011,
+                11,
+                17,
+                0,
+                0,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)),
+            ),
+        ),
     ],
 )
 def test_parse_xsd_datetime_accepts(text, expected):
@@ -56,6 +69,8 @@ def test_parse_xsd_datetime_accepts(text, expected):
         "2011-11-16",  # xsd:date, not xsd:dateTime (no time part) — pre-3.0 dateutil accepted it; now rejected
         "2011-11-16T24:30:00",  # hour 24 is only valid with 00:00 minutes/seconds
         "Nov 7, 2011",  # dateutil-style leniency is gone in 3.0
+        "9999-12-31T24:00:00",  # legal hour-24 form, but rollover overflows datetime.MAXYEAR
+        "2011-11-16T21:08:16z",  # lowercase "z" is not a valid xsd:dateTime UTC designator
     ],
 )
 def test_parse_xsd_datetime_rejects(text):

--- a/src/prov/tests/test_datetime_parsing.py
+++ b/src/prov/tests/test_datetime_parsing.py
@@ -1,0 +1,69 @@
+"""Unit tests for the stdlib-based xsd:dateTime parser (3.0 dateutil drop, #237)."""
+
+import datetime
+
+import pytest
+
+from prov.model import ProvDocument, ProvException, parse_xsd_datetime
+
+UTC = datetime.timezone.utc
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "2012-12-03T21:08:16.686Z",
+            datetime.datetime(2012, 12, 3, 21, 8, 16, 686000, tzinfo=UTC),
+        ),
+        ("2012-12-03T21:08:16", datetime.datetime(2012, 12, 3, 21, 8, 16)),
+        (
+            "2012-12-03T21:08:16+05:30",
+            datetime.datetime(
+                2012,
+                12,
+                3,
+                21,
+                8,
+                16,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)),
+            ),
+        ),
+        # fractional seconds of any length (fromisoformat on 3.10 takes only 3 or 6 digits)
+        (
+            "2012-12-03T21:08:16.68Z",
+            datetime.datetime(2012, 12, 3, 21, 8, 16, 680000, tzinfo=UTC),
+        ),
+        (
+            "2012-12-03T21:08:16.1234567Z",
+            datetime.datetime(2012, 12, 3, 21, 8, 16, 123456, tzinfo=UTC),
+        ),
+        # xsd:dateTime end-of-day form maps to 00:00:00 of the next day
+        ("2011-11-16T24:00:00", datetime.datetime(2011, 11, 17, 0, 0)),
+        ("2011-11-16T24:00:00.000Z", datetime.datetime(2011, 11, 17, 0, 0, tzinfo=UTC)),
+        ("2011-12-31T24:00:00", datetime.datetime(2012, 1, 1, 0, 0)),
+    ],
+)
+def test_parse_xsd_datetime_accepts(text, expected):
+    assert parse_xsd_datetime(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not a date",
+        "",
+        "2011-11-16",  # xsd:date, not xsd:dateTime (no time part) — pre-3.0 dateutil accepted it; now rejected
+        "2011-11-16T24:30:00",  # hour 24 is only valid with 00:00 minutes/seconds
+        "Nov 7, 2011",  # dateutil-style leniency is gone in 3.0
+    ],
+)
+def test_parse_xsd_datetime_rejects(text):
+    assert parse_xsd_datetime(text) is None
+
+
+def test_factory_rejects_bad_time_with_prov_exception():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    with pytest.raises(ProvException):
+        document.activity("ex:a1", startTime="not a date")

--- a/src/prov/tests/test_statements.py
+++ b/src/prov/tests/test_statements.py
@@ -9,12 +9,18 @@ parametrization so the rdf param can be skipped (issue #217; see the
 not-yet-migrated ``test_dot.py``.
 """
 
+import datetime
+
 import pytest
 
 from prov.model import *
 
 EX_NS = Namespace("ex", "http://example.org/")
 EX2_NS = Namespace("ex2", "http://example2.org/")
+
+_TIME_2012 = datetime.datetime(
+    2012, 12, 3, 21, 8, 16, 686000, tzinfo=datetime.timezone.utc
+)
 
 # The 14 "scruffy" documents below add two relations sharing one identifier
 # but differing prov:time; PROV-O cannot represent this (both times serialize
@@ -1353,7 +1359,7 @@ def test_scruffy_generation_1(roundtrip):
         EX_NS["e1"],
         EX_NS["a1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     document.entity(identifier=EX_NS["e1"])
     document.activity(identifier=EX_NS["a1"])
@@ -1373,7 +1379,7 @@ def test_scruffy_generation_2(roundtrip):
         EX_NS["e1"],
         EX_NS["a1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     gen1.add_attributes([(EX_NS["tag2"], "hello-scruff-gen2")])
     gen2.add_attributes([(EX_NS["tag2"], "hi-scruff-gen2")])
@@ -1395,7 +1401,7 @@ def test_scruffy_invalidation_1(roundtrip):
         EX_NS["e1"],
         EX_NS["a1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     document.entity(identifier=EX_NS["e1"])
     document.activity(identifier=EX_NS["a1"])
@@ -1415,7 +1421,7 @@ def test_scruffy_invalidation_2(roundtrip):
         EX_NS["e1"],
         EX_NS["a1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     inv1.add_attributes([(EX_NS["tag2"], "hello")])
     inv2.add_attributes([(EX_NS["tag2"], "hi")])
@@ -1437,7 +1443,7 @@ def test_scruffy_usage_1(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     document.entity(identifier=EX_NS["e1"])
     document.activity(identifier=EX_NS["a1"])
@@ -1457,7 +1463,7 @@ def test_scruffy_usage_2(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     use1.add_attributes([(EX_NS["tag2"], "hello")])
     use2.add_attributes([(EX_NS["tag2"], "hi")])
@@ -1479,7 +1485,7 @@ def test_scruffy_start_1(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     document.entity(identifier=EX_NS["e1"])
     document.activity(identifier=EX_NS["a1"])
@@ -1499,7 +1505,7 @@ def test_scruffy_start_2(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     start1.add_attributes([(EX_NS["tag2"], "hello")])
     start2.add_attributes([(EX_NS["tag2"], "hi")])
@@ -1522,7 +1528,7 @@ def test_scruffy_start_3(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
         starter=EX_NS["a2s"],
     )
     start1.add_attributes([(EX_NS["tag2"], "hello")])
@@ -1548,7 +1554,7 @@ def test_scruffy_start_4(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
         starter=EX_NS["a2s"],
     )
     start1.add_attributes([(EX_NS["tag2"], "hello")])
@@ -1574,7 +1580,7 @@ def test_scruffy_end_1(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     document.entity(identifier=EX_NS["e1"])
     document.activity(identifier=EX_NS["a1"])
@@ -1594,7 +1600,7 @@ def test_scruffy_end_2(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
     )
     end1.add_attributes([(EX_NS["tag2"], "hello")])
     end2.add_attributes([(EX_NS["tag2"], "hi")])
@@ -1617,7 +1623,7 @@ def test_scruffy_end_3(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
         ender=EX_NS["a2s"],
     )
     end1.add_attributes([(EX_NS["tag2"], "hello")])
@@ -1643,7 +1649,7 @@ def test_scruffy_end_4(roundtrip):
         EX_NS["a1"],
         EX_NS["e1"],
         identifier=EX_NS["gen1"],
-        time=dateutil.parser.parse("2012-12-03T21:08:16.686Z"),
+        time=_TIME_2012,
         ender=EX_NS["a2s"],
     )
     end1.add_attributes([(EX_NS["tag2"], "hello")])

--- a/uv.lock
+++ b/uv.lock
@@ -1838,9 +1838,6 @@ wheels = [
 [[package]]
 name = "prov"
 source = { editable = "." }
-dependencies = [
-    { name = "python-dateutil" },
-]
 
 [package.optional-dependencies]
 dot = [
@@ -1878,7 +1875,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-networkx" },
-    { name = "types-python-dateutil" },
 ]
 docs = [
     { name = "furo" },
@@ -1898,7 +1894,6 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'plot'", specifier = ">=2.0" },
     { name = "pydot", marker = "extra == 'dot'", specifier = ">=1.2.0" },
     { name = "pydot", marker = "extra == 'plot'", specifier = ">=1.2.0" },
-    { name = "python-dateutil", specifier = ">=2.2" },
     { name = "rdflib", marker = "extra == 'rdf'", specifier = ">=7.0.0,<8" },
 ]
 provides-extras = ["rdf", "xml", "dot", "graph", "plot"]
@@ -1915,7 +1910,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.20" },
     { name = "types-networkx", specifier = ">=3.4.2.20250509" },
-    { name = "types-python-dateutil", specifier = ">=2.9.0.20260124" },
 ]
 docs = [
     { name = "furo" },
@@ -2662,15 +2656,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/f9/975c2bb35407c241fb788e9c75b2e2642af43a6c9cf81056a119dd98e59c/types_networkx-3.6.1.20260624.tar.gz", hash = "sha256:f031a9ee0bd27de4ab6d3e35a10f3492a4befc7b8c348607892b0ccb1b415d4d", size = 74060, upload-time = "2026-06-24T05:56:25.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/d4/67136d3323dd8a8ecc8124531f737dee97819811026da20a2a72949f462a/types_networkx-3.6.1.20260624-py3-none-any.whl", hash = "sha256:071734f88733afaaa06cbb62eb8c603626f4f9aa18424771acbdd3a638828d9a", size = 162457, upload-time = "2026-06-24T05:56:24.063Z" },
-]
-
-[[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20260518"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Reimplements `parse_xsd_datetime` on `datetime.fromisoformat` with xsd:dateTime normalization: `Z` suffix → `+00:00`, fractional seconds padded/truncated to microsecond precision, and the hour-24 end-of-day lexical form mapped to `00:00:00` of the following day.
- Factory `time=`/`startTime=`/`endTime=` parameters (`_ensure_datetime`) now raise `ProvException` for unparseable strings instead of leaking a raw `dateutil.parser.ParserError`.
- `src/prov/serializers/provrdf.py`'s `xsd:dateTime`/`gYear`/`gYearMonth` decoding is reimplemented on the new parser plus small regexes, dropping its `dateutil.parser` usage too.
- Removes the incidental `prov.model.dateutil` module re-export (`import dateutil as dateutil` in `src/prov/model/__init__.py`).
- Drops `python-dateutil` from `[project.dependencies]` (now `[]`) and `types-python-dateutil` from the dev group; `prov` has no unconditional runtime dependencies as of 3.0.
- Design note: bare `xsd:date` strings (e.g. `"2011-11-16"`) and free-form strings dateutil used to tolerate (e.g. `"Nov 7, 2011"`) are now rejected — a deliberate 3.0 narrowing, not a bug.

Roadmap step 36c (prov 3.0 batch-1 floor-raising). Closes #237.

## Test plan

- [x] New `src/prov/tests/test_datetime_parsing.py` unit tests for `parse_xsd_datetime` (accept/reject cases, hour-24, fractional seconds, factory `ProvException`)
- [x] `src/prov/tests/test_conformance_dm.py`'s two `#237` strict-xfail tests flipped to plain passing tests (xfail count 14 → 12)
- [x] `src/prov/tests/test_statements.py`'s 14 `dateutil.parser.parse(...)` call sites replaced with a shared `_TIME_2012` constant
- [x] Full suite green on Python 3.10 and 3.13 with all extras: `1174 passed, 24 skipped, 12 xfailed`
- [x] Hypothesis round-trip property (`test_property_roundtrip.py`) stays green
- [x] `mypy src`, `ruff check src/`, `ruff format --check src/` all clean
- [x] `grep -rn dateutil src/ pyproject.toml` — no hits outside historical test comments
- [x] Sphinx docs build clean (`sphinx-build -b html docs docs/_build/html -W`)