### PR TITLE
Close out the pyupgrade ratchet: prune stale __future__ annotations imports

### DIFF
--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: TYPE_CHECKING names in signatures
 
 import io
 import logging

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -12,8 +12,6 @@ References:
 .. moduleauthor:: Trung Dong Huynh <trungdong@donggiang.com>
 """
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
-
 from datetime import datetime
 from html import escape
 from typing import Any

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # defer eval: MultiDiGraph isn't subscriptable
 
 from typing import Any
 

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: Namespace used before it's defined
 
 from typing import Any
 

--- a/src/prov/model/__init__.py
+++ b/src/prov/model/__init__.py
@@ -7,8 +7,6 @@ PROV-DM: http://www.w3.org/TR/prov-dm/
 PROV-JSON: https://openprovenance.org/prov-json/
 """
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
-
 import datetime as datetime
 import io as io
 import itertools as itertools

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -1,6 +1,6 @@
 """PROV bundles and documents: containers of PROV records."""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: ProvDocument used before it's defined
 
 import io
 import itertools

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -1,6 +1,6 @@
 """Namespace management for PROV documents and bundles."""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: refs itself before class is defined
 
 from collections.abc import Iterable
 

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -1,6 +1,6 @@
 """Namespace management for PROV documents and bundles."""
 
-from __future__ import annotations  # defer eval: refs itself before class is defined
+from __future__ import annotations  # defer eval: NamespaceManager self-refs in __init__
 
 from collections.abc import Iterable
 

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -1,6 +1,6 @@
 """PROV-DM records: elements, relations, literals, and datatype helpers."""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: TYPE_CHECKING names in signatures
 
 import datetime
 import logging

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -12,8 +12,6 @@ prov-compare -- Compare two PROV-JSON, PROV-XML, or RDF (PROV-O) files for equiv
 @deffield    updated: 2025-06-07
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import sys

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -12,8 +12,6 @@ convert -- Convert PROV-JSON to RDF, PROV-N, PROV-XML, or graphical formats (SVG
 @deffield    updated: 2025-06-07
 """
 
-from __future__ import annotations
-
 import io
 import logging
 import os

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
+from __future__ import annotations  # defer eval: TYPE_CHECKING names in signatures
 
 import io
 from abc import ABC, abstractmethod

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -1,7 +1,5 @@
 """PROV-JSON serializer for ProvDocument."""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
-
 import datetime
 import io
 import json

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1,7 +1,5 @@
 """PROV-RDF serializers for ProvDocument"""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
-
 import base64
 import datetime
 import io

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -1,7 +1,5 @@
 """PROV-XML serializer for ProvDocument."""
 
-from __future__ import annotations  # needed for | type annotations in Python < 3.10
-
 import datetime
 import io
 import logging


### PR DESCRIPTION
## Summary

Roadmap step 34: audit the 14 `from __future__ import annotations` lines (a
3.9-era artifact) across the codebase, confirming `UP` (pyupgrade) ruff rules
have nothing left to flag at the py310 floor.

The plan anticipated the load-bearing cases would only be files with
`if TYPE_CHECKING:` imports used in runtime-evaluated signatures. That's true
for 3 of the 14 files, but the empirical check (`import` on Python 3.10,
which evaluates annotations eagerly, unlike 3.14's deferred evaluation)
turned up 4 more load-bearing cases the plan didn't anticipate: intra-module
forward references, where a signature names a class defined later in the
same file, or a third-party generic that isn't subscriptable at runtime.

**Kept (load-bearing), with the reason:**

| File | Reason |
|---|---|
| `src/prov/__init__.py` | `TYPE_CHECKING`-only `ProvDocument` used in `read()`'s return annotation |
| `src/prov/serializers/__init__.py` | `TYPE_CHECKING`-only `ProvDocument` used in `Serializer.__init__`/`.deserialize()` signatures |
| `src/prov/model/records.py` | `TYPE_CHECKING`-only `ProvBundle` used in `ProvRecord.__init__`/`.bundle` signatures |
| `src/prov/identifier.py` | `QualifiedName.__init__`'s `namespace: Namespace` parameter names `Namespace`, defined later in the same module |
| `src/prov/model/bundle.py` | `ProvBundle`'s signatures (e.g. `document: ProvDocument \| None`) name `ProvDocument`, a subclass defined later in the same module |
| `src/prov/model/namespaces.py` | `NamespaceManager.__init__`'s `parent: NamespaceManager \| None` parameter names the class before its own definition finishes |
| `src/prov/graph.py` | `-> nx.MultiDiGraph[Any]` return annotations: the installed networkx's `MultiDiGraph` has no `__class_getitem__`, so eager evaluation raises `TypeError: 'type' object is not subscriptable` |

Each of these was verified empirically: removing the future-import and
running `python -c "import <module>"` on Python 3.10 raises `NameError` (or,
for `graph.py`, `TypeError`) at import time. Comments were kept short (all
`from __future__ import annotations  # ...` lines are ≤88 chars) so
`ruff format` doesn't wrap them into a multi-line import statement.

**Dropped (inert — no `TYPE_CHECKING` block, no forward references, imports
cleanly on 3.10 without it):** `src/prov/dot.py`, `src/prov/serializers/provjson.py`,
`src/prov/serializers/provrdf.py`, `src/prov/serializers/provxml.py`,
`src/prov/scripts/convert.py`, `src/prov/scripts/compare.py`,
`src/prov/model/__init__.py`.

Also removed the stale `# needed for | type annotations in Python < 3.10`
comment everywhere it appeared — PEP 604 `X | Y` unions are native at the
py310 floor, so that stated reason was never accurate; every surviving
future-import now carries a comment describing the *actual* reason it's
load-bearing.

No runtime behaviour changes — this is purely pruning/annotating import
lines.

## Test plan
- [x] `uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q` → `1177 passed, 24 skipped, 12 xfailed`
- [x] `uv run pytest -q` (default interpreter) → `1177 passed, 24 skipped, 12 xfailed`
- [x] `uv run mypy src` → `Success: no issues found in 17 source files`
- [x] `uv run ruff check src/` → `All checks passed!`
- [x] `uv run ruff format --check src/` → `48 files already formatted`
- [x] `uv run ruff check --select UP src/` → `All checks passed!`
- [x] `grep -rn "type annotations in Python" src/` → no hits