### PR TITLE
Correct the rdflib context-handling comment in encode_document (#96)

### DIFF
--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -637,14 +637,19 @@ class ProvRDFSerializer(Serializer):
             # #96: the context passed here must be a Dataset-owned graph
             # (via container.graph(), mirroring `default_graph` above), not
             # the standalone `bundle` Graph object itself -- passing that
-            # object directly makes rdflib 7.0.0's Dataset keep it as a
+            # object directly makes older rdflib Datasets keep it as a
             # distinct context with its own private NamespaceManager
             # (unlike a container.graph()-obtained one, which shares the
-            # Dataset's own), so the `override=False` bind loop below would
-            # silently have no effect on how this bundle's triples get
-            # abbreviated on output. rdflib >=7.1 normalizes either form to
-            # the same context internally, but container.graph() works
-            # uniformly across the whole supported range.
+            # Dataset's own). The bundle's own bindings still reach the
+            # output that way, but the `override=False` collision guarantee
+            # below silently does not: a bundle-local prefix colliding with
+            # a document-level one may clobber it instead of being renamed.
+            # That outcome is *order-dependent, not version-dependent* --
+            # with the standalone-Graph form it varies run to run on the
+            # same rdflib (observed flipping on 7.0.0 and 7.1.0 across
+            # fresh interpreters), so sampling one run per release invents
+            # a version boundary that does not exist. container.graph() is
+            # deterministic and correct on the 7.0.0 floor and upwards.
             named_graph = container.graph(bundle.identifier)
             container.addN((s, p, o, named_graph) for s, p, o in bundle)
             # #96: bundle-local namespace bindings (and the bundle's own
@@ -715,10 +720,15 @@ class ProvRDFSerializer(Serializer):
 
         for namespace in bundle.namespaces:
             container.bind(namespace.prefix, namespace.uri)
-        # #96: `bundle.namespaces` deliberately excludes the default
-        # namespace (see its docstring), so it needs its own bind() call
-        # here, under the empty prefix, for its terms to render as `:local`
-        # rather than a full IRI.
+        # #96: `bundle.namespaces` excludes the bundle's default namespace
+        # (a separate concept from the core prov/xsd/xsi namespaces that
+        # `get_registered_namespaces` excludes -- `set_default_namespace`
+        # never writes to the registered-namespace dict), so it needs its
+        # own bind() call here, under the empty prefix, for its terms to
+        # render as `:local` rather than a full IRI. Note this widens the
+        # surface of #294: a default- or bundle-namespace term whose local
+        # part ends in a character rdflib cannot abbreviate is now bound
+        # but still emitted as a full IRI, and fails to decode.
         default_namespace = bundle.get_default_namespace()
         if default_namespace is not None:
             container.bind("", default_namespace.uri)


### PR DESCRIPTION
Follow-up to #296, comments only, no behaviour change.

The comment added there claimed rdflib >=7.1 normalizes a standalone `Graph` passed as an `addN` context to the same object `container.graph()` returns. That is wrong, and so is the "broken on 7.0-7.2, fixed from 7.3" reading that one run per release suggests.

Measured against the pre-fix code with a document-level and a bundle-local namespace both claiming the `coll:` prefix, the collision outcome varies run to run on a single rdflib version. Eight fresh interpreters on the 7.0.0 floor gave a mix of correct and clobbered results, and 7.1.0 flipped the same way; 7.1.4 and 7.3.0 happened to come up clean in five runs each, which is exactly how sampling manufactures a version boundary that is not there. The behaviour is order-dependent, not version-dependent. The same eight runs against `container.graph()` were correct every time.

The comment now says that and drops the version claim rather than replacing it with a differently-wrong one. Also fixes a pointer to a docstring that does not document what it was cited for, and records that binding bundle-local and default namespaces widens the surface of #294.

Refs #96