### PR TITLE
Widen the #294 generation exclusion to every trailing metacharacter

### DIFF
--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -40,14 +40,20 @@ EX_NS = Namespace("ex", NAMESPACES["ex"])
 # module docstring) is exercised separately by the hand-written cases in
 # test_provn_escaping.py. Non-ASCII deliberately lives in the string
 # attribute *values* below (criterion 1), never in identifiers.
-# A local part ending in one of these cannot be written as an abbreviated
-# turtle/TriG name, so rdflib emits the term as a full IRI and drops the
-# prefix declaration; reading it back then fails in ``compute_qname`` with
-# ``ValueError: Can't split ...`` — #294, a PROV-O decode defect. Only the
-# *final* character matters (inner and leading occurrences round-trip), so
-# the alphabet itself stays widened and just the trailing position is
-# constrained. Remove this filter when #294 is fixed.
-_RDF_UNSPLITTABLE_TRAILING = "=',:;[]"
+# A local part ending in one of these can leave rdflib unable to write the
+# term as an abbreviated turtle/TriG name, so it emits a full IRI and drops
+# the prefix declaration; reading it back then fails in ``compute_qname``
+# with ``ValueError: Can't split ...`` — #294, a PROV-O decode defect.
+#
+# Whether a given name actually breaks depends on more than its last
+# character — ``a(`` round-trips while ``g:)`` does not — because rdflib
+# scans backwards for a legal split point and what it finds depends on the
+# whole local part. What holds across the failures is the converse: a local
+# part ending in an alphanumeric never fails. Excluding every metacharacter
+# in trailing position is therefore a conservative rule that covers all of
+# them (it also excludes some names that would have worked, which costs a
+# little generation diversity and nothing else). Remove when #294 is fixed.
+_RDF_UNSPLITTABLE_TRAILING = "='(),:;[]"
 
 local_part = st.text(
     alphabet=string.ascii_lowercase + string.digits + "='(),:;[]",


### PR DESCRIPTION
The exclusion added alongside #294 covered `= ' , : ; [ ]`, based on a single-metacharacter probe in which `(` and `)` appeared to round-trip. That probe was too narrow.

The property suite subsequently failed on `entity(ex:g:))` with `ValueError: Can't split 'http://example.org/g:)'`. An exhaustive sweep over one-, two- and three-character local parts drawn from the metacharacter alphabet found 1323 failing names, 224 of which end in `(` or `)`.

Whether a name breaks is not determined by its last character alone — `a(` round-trips while `g:)` does not — because rdflib scans backwards for a legal split point and what it finds depends on the whole local part. The converse does hold across every failure observed: a local part ending in an alphanumeric never fails. Excluding all nine metacharacters in trailing position is therefore a conservative rule covering all of them. It also excludes some names that would have worked, which costs a little generation diversity and nothing else.

Verified with five default-profile and three ci-profile runs against a fresh Hypothesis database each time, plus a 4000-example probe over the same strategy — none reproduced the failure.

This widens a test-generation exclusion only; no library code changes. The exclusion comes out when #294 is fixed, and #294's characterisation has been corrected accordingly.

Refs #294