### PR TITLE
Document bare mentionOf as the deliberate PROV-N syntax

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,6 +86,10 @@ History
 * Security: PROV-XML parsing no longer resolves DTD entities and never
   touches the network (``resolve_entities=False``, ``no_network=True``),
   closing an XXE surface on untrusted input (#273)
+* PROV-N continues to emit Mention as bare ``mentionOf(...)`` — the
+  de-facto syntax of the reference implementations for the last decade —
+  rather than the ``prov:mentionOf`` form derivable from the PROV-Links
+  note; now documented as a deliberate deviation (#248)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -159,7 +159,7 @@ attribute a bundle to an agent as a first-class PROV statement. Tracked as
 | --- | --- | --- | --- | --- | --- | --- |
 | Specialization §5.5.1 | {py:class}`~prov.model.ProvSpecialization` | `specialization()` / `specializationOf()` | `specializationOf` | ✓ | ✓ | ✓ |
 | Alternate §5.5.2 | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` | `alternateOf` | ✓ | ✓ | ✓ (the RDF triple follows the PROV-DM argument order — `alternate(alt1, alt2)` emits `alt1 prov:alternateOf alt2` — since 3.0: [#258](https://github.com/trungdong/prov/issues/258)) |
-| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` (emitted *without* the `prov:` prefix the PROV-Links grammar requires: [#248](https://github.com/trungdong/prov/issues/248)) | ✓ | ✓ | ✓ |
+| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` (emitted as a bare keyword, not the `prov:` prefix the PROV-Links grammar requires — this is a deliberate documented deviation: the bare form has been the de-facto output of reference implementations for the last decade and matches ProvToolbox's ANTLR grammar, so `provconvert` keeps parsing prov's output; closed as design decision 2026-07-20, [#248](https://github.com/trungdong/prov/issues/248)) | ✓ | ✓ | ✓ |
 
 ## Component 6 — Collections
 

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -65,3 +65,24 @@ def test_attribute_name_plain_unchanged():
     document = _doc()
     document.entity("ex:e1", {"ex:plain_key": "value"})
     assert '[ex:plain_key="value"]' in document.get_provn()
+
+
+def test_mention_bare_keyword_no_prefix():
+    """PROV-N Mention emits bare mentionOf(...) without prov: prefix (decision 2026-07-20).
+
+    The PROV-Links specification grammar requires prov:mentionOf, but the bare keyword has
+    been the de-facto output of reference implementations for the last decade and matches
+    ProvToolbox's ANTLR grammar (PROV_N.g:338), so provconvert keeps parsing prov's output.
+    This test locks in the current syntax to prevent silent regressions.
+    """
+    document = _doc()
+    bundle = document.bundle("ex:bundle1")
+    bundle.entity("ex:report1bis")
+    bundle.mentionOf("ex:report1bis", "ex:report1", "ex:bundle2")
+    provn = document.get_provn()
+
+    # Assert bare mentionOf keyword is present
+    assert "mentionOf(ex:report1bis, ex:report1, ex:bundle2)" in provn
+
+    # Assert prov:mentionOf is NOT present (spec-exact form not used)
+    assert "prov:mentionOf" not in provn

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -1,4 +1,5 @@
-"""PROV-N local-part metacharacter escaping (#223, PROV-N [53]/[55])."""
+"""PROV-N output correctness: local-part metacharacter escaping (#223, PROV-N
+[53]/[55]) and Mention keyword rendering (#248)."""
 
 import pytest
 
@@ -81,8 +82,11 @@ def test_mention_bare_keyword_no_prefix():
     bundle.mentionOf("ex:report1bis", "ex:report1", "ex:bundle2")
     provn = document.get_provn()
 
-    # Assert bare mentionOf keyword is present
     assert "mentionOf(ex:report1bis, ex:report1, ex:bundle2)" in provn
 
-    # Assert prov:mentionOf is NOT present (spec-exact form not used)
+    # This negative assertion is the one that actually guards the decision, and
+    # it is not the redundant twin of the line above: ``mentionOf(`` is a
+    # substring of ``prov:mentionOf(``, so a regression to the spec-exact form
+    # would still satisfy the positive assertion. Do not remove this as dead
+    # weight.
     assert "prov:mentionOf" not in provn


### PR DESCRIPTION
## Summary

PROV-N continues to emit Mention relations as bare `mentionOf(...)` rather than the `prov:mentionOf` form the PROV-Links specification requires. This is a deliberate deviation, now documented.

Rationale: the bare keyword has been the de-facto output of reference implementations for the last decade and matches ProvToolbox's ANTLR grammar (PROV_N.g:338), so `provconvert` keeps parsing prov's output. Adopting the spec-exact form would break a decade of interoperability for no practical gain.

**Maintainer decision, 2026-07-20:** keep the current form without change.

## Changes

- Added lock-in test `test_mention_bare_keyword_no_prefix` in `src/prov/tests/test_provn_escaping.py` to assert the PROV-N output uses bare `mentionOf(...)` without `prov:` prefix
- Reworded the Mention row in `docs/reference/conformance.md` to describe this as a documented deviation (not a pending defect)
- Updated `HISTORY.rst` with the disposition

## Test Plan

- Full test suite passes: 1315 passed (was 1314), 24 skipped (unchanged), 0 xfailed (unchanged)
- No changes to serializer or model code (`src/prov/`)
- Ruff lint and format pass
- Mypy passes

Closes #248