### PR TITLE
Document #217 as a permanent PROV-O representational limitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,10 @@ Pytest-native throughout: plain `assert`, module-level `test_*` functions, no
   `HYPOTHESIS_PROFILE=ci`.
 - Shared coverage (`test_statements.py`, `test_attributes.py`, `test_qnames.py`,
   `test_examples.py`) runs once per target via the `roundtrip` fixture. **Known-lossy RDF cases
-  are intentional**: 14 skips in `test_statements.py` (#217), attached via per-function
-  `@pytest.mark.parametrize("fmt", [...])` so only the `rdf` param is marked. Don't "fix" these.
+  are intentional**: 14 skips in `test_statements.py`, documented as a permanent PROV-O
+  representational limitation in `docs/reference/conformance.md` (closed as #217), attached via
+  per-function `@pytest.mark.parametrize("fmt", [...])` so only the `rdf` param is marked. Don't
+  "fix" these.
 - `examples.py` (canonical example documents) and `attribute_values.py` (datatype corpus;
   order significant — some tests reference individual values by index) feed the shared modules
   and several others.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
+* PROV-O: documents containing multiple same-identifier relations with
+  differing formal attributes ("scruffy" statements) are documented as a
+  PROV-O representational limitation — they serialize but do not round-trip
+  through RDF, and deserializing such RDF now raises an error naming the
+  limitation; all other formats are unaffected (#217)
 * BREAKING: ``pydot`` and ``networkx`` are no longer unconditional runtime
   dependencies. ``import prov.dot`` now requires the ``dot`` extra
   (``pip install "prov[dot]"``) and ``import prov.graph`` the ``graph``

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -26,12 +26,32 @@ Every cell below was checked directly against the current source: model classes 
 
 More caveats apply across many rows rather than to one:
 
-- **[#217](https://github.com/trungdong/prov/issues/217)** (RDF): 14 statement-level test cases
-  assert two relations that share one identifier but differ only in `prov:time`; PROV-O has no
-  way to represent that (both times serialize onto the same qualified IRI), so those specific
-  *test cases* are skipped for the `rdf` target. This is a limitation of
-  same-identifier/differing-time relations, not of the relation types themselves —
-  `generation`/`usage`/`start`/`end`/`invalidation` round-trip cleanly in the general case.
+- **PROV-O representational limitation** (RDF, permanent — closed as
+  [#217](https://github.com/trungdong/prov/issues/217)): 14 statement-level test cases assert
+  two relations that share one identifier but differ only in `prov:time`; PROV-O has no
+  conformant way to encode that. PROV-O reifies a relation as a single qualified node (e.g.
+  `prov:qualifiedGeneration`) named directly by the relation's own identifier — one identifier
+  is one RDF node — so a second relation asserting the same identifier can only add more
+  triples to that one node, not create a second, distinguishable node; both `prov:atTime`
+  values end up on the same `prov:qualifiedGeneration` node with no way to tell which value
+  belongs to which asserted relation. There is no encoding that avoids this without either
+  minting a synthetic per-statement IRI (losing the asserted identifier ↔ node correspondence)
+  or fabricating unasserted statements by permuting attribute values on decode — both rejected
+  as options during the 3.0 audit. Accordingly this is documented as a **permanent** limitation
+  of the `rdf` target, not an open bug: the 14 test cases stay skipped for `rdf`
+  (`RDF_SCRUFFY_SKIP` in `test_statements.py`), and decoding third-party RDF with this shape
+  raises `prov.model.ProvException` naming the limitation and pointing back at this page. The
+  historical Java reference implementation (ProvToolbox) collapses identically on encode — its
+  own "scruffy" test fixtures produce one qualified node carrying both values as repeated
+  triples, with no IRI minting — and dropped RDF support entirely in its 2.x line rather than
+  keep the permutation-based decoder it once had. Only this same-identifier/differing-attribute
+  construct is affected: `generation`/`usage`/`start`/`end`/`invalidation` round-trip cleanly in
+  the general case, JSON/XML/PROV-N and the in-memory model are unaffected (the limitation is
+  specific to the PROV-O encoding, not to `prov`'s object model), and plain serialization of
+  such documents remains legal in 3.0 (`prov` never enforces structural constraints at
+  assertion time, [#257](https://github.com/trungdong/prov/issues/257)) — only `unified()`
+  gains conflict detection for records sharing an identifier with conflicting formal attributes,
+  as part of the separate PROV-CONSTRAINTS rework described in {doc}`../upgrading-3.0`.
 - **[#224](https://github.com/trungdong/prov/issues/224)** (XML): the PROV-XML serializer
   silently drops any `other_attributes` entry whose value is the empty string `""`, regardless
   of record type.
@@ -46,12 +66,12 @@ The value-typing and literal-semantics gaps the audit recorded here — #77, #89
 | --- | --- | --- | --- | --- | --- | --- |
 | Entity §5.1.1 | {py:class}`~prov.model.ProvEntity` | `entity()` | `entity` | ✓ | ✓ | ✓ |
 | Activity §5.1.2 | {py:class}`~prov.model.ProvActivity` | `activity()` | `activity` | ✓ | ✓ | ✓ |
-| Generation §5.1.3 | {py:class}`~prov.model.ProvGeneration` | `generation()` / `wasGeneratedBy()` | `wasGeneratedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
-| Usage §5.1.4 | {py:class}`~prov.model.ProvUsage` | `usage()` / `used()` | `used` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
+| Generation §5.1.3 | {py:class}`~prov.model.ProvGeneration` | `generation()` / `wasGeneratedBy()` | `wasGeneratedBy` | ✓ | ✓ | ✓ (permanent PROV-O representational limitation for the 2 same-id/differing-time cases — see above) |
+| Usage §5.1.4 | {py:class}`~prov.model.ProvUsage` | `usage()` / `used()` | `used` | ✓ | ✓ | ✓ (permanent PROV-O representational limitation for the 2 same-id/differing-time cases — see above) |
 | Communication §5.1.5 | {py:class}`~prov.model.ProvCommunication` | `communication()` / `wasInformedBy()` | `wasInformedBy` | ✓ | ✓ | ✓ |
-| Start §5.1.6 | {py:class}`~prov.model.ProvStart` | `start()` / `wasStartedBy()` | `wasStartedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 4 same-id/differing-time cases) |
-| End §5.1.7 | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` | `wasEndedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 4 same-id/differing-time cases) |
-| Invalidation §5.1.8 | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` | `wasInvalidatedBy` | ✓ | ✓ | ✓ ([#217](https://github.com/trungdong/prov/issues/217) for the 2 same-id/differing-time cases) |
+| Start §5.1.6 | {py:class}`~prov.model.ProvStart` | `start()` / `wasStartedBy()` | `wasStartedBy` | ✓ | ✓ | ✓ (permanent PROV-O representational limitation for the 4 same-id/differing-time cases — see above) |
+| End §5.1.7 | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` | `wasEndedBy` | ✓ | ✓ | ✓ (permanent PROV-O representational limitation for the 4 same-id/differing-time cases — see above) |
+| Invalidation §5.1.8 | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` | `wasInvalidatedBy` | ✓ | ✓ | ✓ (permanent PROV-O representational limitation for the 2 same-id/differing-time cases — see above) |
 
 {py:class}`~prov.model.ProvEntity` additionally exposes `wasGeneratedBy()`/`wasInvalidatedBy()`
 and {py:class}`~prov.model.ProvActivity` exposes

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -47,6 +47,7 @@ hook a warning onto — so this table is their only 2.4.0 signpost.
 | [#258](https://github.com/trungdong/prov/issues/258) | PROV-O output for `alternate()`/`alternateOf` transposes subject and object relative to the PROV-O cross reference: `alternate(alt1, alt2)` emits `alt2 prov:alternateOf alt1`, and decoding applies the same swap in reverse. | `alternate(alt1, alt2)` emits `alt1 prov:alternateOf alt2` (subject = first argument), and decoding maps the triple's subject straight onto the relation's first argument. `prov:alternateOf` is symmetric per PROV-CONSTRAINTS, so document-level (semantic) equality of `alternate()` statements is unaffected either way. | If you byte-compare PROV-O output for `alternateOf`, or hand-parse `alternateOf` triples and assume the pre-3.0 (transposed) argument order, re-check that code against 3.0. |
 | [#288](https://github.com/trungdong/prov/issues/288) | PROV-O (RDF) decoding of an `xsd:base64Binary` literal wraps the value in a Python bytes repr (e.g. `"b'aGVsbG8='"`) instead of returning the base64 text itself, corrupting the RDF round trip. | `xsd:base64Binary` literals are decoded to their base64 lexical text; a document with a base64Binary-typed attribute round-trips through RDF equal. | If you consume PROV-O produced by `prov` and process `xsd:base64Binary` attribute values, expect the base64 text (e.g. `"aGVsbG8="`) rather than a bytes repr. |
 | [#96](https://github.com/trungdong/prov/issues/96) | A namespace registered only on a bundle (not the document), or a document/bundle default namespace (`set_default_namespace()`), is never bound into the RDF serializer's namespace manager, so turtle/TriG output falls back to an rdflib-minted `ns1:`-style prefix, or a full IRI, instead of the declared prefix. | Bundle-local and default namespace prefixes are bound into the output alongside document-level ones; a bundle-local prefix colliding with a document-level one is renamed by rdflib rather than clobbering the document-level binding. | If you byte-compare turtle/TriG output, expect different (and now-declared) prefix labels; document-level (semantic) equality is unaffected. |
+| [#217](https://github.com/trungdong/prov/issues/217) | A document containing two relations that share one identifier but disagree on a formal attribute (e.g. two `wasGeneratedBy` statements for the same identifier asserting different `prov:time` — the "scruffy" pattern referenced below) serializes to RDF without error, but PROV-O has no way to represent the construct: both values land on the same qualified node, so decoding that RDF back raised a raw, unhelpful `ProvException`. | Not a fix — **documented as a permanent PROV-O representational limitation** (see {doc}`reference/conformance`): the RDF serializer's decoder now raises a chained `prov.model.ProvException` that names the limitation and points at that page instead of the raw underlying error. Serialization itself, and every other format (JSON, XML, PROV-N) plus the in-memory model, are unaffected — the construct round-trips cleanly through all of them; only decoding RDF containing this shape is affected. | If you decode third-party RDF and hit this error, the source document encodes a construct PROV-O cannot represent; there is no `prov`-side fix to apply — give the differing relations distinct identifiers (or omit the identifier) instead of reusing one. |
 
 ## Unification rework (PROV-CONSTRAINTS)
 
@@ -71,10 +72,14 @@ term unification). Concretely:
 **What to do:** if your code calls `unified()` on documents where records sharing an
 identifier can disagree on a formal attribute (for example, two `wasGeneratedBy`
 statements for the same identifier asserting different `prov:time` values — the
-"scruffy" pattern used in this repo's own test suite), expect that call to raise in 3.0
-where it previously merged silently. Catch the new exception (or restructure the
-document to avoid conflicting formal attributes) before upgrading. Documents without
-this pattern are unaffected.
+"scruffy" pattern used in this repo's own test suite, and the RDF representational
+limitation tracked as #217 above), expect that call to raise in 3.0 where it previously
+merged silently. Catch the new exception (or restructure the document to avoid
+conflicting formal attributes) before upgrading. Documents without this pattern are
+unaffected. Note that this is strictly an opt-in `unified()` behaviour: `prov` performs
+no structural validation at assertion/serialization time (see #257), so building and
+serializing a "scruffy" document remains legal in 3.0 — only calling `unified()` on one,
+or decoding its RDF form, raises.
 
 Note that `prov_to_dot()` (`prov.dot`) and `prov_to_graph()` (`prov.graph`, not
 `graph_to_prov()`, which does not unify) call `unified()` internally, so the

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1418,6 +1418,20 @@ class ProvRDFSerializer(Serializer):
         ):
             if needle in str(pred_new):
                 pred_new = replacement
+        # NOTE: `str(pred_new)` is the short prefixed form (e.g. "prov:time")
+        # when `pred_new` came from `predicate_mapper` (a QualifiedName), but
+        # `val.uri` below is always the full URI -- so a PREDICATE_MAP-routed
+        # predicate (atTime/startedAtTime/endedAtTime/atLocation/hadRole/...)
+        # never matches here and falls through to `other_attributes` instead
+        # (a single occurrence is still recovered downstream, since
+        # ProvRecord.add_attributes() matches extras against formal
+        # attributes by qname on its own). This is deliberate, not an
+        # oversight: matching it here would route repeated instances of such
+        # a predicate into `unique_sets`, and `walk()` in
+        # `_emit_decoded_records` would then emit more than one record for
+        # the *same* identifier -- i.e. resurrect the rejected
+        # permutation-decode option (see docs/reference/conformance.md) for
+        # an identified qualified node. Do not "fix" this format mismatch.
         if str(pred_new) in [val.uri for val in state.formal_attributes[subj]]:
             qname_key = self.document.mandatory_valid_qname(pred_new)  # type: ignore[union-attr]
             state.formal_attributes[subj][qname_key] = obj1
@@ -1448,7 +1462,9 @@ class ProvRDFSerializer(Serializer):
                 doesn't track separately (e.g. two ``prov:atTime`` triples
                 on one identified qualified node) -- the documented,
                 permanent PROV-O representational limitation described in
-                ``docs/reference/conformance.md``.
+                ``docs/reference/conformance.md``. Any other ``ProvException``
+                raised while constructing a record (e.g. an unresolvable
+                qualified name) propagates unchanged.
         """
         for subj in state.record_types:
             attrs = state.other_attributes.get(subj)
@@ -1476,30 +1492,78 @@ class ProvRDFSerializer(Serializer):
                         attrs,
                     )
             except pm.ProvException as exc:
-                # A repeated formal-attribute predicate that isn't tracked
-                # through `unique_sets` (e.g. two prov:atTime triples on one
-                # qualified node) reaches ProvRecord.add_attributes() as
-                # duplicate plain attributes and raises there. PROV-O
-                # represents a same-identifier relation as a single
-                # qualified node, so it has no way to hold two values for
-                # one formal attribute of that relation -- this is a
-                # documented, permanent PROV-O representational limitation
-                # (not a bug on a fix path); see
-                # https://github.com/trungdong/prov/blob/master/docs/reference/conformance.md
+                # Only relabel the specific #217 shape: a formal-attribute
+                # predicate repeated in `attrs` (see the duplicate-detection
+                # docstring below for why such repeats land there instead of
+                # being walked). Anything else -- e.g. an unresolvable
+                # qualified name -- is a genuinely different failure and
+                # must propagate with its original message, not this one.
+                duplicate_attr = _repeated_formal_attribute(
+                    state.record_types[subj], attrs
+                )
+                if duplicate_attr is None:
+                    raise
                 raise pm.ProvException(
                     f"Cannot decode {subj!r} as a single "
-                    f"{state.record_types[subj]} record: {exc}. This is a "
-                    "documented PROV-O representational limitation -- "
-                    "PROV-O reifies a relation as one qualified node named "
-                    "by its identifier, so two same-identifier relations "
-                    "that disagree on a formal attribute (e.g. two "
-                    "prov:atTime values) cannot both be represented. See "
+                    f"{state.record_types[subj]} record: more than one "
+                    f"value for formal attribute {duplicate_attr!r} ({exc}). "
+                    "This is a documented PROV-O representational "
+                    "limitation -- PROV-O reifies a relation as one "
+                    "qualified node named by its identifier, so two "
+                    "same-identifier relations that disagree on a formal "
+                    "attribute (e.g. two prov:atTime values) cannot both be "
+                    "represented. See "
                     "https://github.com/trungdong/prov/blob/master/docs/reference/conformance.md "
                     "for details."
                 ) from exc
 
             if attrs is not None:
                 del state.other_attributes[subj]
+
+
+def _repeated_formal_attribute(
+    record_type: pm.QualifiedName,
+    attrs: list[tuple[pm.QualifiedNameCandidate, Any]] | None,
+) -> str | None:
+    """Return the formal-attribute name repeated in ``attrs``, if any.
+
+    A predicate that :data:`PREDICATE_MAP` maps to a formal-attribute
+    ``QualifiedName`` (e.g. ``prov:atTime``) never matches the URI-keyed
+    lookup in :meth:`ProvRDFSerializer._decode_attribute_triple`
+    (``str(pred_new)`` is the short prefixed form, e.g. ``"prov:time"``,
+    compared against the full-URI ``val.uri`` of each formal-attribute
+    ``QualifiedName`` -- deliberately left as-is, since "fixing" it would
+    route such predicates into ``unique_sets`` and make ``walk()`` emit
+    more than one record for the *same* identifier, i.e. the rejected
+    permutation-decode option). A second instance of such a predicate on
+    the same identified qualified node therefore lands in ``attrs`` as two
+    same-key entries instead of being tracked there, and reaches
+    :meth:`~prov.model.records.ProvRecord.add_attributes` as a duplicate
+    plain attribute, which raises ``ProvException``. This function
+    recognizes that specific shape so callers can relabel only it, leaving
+    every other ``ProvException`` (e.g. an unresolvable qualified name)
+    untouched.
+
+    Args:
+        record_type: The record type being constructed.
+        attrs: The subject's non-formal attributes, as passed to
+            :meth:`~prov.model.ProvBundle.new_record`.
+
+    Returns:
+        The (string) formal-attribute name that appears more than once in
+        ``attrs``, or ``None`` if ``attrs`` has no such repeat.
+    """
+    if not attrs:
+        return None
+    formal_names = {str(q) for q in pm.PROV_REC_CLS[record_type].FORMAL_ATTRIBUTES}
+    seen: set[str] = set()
+    for key, _value in attrs:
+        key_str = str(key)
+        if key_str in formal_names:
+            if key_str in seen:
+                return key_str
+            seen.add(key_str)
+    return None
 
 
 def walk(

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1544,6 +1544,14 @@ def _repeated_formal_attribute(
     every other ``ProvException`` (e.g. an unresolvable qualified name)
     untouched.
 
+    Note: on a qualified node, ``Start``/``End`` carry their time as
+    ``prov:atTime`` too, matching every other timed relation's generic
+    ``prov:time`` formal attribute -- *not* the binary-triple predicates
+    ``prov:startedAtTime``/``prov:endedAtTime``, which apply to the
+    Activity rather than the qualified Start/End node. Decoding those
+    binary-predicate spellings on a qualified node is a separate,
+    currently-mishandled path tracked as #299, out of scope here.
+
     Args:
         record_type: The record type being constructed.
         attrs: The subject's non-formal attributes, as passed to

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1441,6 +1441,14 @@ class ProvRDFSerializer(Serializer):
             bundle: Bundle to add the records to.
             state: Decode state; consumed attributes are removed from it, so
                 what remains afterwards is what could not be converted.
+
+        Raises:
+            ProvException: If a subject carries more than one value for a
+                formal attribute that :attr:`_DecodeState.unique_sets`
+                doesn't track separately (e.g. two ``prov:atTime`` triples
+                on one identified qualified node) -- the documented,
+                permanent PROV-O representational limitation described in
+                ``docs/reference/conformance.md``.
         """
         for subj in state.record_types:
             attrs = state.other_attributes.get(subj)
@@ -1449,23 +1457,46 @@ class ProvRDFSerializer(Serializer):
                 for qname, values in state.unique_sets[subj].items()
                 if values and len(values) > 1
             ]
-            if items_to_walk:
-                for subset in list(walk(items_to_walk)):
-                    for prov_type, value in subset.items():
-                        state.formal_attributes[subj][prov_type] = value
+            try:
+                if items_to_walk:
+                    for subset in list(walk(items_to_walk)):
+                        for prov_type, value in subset.items():
+                            state.formal_attributes[subj][prov_type] = value
+                        bundle.new_record(
+                            state.record_types[subj],
+                            subj,
+                            state.formal_attributes[subj].items(),
+                            attrs,
+                        )
+                else:
                     bundle.new_record(
                         state.record_types[subj],
                         subj,
                         state.formal_attributes[subj].items(),
                         attrs,
                     )
-            else:
-                bundle.new_record(
-                    state.record_types[subj],
-                    subj,
-                    state.formal_attributes[subj].items(),
-                    attrs,
-                )
+            except pm.ProvException as exc:
+                # A repeated formal-attribute predicate that isn't tracked
+                # through `unique_sets` (e.g. two prov:atTime triples on one
+                # qualified node) reaches ProvRecord.add_attributes() as
+                # duplicate plain attributes and raises there. PROV-O
+                # represents a same-identifier relation as a single
+                # qualified node, so it has no way to hold two values for
+                # one formal attribute of that relation -- this is a
+                # documented, permanent PROV-O representational limitation
+                # (not a bug on a fix path); see
+                # https://github.com/trungdong/prov/blob/master/docs/reference/conformance.md
+                raise pm.ProvException(
+                    f"Cannot decode {subj!r} as a single "
+                    f"{state.record_types[subj]} record: {exc}. This is a "
+                    "documented PROV-O representational limitation -- "
+                    "PROV-O reifies a relation as one qualified node named "
+                    "by its identifier, so two same-identifier relations "
+                    "that disagree on a formal attribute (e.g. two "
+                    "prov:atTime values) cannot both be represented. See "
+                    "https://github.com/trungdong/prov/blob/master/docs/reference/conformance.md "
+                    "for details."
+                ) from exc
 
             if attrs is not None:
                 del state.other_attributes[subj]

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -176,19 +176,22 @@ def _populate(draw, container: ProvBundle) -> list[str]:
     # another bundle's identifier), so `prov_documents` emits it separately once
     # a sub-bundle has been drawn.
     #
-    # #217: PROV-O cannot represent two relations of the same kind between the
+    # PROV-O cannot represent two relations of the same kind between the
     # same primary endpoints that differ only in a *qualifying* formal attribute
     # (e.g. prov:time) — one collapses or loses an attribute on the RDF round
-    # trip. Anonymity alone does NOT avoid this. We therefore keep at most one
-    # relation of each kind per (endpoint1, endpoint2) pair (the `fresh` guard
-    # below), which is exactly the construct #217 tracks; excluding it is a
-    # generation-validity narrowing, not a serializer change. The guard is
-    # deliberately conservative — broader than #217's exact same-identifier
-    # shape — because it also forecloses #226-style collapse: it suppresses e.g.
-    # two `association`s sharing (activity, agent) but differing by `plan`.
-    # Those non-delegation qualified variants (association `plan`, start/end
-    # `starter`/`ender`) were verified to round-trip cleanly, so the guard
-    # forecloses #217/#226-style loss without masking any other known bug.
+    # trip. Anonymity alone does NOT avoid this. This is the permanent,
+    # documented PROV-O representational limitation explained in
+    # docs/reference/conformance.md (no conformant encoding exists for it).
+    # We therefore keep at most one relation of each kind per (endpoint1,
+    # endpoint2) pair (the `fresh` guard below), which is exactly that
+    # construct; excluding it is a generation-validity narrowing, not a
+    # serializer change. The guard is deliberately conservative — broader than
+    # the exact same-identifier shape — because it also forecloses #226-style
+    # collapse: it suppresses e.g. two `association`s sharing (activity, agent)
+    # but differing by `plan`. Those non-delegation qualified variants
+    # (association `plan`, start/end `starter`/`ender`) were verified to
+    # round-trip cleanly, so the guard forecloses this loss without masking
+    # any other known bug.
     seen: set[tuple[str, str, str]] = set()
 
     def fresh(kind: str, e1: str, e2: str) -> bool:

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -19,7 +19,7 @@ from rdflib.compare import graph_diff
 from rdflib.graph import Dataset, Graph
 
 import prov.model as pm
-from prov.model import ProvDocument, ProvException
+from prov.model import ProvDocument, ProvException, ProvExceptionInvalidQualifiedName
 from prov.serializers.provrdf import (
     ProvRDFException,
     ProvRDFSerializer,
@@ -414,6 +414,36 @@ def test_decode_scruffy_qualified_generation_raises_documented_limitation():
     assert "conformance.md" in message
     # The chained original ProvException is preserved, not swallowed.
     assert isinstance(ctx.value.__cause__, ProvException)
+
+
+def test_decode_unrelated_provexception_is_not_relabelled_as_scruffy():
+    # Regression: the #217 catch in _emit_decoded_records() must only
+    # relabel the specific duplicate-formal-attribute failure above, not
+    # every ProvException raised while building a record. This document has
+    # no duplication at all -- a single prov:activity triple pointing at a
+    # blank node (which cannot resolve to a valid QualifiedName) and a
+    # single prov:atTime triple -- so it must fail exactly as it does on
+    # master: a plain ProvExceptionInvalidQualifiedName, not the #217
+    # message.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix ex: <http://example.org/> .
+
+    ex:e1 a prov:Entity ;
+        prov:qualifiedGeneration ex:gen1 .
+
+    ex:gen1 a prov:Generation ;
+        prov:activity _:b1 ;
+        prov:atTime "2012-01-01T00:00:00"^^xsd:dateTime .
+    """
+    with pytest.raises(ProvExceptionInvalidQualifiedName) as ctx:
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    message = str(ctx.value)
+    assert "documented PROV-O representational limitation" not in message
+    assert "conformance.md" not in message
+    assert message.startswith("Invalid Qualified Name:")
 
 
 def test_alternate_triple_follows_dm_argument_order():

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -6,6 +6,7 @@ pytest-native ``fmt`` matrix (see ``conftest.py`` and the ``test_statements``/
 only the genuinely RDF-specific cases.
 """
 
+import datetime
 import logging
 import os
 import struct
@@ -408,6 +409,45 @@ def test_decode_scruffy_qualified_generation_raises_documented_limitation():
     """
     with pytest.raises(ProvException) as ctx:
         ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    message = str(ctx.value)
+    assert "documented PROV-O representational limitation" in message
+    assert "conformance.md" in message
+    # The chained original ProvException is preserved, not swallowed.
+    assert isinstance(ctx.value.__cause__, ProvException)
+
+
+@pytest.mark.parametrize(
+    "factory_name, args",
+    [
+        ("generation", ("ex:e1", "ex:a1")),
+        ("usage", ("ex:a1", "ex:e1")),
+        ("start", ("ex:a1", "ex:e1")),
+        ("end", ("ex:a1", "ex:e1")),
+        ("invalidation", ("ex:e1", "ex:a1")),
+    ],
+)
+def test_decode_scruffy_relations_raise_documented_limitation(factory_name, args):
+    # #217: all five relation families with a qualified PROV-O form --
+    # generation/usage/start/end/invalidation -- share the same permanent
+    # representational limitation (docs/reference/conformance.md), and the
+    # 14 skipped round-trip cases in test_statements.py cover exactly this
+    # shape for each of them. Build the scruffy construct with prov's own
+    # model and serializer (rather than hand-authoring PROV-O, as the
+    # single-family test above does) so this test tracks what prov itself
+    # actually emits for each family, not a guess at it.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    factory = getattr(document, factory_name)
+    factory(*args, identifier="ex:rel1", time=datetime.datetime(2012, 1, 1))
+    factory(*args, identifier="ex:rel1", time=datetime.datetime(2013, 1, 1))
+
+    rdf = document.serialize(format="rdf")
+
+    with pytest.raises(ProvException) as ctx:
+        ProvDocument.deserialize(content=rdf, format="rdf")
 
     message = str(ctx.value)
     assert "documented PROV-O representational limitation" in message

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -19,7 +19,7 @@ from rdflib.compare import graph_diff
 from rdflib.graph import Dataset, Graph
 
 import prov.model as pm
-from prov.model import ProvDocument
+from prov.model import ProvDocument, ProvException
 from prov.serializers.provrdf import (
     ProvRDFException,
     ProvRDFSerializer,
@@ -382,6 +382,38 @@ def test_decode_multi_valued_qualified_relation_produces_cartesian_product():
         if name.localpart == "entity"
     }
     assert {str(qn) for qn in used_entities} == {"ex:e1", "ex:e2"}
+
+
+def test_decode_scruffy_qualified_generation_raises_documented_limitation():
+    # #217, closed as a permanent PROV-O representational limitation (see
+    # docs/reference/conformance.md): PROV-O reifies a relation as a single
+    # qualified node named by its own identifier, so two prov:atTime values
+    # on the *same* identified prov:qualifiedGeneration node cannot be told
+    # apart on decode. Unlike the anonymous-bnode cartesian-product case
+    # above, this identified-node shape must raise rather than silently
+    # fabricate two same-identifier records.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix ex: <http://example.org/> .
+
+    ex:e1 a prov:Entity ;
+        prov:qualifiedGeneration ex:gen1 .
+    ex:a1 a prov:Activity .
+
+    ex:gen1 a prov:Generation ;
+        prov:activity ex:a1 ;
+        prov:atTime "2012-01-01T00:00:00"^^xsd:dateTime,
+            "2013-01-01T00:00:00"^^xsd:dateTime .
+    """
+    with pytest.raises(ProvException) as ctx:
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    message = str(ctx.value)
+    assert "documented PROV-O representational limitation" in message
+    assert "conformance.md" in message
+    # The chained original ProvException is preserved, not swallowed.
+    assert isinstance(ctx.value.__cause__, ProvException)
 
 
 def test_alternate_triple_follows_dm_argument_order():

--- a/src/prov/tests/test_statements.py
+++ b/src/prov/tests/test_statements.py
@@ -4,7 +4,8 @@ Migrated from the ``TestStatementsBase`` mixin (``statements.py``): each test
 method becomes a module-level function taking the ``roundtrip`` fixture, which
 runs it once per target in ``SHARED_TARGETS`` (model/json/xml/rdf). The 14
 "scruffy" cases opt out of the shared ``fmt`` fixture with their own explicit
-parametrization so the rdf param can be skipped (issue #217; see the
+parametrization so the rdf param can be skipped (permanent PROV-O
+representational limitation, see ``docs/reference/conformance.md``; the
 ``scruffy_fmt`` decorator below). The legacy mixin remains for the
 not-yet-migrated ``test_dot.py``.
 """
@@ -25,12 +26,15 @@ _TIME_2012 = datetime.datetime(
 # The 14 "scruffy" documents below add two relations sharing one identifier
 # but differing prov:time; PROV-O cannot represent this (both times serialize
 # onto the one qualified IRI, and deserialization then raises ProvException:
-# "Cannot have more than one value for attribute prov:time"). This is an
-# accepted PROV-O representational limitation, not a bug on a fix path, so the
-# rdf param is skipped rather than xfailed (design doc §2/§3, issue #217).
+# "Cannot have more than one value for attribute prov:time"). This is a
+# permanent, documented PROV-O representational limitation, not a bug on a
+# fix path, so the rdf param is skipped rather than xfailed — see
+# docs/reference/conformance.md for the full explanation of why no
+# conformant RDF encoding exists.
 RDF_SCRUFFY_SKIP = pytest.mark.skip(
     reason="PROV-O cannot represent same-identifier relations differing by "
-    "prov:time — accepted limitation, issue #217",
+    "prov:time — permanent, documented limitation, see "
+    "docs/reference/conformance.md",
 )
 
 # These functions opt out of the module-wide `fmt` fixture (see conftest.py)


### PR DESCRIPTION
## Summary

Closes #217.

**Decision: Option A (documented limitation, no IRI minting, no permutation decode).** Same-identifier relations with differing formal attributes ("scruffy" statements) are already PROV-CONSTRAINTS-invalid (same-id statements with conflicting formal attributes violate uniqueness after key-merging), so building decode machinery to resurrect them through the one format that structurally cannot hold them is misplaced effort. Documenting the limitation costs nothing and can be compatibly relaxed later (error -> permute) if real-world demand appears, whereas shipping a permutation decode and reverting it would break users.

Rejected alternatives, kept on record:
- Minting per-statement qualified-node IRIs: the emitted RDF would no longer use the asserted identifier as the qualified-node IRI, losing the id <-> node correspondence; any scheme is prov-proprietary.
- ProvToolbox-style permutation decode on the RDF side: fabricates unasserted statements for >=2-attribute divergence and yields multiple same-id records on RDF input -- the worst failure mode for a provenance library.

Reference-implementation evidence (ProvToolbox, checked against its history): the Java stack collapses identically to prov's on encode -- its own "scruffy" fixtures show one qualified node carrying both attribute values as repeated triples, with no IRI minting. Its historical decode-side permutation reconstruction (`QualifiedCollector`) was not carried forward; ProvToolbox itself dropped RDF support entirely in its 2.x line.

## Changes

- `docs/reference/conformance.md`: the #217 caveat and the per-row RDF notes (Generation/Usage/Start/End/Invalidation) are reworded from open-issue caveats to a permanent documented limitation, explaining *why* no conformant PROV-O encoding exists (one identifier is one RDF node) and noting the ProvToolbox encode parity.
- `docs/upgrading-3.0.md`: a new limitation row -- scruffy documents serialize to RDF but do not round-trip; JSON/XML/PROV-N and the in-memory model are unaffected; decoding such RDF now raises with a pointer at the documentation. Also cross-references the existing `unified()` PROV-CONSTRAINTS section to the #257 lock (no assertion-time enforcement of structural constraints -- plain serialization of a scruffy document stays legal in 3.0; only `unified()` and RDF decode raise).
- `src/prov/serializers/provrdf.py`: `_emit_decoded_records` now catches the model-level `ProvException` ("Cannot have more than one value for attribute ...") raised when qualified-node reassembly hits a duplicate formal attribute, and re-raises a chained `ProvException` naming the limitation and pointing at `docs/reference/conformance.md`. `records.py` is untouched.
- `src/prov/tests/test_statements.py` / `src/prov/tests/strategies.py`: the `RDF_SCRUFFY_SKIP` reason and the same-kind-relation-pair exclusion comment now point at conformance.md instead of the (now-closed) issue. No skip marker lifted -- skip count is unchanged at 24.
- `src/prov/tests/test_rdf.py`: new test decoding inline trig with two `prov:atTime` values on one identified `prov:qualifiedGeneration` node, asserting the raised `ProvException` names the documented limitation and is chained from the original exception.
- `HISTORY.rst`, `CLAUDE.md`: updated to describe the permanent-limitation framing instead of an open issue.

## Test plan

- [x] `uv run pytest -q src/prov/tests/test_statements.py src/prov/tests/test_rdf.py` -- 605 passed, 14 skipped
- [x] `uv run pytest -q` (full suite) -- 1269 passed, 24 skipped, 1 xfailed (skip count unchanged; +1 new test)
- [x] `uv run ruff check src/` -- clean
- [x] `uv run ruff format --check src/` -- clean
- [x] `uv run mypy src` -- clean
- [x] Confirmed the new test fails with the original (unhelpful) error message when the chaining change is reverted
- [x] Sphinx docs build clean (`sphinx-build -b html docs docs/_build/html`)