### PR TITLE
Decompose the PROV-O encode/decode container functions into per-record-type dispatch (#274)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,6 +50,9 @@ History
 * PROV-N output escapes qualified-name local parts per the grammar's
   ``PN_CHARS_ESC`` production, so identifiers containing ``' ( ) , : ; [ ]
   =`` no longer produce invalid PROV-N (#223)
+* Internal: the PROV-O (RDF) serializer's encode/decode container functions
+  were decomposed into per-record-type dispatch (cyclomatic complexity 81/66
+  → under 15 per function), with byte-identical output (#274)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -6,7 +6,8 @@ import io
 import re
 import warnings
 from collections import OrderedDict
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 from rdflib import RDF, RDFS, XSD
@@ -17,7 +18,6 @@ import prov.model as pm
 from prov import Error
 from prov.constants import (
     PROV,
-    PROV_ACTIVITY,
     PROV_ALTERNATE,
     PROV_ASSOCIATION,
     PROV_ATTR_ENDER,
@@ -170,6 +170,159 @@ PREDICATE_MAP = {
 :meth:`~ProvRDFSerializer.decode_container`: maps PROV-O predicate URIRefs
 that don't already match a PROV formal-attribute QualifiedName to the
 QualifiedName of the formal attribute they represent."""
+
+
+#: Relation types whose two leading formal attributes are *not* emitted as a
+#: plain binary ``subject predicate object`` triple when the relation is
+#: unidentified -- unless those two attributes are the only thing it carries.
+#: Everything else about them lives on the ``prov:qualified*`` node instead.
+_QUALIFIED_ONLY_RELATIONS = frozenset(
+    {
+        PROV_END,
+        PROV_START,
+        PROV_USAGE,
+        PROV_GENERATION,
+        PROV_DERIVATION,
+        PROV_ASSOCIATION,
+        PROV_INVALIDATION,
+    }
+)
+
+#: ``prov:type`` values that rename a derivation's qualification node, e.g. a
+#: derivation typed ``prov:Revision`` is qualified via ``prov:qualifiedRevision``
+#: and typed ``prov:Revision`` rather than ``prov:Derivation``.
+_DERIVATION_SUBTYPES = frozenset(
+    {PROV["Revision"], PROV["Quotation"], PROV["PrimarySource"]}
+)
+
+
+def _prov_uri(localpart: str) -> URIRef:
+    """Return the ``prov:`` predicate URIRef for a PROV-O term local part."""
+    return URIRef(PROV[localpart].uri)
+
+
+#: Per-record-type predicate rewrites applied, in order, to the predicate
+#: chosen for a qualified relation's attribute. Each entry is a
+#: ``(needle, replacement)`` pair: when ``needle`` (a full ``prov:`` term URI)
+#: occurs in the predicate computed so far, the predicate becomes
+#: ``replacement``. Rewrites are sequential -- a later pair sees the result of
+#: an earlier one -- which is what lets e.g. ``prov:used`` become
+#: ``prov:entity`` on a usage before the shared time/location rewrites run.
+#:
+#: This table replaces the per-type ``if`` ladder that used to live inline in
+#: :meth:`ProvRDFSerializer.encode_container`; the ordering here reproduces
+#: that ladder exactly. The ladder's ``rec_type in [PROV_ACTIVITY]`` arm is
+#: deliberately absent: it was unreachable (this code only ever runs for
+#: records where ``is_relation()`` is true, so ``rec_type`` is never an
+#: element type) and would have raised ``TypeError`` had it been reached.
+_TIMED_INFLUENCE_REWRITES = (
+    (PROV["time"].uri, _prov_uri("atTime")),
+    (PROV["ender"].uri, _prov_uri("hadActivity")),
+    (PROV["starter"].uri, _prov_uri("hadActivity")),
+    (PROV["location"].uri, _prov_uri("atLocation")),
+)
+_RELATION_PREDICATE_REWRITES: dict[QualifiedName, tuple[tuple[str, URIRef], ...]] = {
+    PROV_DELEGATION: ((PROV["activity"].uri, _prov_uri("hadActivity")),),
+    PROV_END: ((PROV["trigger"].uri, _prov_uri("entity")), *_TIMED_INFLUENCE_REWRITES),
+    PROV_START: (
+        (PROV["trigger"].uri, _prov_uri("entity")),
+        *_TIMED_INFLUENCE_REWRITES,
+    ),
+    PROV_USAGE: ((PROV["used"].uri, _prov_uri("entity")), *_TIMED_INFLUENCE_REWRITES),
+    PROV_GENERATION: _TIMED_INFLUENCE_REWRITES,
+    PROV_INVALIDATION: _TIMED_INFLUENCE_REWRITES,
+    PROV_DERIVATION: (
+        (PROV["activity"].uri, _prov_uri("hadActivity")),
+        (PROV["generation"].uri, _prov_uri("hadGeneration")),
+        (PROV["usage"].uri, _prov_uri("hadUsage")),
+        (PROV["usedEntity"].uri, _prov_uri("entity")),
+    ),
+}
+
+#: Predicate rewrites applied to every relation type, before the per-type
+#: rewrites in :data:`_RELATION_PREDICATE_REWRITES`.
+_COMMON_PREDICATE_REWRITES = (
+    (PROV["plan"].uri, _prov_uri("hadPlan")),
+    (PROV["informant"].uri, _prov_uri("activity")),
+    (PROV["responsible"].uri, _prov_uri("agent")),
+)
+
+#: Extra-attribute names with a dedicated PROV-O predicate, used when encoding
+#: the attributes hanging off a relation's qualification node.
+_QUALIFIED_ATTR_PREDICATES = {
+    PROV["role"]: _prov_uri("hadRole"),
+    PROV["plan"]: _prov_uri("hadPlan"),
+    PROV["type"]: RDF.type,
+    PROV["label"]: RDFS.label,
+}
+
+#: Predicates for the attributes encoded directly onto an element (entity,
+#: activity, agent) rather than onto a qualification node.
+_ELEMENT_ATTR_PREDICATES = {
+    PROV["type"]: RDF.type,
+    PROV["label"]: RDFS.label,
+    PROV_ATTR_STARTTIME: _prov_uri("startedAtTime"),
+    PROV_ATTR_ENDTIME: _prov_uri("endedAtTime"),
+}
+
+#: Per-record-type formal-attribute rewrites applied, in order, when decoding.
+#: Each ``(needle, replacement)`` pair replaces the predicate resolved so far
+#: with ``replacement`` when ``needle`` occurs in its string form -- the decode
+#: mirror of :data:`_RELATION_PREDICATE_REWRITES`, and likewise a faithful
+#: transcription of the ``if`` ladder it replaces.
+_DECODE_PREDICATE_REWRITES: dict[
+    QualifiedName, tuple[tuple[str, QualifiedName], ...]
+] = {
+    PROV_COMMUNICATION: (("activity", PROV_ATTR_INFORMANT),),
+    PROV_DELEGATION: (("agent", PROV_ATTR_RESPONSIBLE),),
+    PROV_END: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_ENDER)),
+    PROV_START: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_STARTER)),
+    PROV_DERIVATION: (("entity", PROV_ATTR_USED_ENTITY),),
+}
+
+
+@dataclass
+class _DecodeState:
+    """Mutable state threaded through :meth:`ProvRDFSerializer.decode_container`.
+
+    Attributes:
+        record_types: Maps a subject to the record type decoded for it.
+        formal_attributes: Per subject, the formal attribute values gathered
+            so far (``None`` where still unknown or ambiguous).
+        unique_sets: Per subject, every candidate value seen for each formal
+            attribute -- more than one means the attribute is ambiguous and
+            must be resolved by walking the combinations.
+        other_attributes: Per subject, the non-formal attributes gathered so
+            far. Entries are removed as they are consumed, so whatever
+            remains at the end could not be converted.
+    """
+
+    record_types: dict[str, pm.QualifiedName] = field(default_factory=dict)
+    formal_attributes: dict[str, dict[pm.QualifiedName, Any]] = field(
+        default_factory=dict
+    )
+    unique_sets: dict[str, dict[pm.QualifiedName, list[Any]]] = field(
+        default_factory=dict
+    )
+    other_attributes: dict[str, list[tuple[pm.QualifiedNameCandidate, Any]]] = field(
+        default_factory=dict
+    )
+
+    def register(self, subj: str, prov_obj: pm.QualifiedName) -> None:
+        """Record ``subj``'s type and seed its empty formal-attribute slots.
+
+        Args:
+            subj: The subject being typed.
+            prov_obj: The record type decoded for it.
+        """
+        self.record_types[subj] = prov_obj
+        klass = pm.PROV_REC_CLS[prov_obj]
+        self.formal_attributes[subj] = OrderedDict(
+            [(key, None) for key in klass.FORMAL_ATTRIBUTES]
+        )
+        self.unique_sets[subj] = OrderedDict(
+            [(key, []) for key in klass.FORMAL_ATTRIBUTES]
+        )
 
 
 def attr2rdf(attr: QualifiedName) -> URIRef:
@@ -528,229 +681,342 @@ class ProvRDFSerializer(Serializer):
 
         for record in bundle._records:
             rec_type = record.get_type()
+            rec_id: URIRef | None
             if hasattr(record, "identifier") and record.identifier:
-                identifier = URIRef(str(real_or_anon_id(record)))
-                container.add((identifier, RDF.type, URIRef(rec_type.uri)))
+                rec_id = URIRef(str(real_or_anon_id(record)))
+                container.add((rec_id, RDF.type, URIRef(rec_type.uri)))
             else:
-                identifier = None
-            if record.attributes:
-                bnode = None
-                formal_objects = []
-                used_objects = []
-                all_attributes = list(record.formal_attributes) + list(
-                    record.attributes
-                )
-                formal_qualifiers = False
-                for attrid, (_attr, value) in enumerate(list(record.formal_attributes)):
-                    if (identifier is not None and value is not None) or (
-                        identifier is None and value is not None and attrid > 1
-                    ):
-                        formal_qualifiers = True
-                has_qualifiers = len(record.extra_attributes) > 0 or formal_qualifiers
-                for idx, (attr, value) in enumerate(all_attributes):
-                    if record.is_relation():
-                        pred: URIRef | RDFLiteral = URIRef(
-                            PROV[PROV_N_MAP[rec_type]].uri
-                        )
-                        # create bnode relation
-                        if bnode is None:
-                            valid_formal_indices = set()
-                            for idx, (key, val) in enumerate(record.formal_attributes):
-                                formal_objects.append(key)
-                                if val:
-                                    valid_formal_indices.add(idx)
-                            used_objects = [record.formal_attributes[0][0]]
-                            subj: URIRef | RDFLiteral | None = None
-                            if record.formal_attributes[0][1]:
-                                subj = URIRef(record.formal_attributes[0][1].uri)
-                            if identifier is None and subj is not None:
-                                try:
-                                    obj_val = record.formal_attributes[1][1]
-                                except IndexError:
-                                    obj_val = None
-                                if obj_val and (
-                                    rec_type
-                                    not in {
-                                        PROV_END,
-                                        PROV_START,
-                                        PROV_USAGE,
-                                        PROV_GENERATION,
-                                        PROV_DERIVATION,
-                                        PROV_ASSOCIATION,
-                                        PROV_INVALIDATION,
-                                    }
-                                    or (
-                                        valid_formal_indices == {0, 1}
-                                        and len(record.extra_attributes) == 0
-                                    )
-                                ):
-                                    used_objects.append(record.formal_attributes[1][0])
-                                    obj_val = self.encode_rdf_representation(obj_val)
-                                    if rec_type == PROV_ALTERNATE:
-                                        subj, obj_val = obj_val, subj
-                                    container.add((subj, pred, obj_val))
-                                    if rec_type == PROV_MENTION:
-                                        if record.formal_attributes[2][1]:
-                                            used_objects.append(
-                                                record.formal_attributes[2][0]
-                                            )
-                                            obj_val = self.encode_rdf_representation(
-                                                record.formal_attributes[2][1]
-                                            )
-                                            container.add(
-                                                (
-                                                    subj,
-                                                    URIRef(PROV["asInBundle"].uri),
-                                                    obj_val,
-                                                )
-                                            )
-                                        has_qualifiers = False
-                            if rec_type in [PROV_ALTERNATE]:
-                                continue
-                            if subj and (has_qualifiers or identifier):
-                                qualifier = rec_type._localpart
-                                rec_uri = rec_type.uri
-                                for attr_name, val in record.extra_attributes:
-                                    if attr_name == PROV["type"] and (
-                                        PROV["Revision"] == val
-                                        or PROV["Quotation"] == val
-                                        or PROV["PrimarySource"] == val
-                                    ):
-                                        qualifier = val._localpart
-                                        rec_uri = val.uri
-                                        if identifier is not None:
-                                            container.remove(
-                                                (
-                                                    identifier,
-                                                    RDF.type,
-                                                    URIRef(rec_type.uri),
-                                                )
-                                            )
-                                QRole = URIRef(PROV["qualified" + qualifier].uri)
-                                if identifier is not None:
-                                    container.add((subj, QRole, identifier))
-                                else:
-                                    bnode = identifier = BNode()
-                                    container.add((subj, QRole, identifier))
-                                    container.add(
-                                        (identifier, RDF.type, URIRef(rec_uri))
-                                    )  # reset identifier to BNode
-                        if value is not None and attr not in used_objects:
-                            if attr in formal_objects:
-                                pred = attr2rdf(attr)
-                            elif attr == PROV["role"]:
-                                pred = URIRef(PROV["hadRole"].uri)
-                            elif attr == PROV["plan"]:
-                                pred = URIRef(PROV["hadPlan"].uri)
-                            elif attr == PROV["type"]:
-                                pred = RDF.type
-                            elif attr == PROV["label"]:
-                                pred = RDFS.label
-                            elif isinstance(attr, pm.QualifiedName):
-                                pred = URIRef(attr.uri)
-                            else:
-                                pred = self.encode_rdf_representation(attr)
-                            if PROV["plan"].uri in pred:
-                                pred = URIRef(PROV["hadPlan"].uri)
-                            if PROV["informant"].uri in pred:
-                                pred = URIRef(PROV["activity"].uri)
-                            if PROV["responsible"].uri in pred:
-                                pred = URIRef(PROV["agent"].uri)
-                            if (
-                                rec_type == PROV_DELEGATION
-                                and PROV["activity"].uri in pred
-                            ):
-                                pred = URIRef(PROV["hadActivity"].uri)
-                            if (
-                                rec_type in [PROV_END, PROV_START]
-                                and PROV["trigger"].uri in pred
-                            ) or (
-                                rec_type in [PROV_USAGE] and PROV["used"].uri in pred
-                            ):
-                                pred = URIRef(PROV["entity"].uri)
-                            if rec_type in [
-                                PROV_GENERATION,
-                                PROV_END,
-                                PROV_START,
-                                PROV_USAGE,
-                                PROV_INVALIDATION,
-                            ]:
-                                if PROV["time"].uri in pred:
-                                    pred = URIRef(PROV["atTime"].uri)
-                                if PROV["ender"].uri in pred:
-                                    pred = URIRef(PROV["hadActivity"].uri)
-                                if PROV["starter"].uri in pred:
-                                    pred = URIRef(PROV["hadActivity"].uri)
-                                if PROV["location"].uri in pred:
-                                    pred = URIRef(PROV["atLocation"].uri)
-                            if rec_type in [PROV_ACTIVITY]:
-                                # dead branch kept as-is: rec_type is never
-                                # PROV_ACTIVITY inside the is_relation() path, and
-                                # `QualifiedName in URIRef` would raise TypeError
-                                if PROV_ATTR_STARTTIME in pred:  # type: ignore[operator]
-                                    pred = URIRef(PROV["startedAtTime"].uri)
-                                if PROV_ATTR_ENDTIME in pred:  # type: ignore[operator]
-                                    pred = URIRef(PROV["endedAtTime"].uri)
-                            if rec_type == PROV_DERIVATION:
-                                if PROV["activity"].uri in pred:
-                                    pred = URIRef(PROV["hadActivity"].uri)
-                                if PROV["generation"].uri in pred:
-                                    pred = URIRef(PROV["hadGeneration"].uri)
-                                if PROV["usage"].uri in pred:
-                                    pred = URIRef(PROV["hadUsage"].uri)
-                                if PROV["usedEntity"].uri in pred:
-                                    pred = URIRef(PROV["entity"].uri)
-                            container.add(
-                                (
-                                    # a qualified relation always has a URIRef or
-                                    # BNode identifier by this point
-                                    cast("URIRef | BNode", identifier),
-                                    pred,
-                                    self.encode_rdf_representation(value),
-                                )
-                            )
-                        continue
-                    if value is None:
-                        continue
-                    if isinstance(value, pm.ProvRecord):
-                        obj: RDFLiteral | URIRef = URIRef(str(real_or_anon_id(value)))
-                    else:
-                        #  Assuming this is a datetime value
-                        obj = self.encode_rdf_representation(value)
-                    if attr == PROV["location"]:
-                        pred = URIRef(PROV["atLocation"].uri)
-                        # `False and ...` deliberately disables this branch (see
-                        # git history back to 2014): kept for now because touching
-                        # it risks changing frozen 2.x RDF output; scheduled for
-                        # deletion in 3.0 (item F2 in
-                        # docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md).
-                        if False and isinstance(value, (URIRef, pm.QualifiedName)):  # noqa: SIM223
-                            if isinstance(value, pm.QualifiedName):
-                                value = URIRef(value.uri)
-                            container.add((identifier, pred, value))
-                        else:
-                            container.add(
-                                (
-                                    # elements always carry an identifier here
-                                    cast("URIRef | BNode", identifier),
-                                    pred,
-                                    self.encode_rdf_representation(obj),
-                                )
-                            )
-                        continue
-                    if attr == PROV["type"]:
-                        pred = RDF.type
-                    elif attr == PROV["label"]:
-                        pred = RDFS.label
-                    elif attr == PROV_ATTR_STARTTIME:
-                        pred = URIRef(PROV["startedAtTime"].uri)
-                    elif attr == PROV_ATTR_ENDTIME:
-                        pred = URIRef(PROV["endedAtTime"].uri)
-                    else:
-                        pred = self.encode_rdf_representation(attr)
-                    # elements always carry an identifier here
-                    container.add((cast("URIRef | BNode", identifier), pred, obj))
+                rec_id = None
+            if not record.attributes:
+                continue
+            if record.is_relation():
+                self._encode_relation(container, record, rec_type, rec_id, PROV_N_MAP)
+            else:
+                self._encode_element(container, record, rec_id, real_or_anon_id)
         return container
+
+    def _encode_element(
+        self,
+        container: Graph,
+        record: pm.ProvRecord,
+        identifier: URIRef | None,
+        real_or_anon_id: "Callable[[pm.ProvRecord], str]",
+    ) -> None:
+        """Encode an element's (entity/activity/agent) attributes as direct triples.
+
+        Args:
+            container: Graph to add triples to.
+            record: The element record being encoded.
+            identifier: The element's subject URIRef.
+            real_or_anon_id: Resolves a referenced record to its identifier
+                string, minting a stable anonymous one where needed.
+        """
+        all_attributes = list(record.formal_attributes) + list(record.attributes)
+        for attr, value in all_attributes:
+            if value is None:
+                continue
+            if isinstance(value, pm.ProvRecord):
+                obj: RDFLiteral | URIRef = URIRef(str(real_or_anon_id(value)))
+            else:
+                #  Assuming this is a datetime value
+                obj = self.encode_rdf_representation(value)
+            pred: URIRef | RDFLiteral
+            if attr == PROV["location"]:
+                pred = _prov_uri("atLocation")
+                # `False and ...` deliberately disables this branch (see
+                # git history back to 2014): kept for now because touching
+                # it risks changing frozen 2.x RDF output; scheduled for
+                # deletion in 3.0 (item F2 in
+                # docs/superpowers/specs/2026-07-04-3x-typing-api-improvements.md).
+                if False and isinstance(value, (URIRef, pm.QualifiedName)):  # noqa: SIM223
+                    if isinstance(value, pm.QualifiedName):
+                        value = URIRef(value.uri)
+                    container.add((identifier, pred, value))
+                else:
+                    container.add(
+                        (
+                            # elements always carry an identifier here
+                            cast("URIRef | BNode", identifier),
+                            pred,
+                            self.encode_rdf_representation(obj),
+                        )
+                    )
+                continue
+            if isinstance(attr, pm.QualifiedName) and attr in _ELEMENT_ATTR_PREDICATES:
+                pred = _ELEMENT_ATTR_PREDICATES[attr]
+            else:
+                pred = self.encode_rdf_representation(attr)
+            # elements always carry an identifier here
+            container.add((cast("URIRef | BNode", identifier), pred, obj))
+
+    def _encode_relation(
+        self,
+        container: Graph,
+        record: pm.ProvRecord,
+        rec_type: pm.QualifiedName,
+        identifier: URIRef | None,
+        PROV_N_MAP: dict[pm.QualifiedName, str],
+    ) -> None:
+        """Encode a relation using PROV-O's qualification pattern.
+
+        Emits the binary ``subject predicate object`` triple for the two
+        leading formal attributes where PROV-O allows one, then hangs the
+        remaining formal and extra attributes off a ``prov:qualified*`` node
+        (the record's own identifier, or a fresh blank node).
+
+        Args:
+            container: Graph to add triples to.
+            record: The relation record being encoded.
+            rec_type: ``record``'s record type QualifiedName.
+            identifier: The relation's own subject URIRef, or ``None`` when it
+                is unidentified (in which case a blank node is minted).
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword.
+        """
+        bnode = None
+        formal_objects: list[pm.QualifiedName] = []
+        used_objects: list[pm.QualifiedName] = []
+        all_attributes = list(record.formal_attributes) + list(record.attributes)
+        formal_qualifiers = False
+        for attrid, (_attr, value) in enumerate(list(record.formal_attributes)):
+            if (identifier is not None and value is not None) or (
+                identifier is None and value is not None and attrid > 1
+            ):
+                formal_qualifiers = True
+        has_qualifiers = len(record.extra_attributes) > 0 or formal_qualifiers
+
+        node: URIRef | BNode | None = identifier
+        for attr, value in all_attributes:
+            # The qualification head is (re)built until a blank node is minted
+            # for it; for an identified relation no blank node is ever minted,
+            # so this re-runs per attribute exactly as it always has -- every
+            # triple it emits is idempotent, so the repetition is harmless.
+            if bnode is None:
+                node, bnode, skip = self._encode_relation_head(
+                    container,
+                    record,
+                    rec_type,
+                    node,
+                    PROV_N_MAP,
+                    formal_objects,
+                    used_objects,
+                    has_qualifiers,
+                )
+                if skip:
+                    continue
+            if value is not None and attr not in used_objects:
+                container.add(
+                    (
+                        # a qualified relation always has a URIRef or
+                        # BNode identifier by this point
+                        cast("URIRef | BNode", node),
+                        self._qualified_attr_predicate(rec_type, attr, formal_objects),
+                        self.encode_rdf_representation(value),
+                    )
+                )
+
+    def _encode_relation_head(
+        self,
+        container: Graph,
+        record: pm.ProvRecord,
+        rec_type: pm.QualifiedName,
+        identifier: URIRef | BNode | None,
+        PROV_N_MAP: dict[pm.QualifiedName, str],
+        formal_objects: list[pm.QualifiedName],
+        used_objects: list[pm.QualifiedName],
+        has_qualifiers: bool,
+    ) -> tuple[URIRef | BNode | None, BNode | None, bool]:
+        """Emit a relation's binary triple and its ``prov:qualified*`` node.
+
+        Args:
+            container: Graph to add triples to.
+            record: The relation record being encoded.
+            rec_type: ``record``'s record type QualifiedName.
+            identifier: The relation's subject URIRef, or ``None``.
+            PROV_N_MAP: Maps record type QualifiedName to PROV-N keyword.
+            formal_objects: Accumulator, extended with the record's formal
+                attribute names (used to recognise formal attributes later).
+            used_objects: Accumulator, replaced in place with the formal
+                attributes already consumed by the binary triple.
+            has_qualifiers: Whether the relation carries anything beyond the
+                two attributes of its binary triple.
+
+        Returns:
+            ``(node, bnode, skip)``: the subject to hang remaining attributes
+            off, the blank node minted for it (``None`` if none was), and
+            whether the caller should skip this attribute entirely.
+        """
+        pred = _prov_uri(PROV_N_MAP[rec_type])
+        valid_formal_indices = set()
+        for idx, (key, val) in enumerate(record.formal_attributes):
+            formal_objects.append(key)
+            if val:
+                valid_formal_indices.add(idx)
+        used_objects[:] = [record.formal_attributes[0][0]]
+        subj: URIRef | RDFLiteral | None = None
+        if record.formal_attributes[0][1]:
+            subj = URIRef(record.formal_attributes[0][1].uri)
+        if identifier is None and subj is not None:
+            has_qualifiers = self._encode_relation_binary_triple(
+                container,
+                record,
+                rec_type,
+                pred,
+                subj,
+                valid_formal_indices,
+                used_objects,
+                has_qualifiers,
+            )
+        if rec_type in [PROV_ALTERNATE]:
+            # #258/#250 territory: alternateOf emits only its binary triple,
+            # so any extra attributes it carries are dropped. Preserved as-is.
+            return identifier, None, True
+        if subj and (has_qualifiers or identifier):
+            return (
+                *self._encode_qualification_node(
+                    container, record, rec_type, identifier, subj
+                ),
+                False,
+            )
+        return identifier, None, False
+
+    def _encode_relation_binary_triple(
+        self,
+        container: Graph,
+        record: pm.ProvRecord,
+        rec_type: pm.QualifiedName,
+        pred: URIRef,
+        subj: URIRef | RDFLiteral,
+        valid_formal_indices: set[int],
+        used_objects: list[pm.QualifiedName],
+        has_qualifiers: bool,
+    ) -> bool:
+        """Emit the plain binary triple for an unidentified relation, if allowed.
+
+        Args:
+            container: Graph to add triples to.
+            record: The relation record being encoded.
+            rec_type: ``record``'s record type QualifiedName.
+            pred: The relation's PROV-O predicate.
+            subj: Subject term for the binary triple.
+            valid_formal_indices: Indices of formal attributes that have a value.
+            used_objects: Accumulator, extended with the formal attributes
+                consumed by the emitted triple(s).
+            has_qualifiers: Current qualification flag.
+
+        Returns:
+            The (possibly updated) ``has_qualifiers`` flag.
+        """
+        try:
+            obj_val = record.formal_attributes[1][1]
+        except IndexError:
+            obj_val = None
+        if not obj_val:
+            return has_qualifiers
+        if rec_type in _QUALIFIED_ONLY_RELATIONS and not (
+            valid_formal_indices == {0, 1} and len(record.extra_attributes) == 0
+        ):
+            return has_qualifiers
+        used_objects.append(record.formal_attributes[1][0])
+        obj_term: URIRef | RDFLiteral = self.encode_rdf_representation(obj_val)
+        if rec_type == PROV_ALTERNATE:
+            # #258: subject and object are swapped here relative to PROV-O.
+            # Preserved verbatim; fixed separately.
+            subj, obj_term = obj_term, subj
+        container.add((subj, pred, obj_term))
+        if rec_type == PROV_MENTION:
+            if record.formal_attributes[2][1]:
+                used_objects.append(record.formal_attributes[2][0])
+                container.add(
+                    (
+                        subj,
+                        _prov_uri("asInBundle"),
+                        self.encode_rdf_representation(record.formal_attributes[2][1]),
+                    )
+                )
+            has_qualifiers = False
+        return has_qualifiers
+
+    def _encode_qualification_node(
+        self,
+        container: Graph,
+        record: pm.ProvRecord,
+        rec_type: pm.QualifiedName,
+        identifier: URIRef | BNode | None,
+        subj: URIRef | RDFLiteral,
+    ) -> tuple[URIRef | BNode, BNode | None]:
+        """Link (and, when anonymous, create and type) a ``prov:qualified*`` node.
+
+        A ``prov:type`` of ``prov:Revision``/``prov:Quotation``/
+        ``prov:PrimarySource`` renames the qualification property and the
+        node's own type, replacing the record type's own ``rdf:type`` triple.
+
+        Args:
+            container: Graph to add triples to.
+            record: The relation record being encoded.
+            rec_type: ``record``'s record type QualifiedName.
+            identifier: The relation's subject URIRef, or ``None`` to mint a
+                blank node.
+            subj: Subject the qualification node hangs off.
+
+        Returns:
+            ``(node, bnode)``: the qualification node, and the blank node
+            minted for it (``None`` when ``identifier`` was already set).
+        """
+        qualifier = rec_type._localpart
+        rec_uri = rec_type.uri
+        for attr_name, val in record.extra_attributes:
+            if attr_name == PROV["type"] and val in _DERIVATION_SUBTYPES:
+                qualifier = val._localpart
+                rec_uri = val.uri
+                if identifier is not None:
+                    container.remove((identifier, RDF.type, URIRef(rec_type.uri)))
+        QRole = _prov_uri("qualified" + qualifier)
+        if identifier is not None:
+            container.add((subj, QRole, identifier))
+            return identifier, None
+        # #250: the anonymous qualification node is deliberately left without
+        # its influencer property here. Preserved verbatim; fixed separately.
+        bnode = BNode()
+        container.add((subj, QRole, bnode))
+        container.add((bnode, RDF.type, URIRef(rec_uri)))
+        return bnode, bnode
+
+    def _qualified_attr_predicate(
+        self,
+        rec_type: pm.QualifiedName,
+        attr: pm.QualifiedNameCandidate,
+        formal_objects: list[pm.QualifiedName],
+    ) -> URIRef | RDFLiteral:
+        """Return the PROV-O predicate for one attribute of a qualified relation.
+
+        Picks a base predicate for ``attr``, then applies the common and
+        per-record-type rewrites from :data:`_COMMON_PREDICATE_REWRITES` and
+        :data:`_RELATION_PREDICATE_REWRITES` in order.
+
+        Args:
+            rec_type: The relation's record type QualifiedName.
+            attr: The attribute name being encoded.
+            formal_objects: The relation's formal attribute names.
+
+        Returns:
+            The predicate term to use for ``attr``.
+        """
+        pred: URIRef | RDFLiteral
+        if attr in formal_objects:
+            pred = attr2rdf(cast(QualifiedName, attr))
+        elif isinstance(attr, pm.QualifiedName) and attr in _QUALIFIED_ATTR_PREDICATES:
+            pred = _QUALIFIED_ATTR_PREDICATES[attr]
+        elif isinstance(attr, pm.QualifiedName):
+            pred = URIRef(attr.uri)
+        else:
+            pred = self.encode_rdf_representation(attr)
+        for needle, replacement in (
+            *_COMMON_PREDICATE_REWRITES,
+            *_RELATION_PREDICATE_REWRITES.get(rec_type, ()),
+        ):
+            if needle in pred:
+                pred = replacement
+        return pred
 
     def decode_document(
         self,
@@ -854,177 +1120,276 @@ class ProvRDFSerializer(Serializer):
             UserWarning: If, after decoding, some attributes could not be
                 matched to any formal attribute or converted.
         """
-        record_types = {}  # type: dict[str, pm.QualifiedName]
-        PROV_CLS_MAP = {}  # type: dict[str, pm.QualifiedName]
-        formal_attributes = {}  # type: dict[str, dict[pm.QualifiedName, pm.QualifiedNameCandidate | datetime.datetime | None]]
-        unique_sets = {}  # type: dict[str, dict[pm.QualifiedName, list[pm.QualifiedNameCandidate | datetime.datetime]]]
-        for prov_type, _ in PROV_BASE_CLS.items():
-            PROV_CLS_MAP[prov_type.uri] = PROV_BASE_CLS[prov_type]
-        other_attributes = {}  # type: dict[str, list[tuple[pm.QualifiedNameCandidate, Any]]]
-        # subj/obj hold rdflib terms (Node) when bound by the triple loops below
-        # and their string forms after conversion
-        subj: str | Node
-        obj: str | Node
-        for stmt in graph.triples((None, RDF.type, None)):
-            subj = str(stmt[0])
-            obj = str(stmt[2])
-            if obj in PROV_CLS_MAP:
-                if (
-                    not isinstance(stmt[0], BNode)
-                    and self.valid_identifier(subj) is None
-                ):
-                    prefix, iri, _ = graph.namespace_manager.compute_qname(subj)
-                    self.document.add_namespace(prefix, iri)  # type: ignore[union-attr]
-                try:
-                    prov_obj = PROV_CLS_MAP[obj]
-                except AttributeError:
-                    prov_obj = None
-                add_attr = True
-                # objects of rdf:type triples are URIRefs (str subclass);
-                # rdflib types them only as Node
-                isderivation = (
-                    pm.PROV["Revision"].uri in cast(str, stmt[2])
-                    or pm.PROV["Quotation"].uri in cast(str, stmt[2])
-                    or pm.PROV["PrimarySource"].uri in cast(str, stmt[2])
-                )
-                if (
-                    subj not in record_types
-                    and prov_obj
-                    and (
-                        prov_obj.uri == obj
-                        or isderivation
-                        or isinstance(stmt[0], BNode)
-                    )
-                ):
-                    record_types[subj] = prov_obj
-                    klass = pm.PROV_REC_CLS[prov_obj]
-                    formal_attributes[subj] = OrderedDict(
-                        [(key, None) for key in klass.FORMAL_ATTRIBUTES]
-                    )
-                    unique_sets[subj] = OrderedDict(
-                        [(key, []) for key in klass.FORMAL_ATTRIBUTES]
-                    )
-                    add_attr = False or (
-                        (isinstance(stmt[0], BNode) or isderivation)
-                        and prov_obj.uri != obj
-                    )
-                if add_attr:
-                    if subj not in other_attributes:
-                        other_attributes[subj] = []
-                    obj_formatted = self.decode_rdf_representation(stmt[2], graph)
-                    other_attributes[subj].append((pm.PROV["type"], obj_formatted))
-            else:
-                if subj not in other_attributes:
-                    other_attributes[subj] = []
-                obj = self.decode_rdf_representation(stmt[2], graph)
-                other_attributes[subj].append((pm.PROV["type"], obj))
-        for subj, pred, obj in graph:
-            subj = str(subj)
-            # predicates in RDF are always URIRefs; rdflib types them as Node
-            pred = cast(URIRef, pred)
-            if subj not in other_attributes:
-                other_attributes[subj] = []
-            if pred == RDF.type:
-                continue
-            if pred in relation_mapper:
-                if "alternateOf" in pred:
-                    getattr(bundle, relation_mapper[pred])(obj, subj)
-                elif "mentionOf" in pred:
-                    mentionBundle = None
-                    for stmt in graph.triples(
-                        (URIRef(subj), URIRef(pm.PROV["asInBundle"].uri), None)
-                    ):
-                        mentionBundle = stmt[2]
-                    getattr(bundle, relation_mapper[pred])(
-                        subj, str(obj), mentionBundle
-                    )
-                elif "actedOnBehalfOf" in pred or "wasAssociatedWith" in pred:
-                    qualifier = (
-                        "qualified"
-                        + relation_mapper[pred].upper()[0]
-                        + relation_mapper[pred][1:]
-                    )
-                    qualifier_bnode = None
-                    for stmt in graph.triples(
-                        (URIRef(subj), URIRef(pm.PROV[qualifier].uri), None)
-                    ):
-                        qualifier_bnode = stmt[2]
-                    if qualifier_bnode is None:
-                        getattr(bundle, relation_mapper[pred])(subj, str(obj))
-                    else:
-                        fakeys = list(formal_attributes[str(qualifier_bnode)].keys())
-                        formal_attributes[str(qualifier_bnode)][fakeys[0]] = subj
-                        formal_attributes[str(qualifier_bnode)][fakeys[1]] = str(obj)
-                else:
-                    getattr(bundle, relation_mapper[pred])(subj, str(obj))
-            elif subj in record_types:
-                obj1 = self.decode_rdf_representation(obj, graph)
-                if obj is not None and obj1 is None:
-                    raise ValueError(("Error transforming", obj))
-                pred_new: URIRef | pm.QualifiedName = pred
-                if pred in predicate_mapper:
-                    pred_new = predicate_mapper[pred]
-                if record_types[subj] == PROV_COMMUNICATION and "activity" in str(
-                    pred_new
-                ):
-                    pred_new = PROV_ATTR_INFORMANT
-                if record_types[subj] == PROV_DELEGATION and "agent" in str(pred_new):
-                    pred_new = PROV_ATTR_RESPONSIBLE
-                if record_types[subj] in [PROV_END, PROV_START] and "entity" in str(
-                    pred_new
-                ):
-                    pred_new = PROV_ATTR_TRIGGER
-                if record_types[subj] in [PROV_END] and "activity" in str(pred_new):
-                    pred_new = PROV_ATTR_ENDER
-                if record_types[subj] in [PROV_START] and "activity" in str(pred_new):
-                    pred_new = PROV_ATTR_STARTER
-                if record_types[subj] == PROV_DERIVATION and "entity" in str(pred_new):
-                    pred_new = PROV_ATTR_USED_ENTITY
-                if str(pred_new) in [val.uri for val in formal_attributes[subj]]:
-                    qname_key = self.document.mandatory_valid_qname(pred_new)  # type: ignore[union-attr]
-                    formal_attributes[subj][qname_key] = obj1
-                    unique_sets[subj][qname_key].append(obj1)
-                    if len(unique_sets[subj][qname_key]) > 1:
-                        formal_attributes[subj][qname_key] = None
-                else:
-                    if "qualified" not in str(pred_new) and "asInBundle" not in str(
-                        pred_new
-                    ):
-                        other_attributes[subj].append((str(pred_new), obj1))
-            local_key = str(obj)
-            if local_key in record_types and "qualified" in pred:
-                formal_attributes[local_key][
-                    next(iter(formal_attributes[local_key].keys()))
-                ] = subj
-        for subj in record_types:
-            attrs = None
-            if subj in other_attributes:
-                attrs = other_attributes[subj]
-            items_to_walk = []  # type: list[tuple[pm.QualifiedName, list[pm.QualifiedNameCandidate | datetime.datetime]]]
-            for qname, values in unique_sets[subj].items():
-                if values and len(values) > 1:
-                    items_to_walk.append((qname, values))
-            if items_to_walk:
-                for subset in list(walk(items_to_walk)):
-                    for prov_type, value in subset.items():
-                        formal_attributes[subj][prov_type] = value
-                    bundle.new_record(
-                        record_types[subj], subj, formal_attributes[subj].items(), attrs
-                    )
-            else:
-                bundle.new_record(
-                    record_types[subj], subj, formal_attributes[subj].items(), attrs
-                )
+        prov_cls_map = {
+            prov_type.uri: base_cls for prov_type, base_cls in PROV_BASE_CLS.items()
+        }
+        state = _DecodeState()
+        self._decode_type_triples(graph, state, prov_cls_map)
+        self._decode_triples(graph, bundle, state, relation_mapper, predicate_mapper)
+        self._emit_decoded_records(bundle, state)
 
-            if attrs is not None:
-                del other_attributes[subj]
-
-        if other_attributes:
+        if state.other_attributes:
             warnings.warn(
-                "The following attributes were not converted: " + str(other_attributes),
+                "The following attributes were not converted: "
+                + str(state.other_attributes),
                 UserWarning,
                 stacklevel=2,
             )
+
+    def _decode_type_triples(
+        self,
+        graph: Graph,
+        state: "_DecodeState",
+        prov_cls_map: dict[str, pm.QualifiedName],
+    ) -> None:
+        """Reconstruct each subject's record type from its ``rdf:type`` triples.
+
+        Registers a record type in ``state`` for every subject typed with a
+        known PROV-O class; every other ``rdf:type`` object (and the extra
+        types of an already-registered subject) becomes a ``prov:type``
+        attribute instead.
+
+        Args:
+            graph: The RDF (sub)graph being decoded.
+            state: Decode state, mutated in place.
+            prov_cls_map: Maps a PROV-O class URI to its base record type.
+        """
+        for stmt in graph.triples((None, RDF.type, None)):
+            subj = str(stmt[0])
+            obj = str(stmt[2])
+            add_attr = (
+                self._register_record_type(graph, stmt, subj, obj, prov_cls_map, state)
+                if obj in prov_cls_map
+                else True
+            )
+            if add_attr:
+                state.other_attributes.setdefault(subj, []).append(
+                    (pm.PROV["type"], self.decode_rdf_representation(stmt[2], graph))
+                )
+
+    def _register_record_type(
+        self,
+        graph: Graph,
+        stmt: tuple[Node, Node, Node],
+        subj: str,
+        obj: str,
+        prov_cls_map: dict[str, pm.QualifiedName],
+        state: "_DecodeState",
+    ) -> bool:
+        """Register one subject's record type, if this triple establishes it.
+
+        Args:
+            graph: The RDF (sub)graph being decoded.
+            stmt: The ``rdf:type`` triple.
+            subj: ``stmt``'s subject, as a string.
+            obj: ``stmt``'s object, as a string.
+            prov_cls_map: Maps a PROV-O class URI to its base record type.
+            state: Decode state, mutated in place.
+
+        Returns:
+            Whether the triple's object should *also* be recorded as a
+            ``prov:type`` attribute (true for a derivation subtype or an
+            extra type on a blank node, and for any subject already typed).
+        """
+        if not isinstance(stmt[0], BNode) and self.valid_identifier(subj) is None:
+            prefix, iri, _ = graph.namespace_manager.compute_qname(subj)
+            self.document.add_namespace(prefix, iri)  # type: ignore[union-attr]
+        prov_obj = prov_cls_map[obj]
+        # objects of rdf:type triples are URIRefs (str subclass);
+        # rdflib types them only as Node
+        isderivation = any(
+            pm.PROV[subtype].uri in cast(str, stmt[2])
+            for subtype in ("Revision", "Quotation", "PrimarySource")
+        )
+        if subj in state.record_types or not (
+            prov_obj.uri == obj or isderivation or isinstance(stmt[0], BNode)
+        ):
+            return True
+        state.register(subj, prov_obj)
+        return (isinstance(stmt[0], BNode) or isderivation) and prov_obj.uri != obj
+
+    def _decode_triples(
+        self,
+        graph: Graph,
+        bundle: pm.ProvBundle,
+        state: "_DecodeState",
+        relation_mapper: dict[URIRef, str],
+        predicate_mapper: dict[URIRef, pm.QualifiedName],
+    ) -> None:
+        """Walk every triple, filling in relations and attributes.
+
+        Args:
+            graph: The RDF (sub)graph being decoded.
+            bundle: Bundle to add reconstructed relations to.
+            state: Decode state, mutated in place.
+            relation_mapper: Maps PROV-O relation predicate URIRefs to
+                :class:`~prov.model.ProvBundle` factory method names.
+            predicate_mapper: Maps PROV-O predicate URIRefs to formal
+                attribute QualifiedNames.
+        """
+        for subj_node, pred_node, obj in graph:
+            subj = str(subj_node)
+            # predicates in RDF are always URIRefs; rdflib types them as Node
+            pred = cast(URIRef, pred_node)
+            state.other_attributes.setdefault(subj, [])
+            if pred == RDF.type:
+                continue
+            if pred in relation_mapper:
+                self._decode_relation_triple(
+                    graph, bundle, state, subj, pred, obj, relation_mapper
+                )
+            elif subj in state.record_types:
+                self._decode_attribute_triple(
+                    graph, state, subj, pred, obj, predicate_mapper
+                )
+            local_key = str(obj)
+            if local_key in state.record_types and "qualified" in pred:
+                # The qualification node's influencer: the subject that points
+                # at it fills the relation's first formal attribute.
+                state.formal_attributes[local_key][
+                    next(iter(state.formal_attributes[local_key].keys()))
+                ] = subj
+
+    def _decode_relation_triple(
+        self,
+        graph: Graph,
+        bundle: pm.ProvBundle,
+        state: "_DecodeState",
+        subj: str,
+        pred: URIRef,
+        obj: Node,
+        relation_mapper: dict[URIRef, str],
+    ) -> None:
+        """Recreate one relation from its PROV-O binary triple.
+
+        Most relations map straight onto a :class:`~prov.model.ProvBundle`
+        factory call. ``prov:alternateOf`` passes its terms in reverse;
+        ``prov:mentionOf`` picks up its bundle from the subject's
+        ``prov:asInBundle`` triple; and delegation/association defer to their
+        qualification node when they have one, filling its first two formal
+        attributes instead of creating a record here.
+
+        Args:
+            graph: The RDF (sub)graph being decoded.
+            bundle: Bundle to add the relation to.
+            state: Decode state, mutated in place.
+            subj: The triple's subject, as a string.
+            pred: The triple's relation predicate.
+            obj: The triple's object.
+            relation_mapper: Maps PROV-O relation predicate URIRefs to
+                :class:`~prov.model.ProvBundle` factory method names.
+        """
+        factory = getattr(bundle, relation_mapper[pred])
+        if "alternateOf" in pred:
+            # #258: the terms are passed in reverse here. Preserved verbatim.
+            factory(obj, subj)
+            return
+        if "mentionOf" in pred:
+            mention_bundle = None
+            for stmt in graph.triples(
+                (URIRef(subj), URIRef(pm.PROV["asInBundle"].uri), None)
+            ):
+                mention_bundle = stmt[2]
+            factory(subj, str(obj), mention_bundle)
+            return
+        if "actedOnBehalfOf" in pred or "wasAssociatedWith" in pred:
+            name = relation_mapper[pred]
+            qualifier = "qualified" + name.upper()[0] + name[1:]
+            qualifier_bnode = None
+            for stmt in graph.triples(
+                (URIRef(subj), URIRef(pm.PROV[qualifier].uri), None)
+            ):
+                qualifier_bnode = stmt[2]
+            if qualifier_bnode is not None:
+                fakeys = list(state.formal_attributes[str(qualifier_bnode)].keys())
+                state.formal_attributes[str(qualifier_bnode)][fakeys[0]] = subj
+                state.formal_attributes[str(qualifier_bnode)][fakeys[1]] = str(obj)
+                return
+        factory(subj, str(obj))
+
+    def _decode_attribute_triple(
+        self,
+        graph: Graph,
+        state: "_DecodeState",
+        subj: str,
+        pred: URIRef,
+        obj: Node,
+        predicate_mapper: dict[URIRef, pm.QualifiedName],
+    ) -> None:
+        """Decode one non-relation triple into a formal or extra attribute.
+
+        Args:
+            graph: The RDF (sub)graph being decoded.
+            state: Decode state, mutated in place.
+            subj: The triple's subject, as a string.
+            pred: The triple's predicate.
+            obj: The triple's object.
+            predicate_mapper: Maps PROV-O predicate URIRefs to formal
+                attribute QualifiedNames.
+
+        Raises:
+            ValueError: If ``obj`` cannot be decoded to a usable value.
+        """
+        obj1 = self.decode_rdf_representation(obj, graph)
+        if obj is not None and obj1 is None:
+            raise ValueError(("Error transforming", obj))
+        pred_new: URIRef | pm.QualifiedName = predicate_mapper.get(pred, pred)
+        for needle, replacement in _DECODE_PREDICATE_REWRITES.get(
+            state.record_types[subj], ()
+        ):
+            if needle in str(pred_new):
+                pred_new = replacement
+        if str(pred_new) in [val.uri for val in state.formal_attributes[subj]]:
+            qname_key = self.document.mandatory_valid_qname(pred_new)  # type: ignore[union-attr]
+            state.formal_attributes[subj][qname_key] = obj1
+            state.unique_sets[subj][qname_key].append(obj1)
+            if len(state.unique_sets[subj][qname_key]) > 1:
+                # An ambiguous formal attribute is cleared here and resolved
+                # by walking every combination in _emit_decoded_records().
+                state.formal_attributes[subj][qname_key] = None
+        elif "qualified" not in str(pred_new) and "asInBundle" not in str(pred_new):
+            state.other_attributes[subj].append((str(pred_new), obj1))
+
+    def _emit_decoded_records(
+        self, bundle: pm.ProvBundle, state: "_DecodeState"
+    ) -> None:
+        """Add a record to ``bundle`` for every decoded subject.
+
+        A subject whose formal attributes picked up more than one candidate
+        value yields one record per combination of those values.
+
+        Args:
+            bundle: Bundle to add the records to.
+            state: Decode state; consumed attributes are removed from it, so
+                what remains afterwards is what could not be converted.
+        """
+        for subj in state.record_types:
+            attrs = state.other_attributes.get(subj)
+            items_to_walk = [
+                (qname, values)
+                for qname, values in state.unique_sets[subj].items()
+                if values and len(values) > 1
+            ]
+            if items_to_walk:
+                for subset in list(walk(items_to_walk)):
+                    for prov_type, value in subset.items():
+                        state.formal_attributes[subj][prov_type] = value
+                    bundle.new_record(
+                        state.record_types[subj],
+                        subj,
+                        state.formal_attributes[subj].items(),
+                        attrs,
+                    )
+            else:
+                bundle.new_record(
+                    state.record_types[subj],
+                    subj,
+                    state.formal_attributes[subj].items(),
+                    attrs,
+                )
+
+            if attrs is not None:
+                del state.other_attributes[subj]
 
 
 def walk(


### PR DESCRIPTION
`encode_container` (CCN 81, 285 lines) and `decode_container` (CCN 66, 209 lines) were single functions holding every record family's rules in one if/elif ladder. Both are now thin drivers over per-record-family helpers, with the per-type differences lifted out of the control flow into module-level descriptor tables keyed on record type — mirroring how `PROV_REC_CLS`/`PROV_N_MAP` key behaviour in `prov.constants`.

This is the enabler for the rest of the batch: the following changes all edit this module, and each now lands in one small helper instead of inside a 300-line ladder.

## Shape

Encoding splits into the genuinely different shapes rather than one helper per relation type (15 near-identical functions would have been worse than the ladder): `_encode_element` for entity/activity/agent triples, and `_encode_relation` plus `_encode_relation_head` / `_encode_relation_binary_triple` / `_encode_qualification_node` for the qualification pattern. Decoding splits along its existing phases — `_decode_type_triples`, `_decode_triples`, `_emit_decoded_records` — with the state dicts threaded through a `_DecodeState` dataclass.

The per-type predicate ladders become ordered `(needle, replacement)` tables (`_COMMON_PREDICATE_REWRITES`, `_RELATION_PREDICATE_REWRITES`, `_DECODE_PREDICATE_REWRITES`) applied in sequence, which reproduces the ladders' sequential semantics exactly — including cases where a later rewrite inspects the result of an earlier one (e.g. `prov:used` becoming `prov:entity` on a usage before the shared time/location rewrites run).

## Behaviour preservation

Pure refactor. Every quirk is copied verbatim and commented as such, including the ones later changes fix: #250's missing influencer property on anonymous qualified nodes, #258's alternate subject/object swap, the `PROV_ALTERNATE` `continue` that drops extra attributes, and #288's base64 decode. Batch 2a's literal machinery (`_FullPrecisionDoubleLiteral`, `_LOSSLESS_COLLAPSE_DATATYPES`, `encode_rdf_representation`, `decode_rdf_representation`, `literal_rdf_representation`) is untouched and still called the same way.

One deletion: the `rec_type in [PROV_ACTIVITY]` arm of the relation predicate ladder. It was unreachable — that code only runs where `is_relation()` is true, so `rec_type` is never an element type — and would have raised `TypeError` had it been reached (it compared a `QualifiedName` against a `URIRef` with `in`, and carried a `# type: ignore[operator]` plus a comment saying it was dead). Removing it makes `PROV_ACTIVITY` an unused import here; it remains importable from its documented home, `prov.constants`, and is outside the surface guarded by `test_public_api.py`. `ProvRDFSerializer`'s own API is unchanged.

## Parity evidence

Raw RDF output is **not** byte-stable across runs in this codebase — rdflib mints random blank-node labels, and decode additionally varies with blank-node ordering. Verified by running the capture twice against unmodified `master` first: every RDF format differed. So parity is proved with a canonicalised comparison instead of raw bytes:

- **encode**: per-graph canonical n-triples via `rdflib.compare.to_canonical_graph` (canonical blank-node relabelling), plus exact sorted namespace bindings and exact triple/blank-node counts.
- **decode**: a prefix-independent canonical dump of the decoded `ProvDocument` (every QualifiedName expanded to its full URI, records sorted), so randomised prefix minting (`ns1`/`ns2`/…) cannot mask a real difference.

Corpus: all 8 `examples.tests` documents, a document exercising the full `ATTRIBUTE_VALUES` datatype corpus, and every fixture under `tests/json/` and `tests/rdf/` — each encoded and round-tripped through trig, nt11, turtle, xml and nquads, with warnings captured. 4690 captures per run, run 3× on `master` and 10× on this branch under `PYTHONHASHSEED=0`.

```
captures                   : 4690
byte-identical old vs new  : 4656
nondeterministic (excluded):   34
REAL REGRESSIONS           :    0
```

The 34 exclusions are pre-existing nondeterminism, each confirmed to vary *within* a single version (old and/or new), not between versions. Two causes: blank-node-subject records where decode collapses `1` and `True` (equal in Python) and keeps whichever arrives first, and fixtures where an ordering-dependent `ProvExceptionInvalidQualifiedName` names `tag4` or `tag5`. The new code was observed producing both values across its 10 runs, so these are not behaviour changes.

## Complexity

| function | before | after |
| --- | --- | --- |
| `encode_container` | 81 | 8 |
| `decode_container` | 66 | 3 |
| `decode_rdf_representation` | 19 | 19 (unchanged) |
| module average CCN | 13.1 | 6.0 |

`uvx lizard -C 15` reports exactly one warning, the pre-declared exception: `decode_rdf_representation` at CCN 19, left alone deliberately as freshly-written literal-handling code that the next change edits. No new function exceeds CCN 13. Largest new helpers: `_encode_relation` (13), `_encode_element` (10), `_encode_relation_head` (10), `_register_record_type` (10), `_decode_attribute_triple` (10).

## Verification

```
uv run pytest -q                  1247 passed, 24 skipped, 2 xfailed  (unchanged)
HYPOTHESIS_PROFILE=ci pytest      3 passed (property round-trip)
uvx lizard -C 15 provrdf.py       1 warning (pre-declared CCN-19 exception)
uv run mypy src                   Success: no issues found in 17 source files
uv run ruff check src/            All checks passed!
uv run ruff format --check src/   51 files already formatted
```

Fixes #274