### PR TITLE
Fix find_diff blindness to single-triple differences (#304)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -90,6 +90,10 @@ History
   de-facto syntax of the reference implementations for the last decade —
   rather than the ``prov:mentionOf`` form derivable from the PROV-Links
   note; now documented as a deliberate deviation (#248)
+* Test infrastructure: the RDF fixture-comparison helper ``find_diff()`` now
+  correctly detects single-triple differences in test assertions (previously
+  a one-triple difference was invisible, masking potential regressions in
+  fixture expectations) (#304)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/superpowers/plans/2026-07-20-3.0-batch2c-provo-decode-fidelity.md
+++ b/docs/superpowers/plans/2026-07-20-3.0-batch2c-provo-decode-fidelity.md
@@ -1,0 +1,170 @@
+# prov 3.0 Batch 2c: PROV-O Decode Fidelity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four PROV-O decode-fidelity defects that batch 2b surfaced but deliberately did not fix — a blind test helper (#304), misfiled Start/End times (#299), anonymous relations decoding to two records (#303), and qualified names that cannot be read back at all (#294) — and lift the generation-time exclusion that currently masks the last of them.
+
+**Architecture:** Four tasks, each one focused PR merged to master with green CI. **Task 1 (#304) goes first and is not optional ordering**: `find_diff` is currently blind to any one-triple difference, so `test_json_to_ttl_match` cannot detect a single-triple regression in an `rdf/` fixture expectation. Tasks 2–4 all change decode output, and Task 4 changes it for the fixture corpus specifically. Restoring the helper first means the remaining tasks land against a fixture check that actually works, instead of one that silently passes. Tasks 2 and 3 are independent decode fixes ordered small-to-large. Task 4 goes last because it is the only one needing a design decision, it lifts a `strategies.py` exclusion (widening what every other test generates), and it benefits from the other three being settled.
+
+All four defects live in `src/prov/serializers/provrdf.py`'s decode path (except #304, which is its test-side safety net). Batch 2b's Task 1 decomposed `encode_container`/`decode_container` (CCN 81/66) into per-record-family helpers behind descriptor tables; that refactor is what makes these tractable as small, separately-reviewable diffs.
+
+**Tech Stack:** Python 3.10–3.14 + PyPy 3.11, uv, ruff, mypy --strict, pytest + Hypothesis, rdflib 7.x, lxml.
+
+**Authorities:** issues #294, #299, #303, #304 (each carries a verified reproduction and a fix direction); `docs/reference/conformance.md`; `docs/upgrading-3.0.md` (public contract — updated in the same PR as each behaviour change). The #217 decision (documented PROV-O representational limitation; no IRI minting, no permutation decode) is **settled and must not be reopened** — Task 2 in particular sits adjacent to that machinery.
+
+**Assumption:** Batch 2b is fully merged. Re-confirm the baseline at execution start (2b ended at `1311 passed, 24 skipped, 0 xfailed` after Task 8; Tasks 9 and 10 add tests without changing skip/xfail counts).
+
+**User decisions (already made):**
+- Batch 2c exists as a separate batch rather than being folded into 2b (2026-07-20): all four are pre-existing defects, none is a regression, and two need design judgement that a scope-extension would have rushed.
+- The #217 lock stands: no IRI minting, no permutation decode, no reopening. Task 2's rewrite additions must not route repeated values into `unique_sets`.
+- The #257 lock stands: deserializer-side input handling only; never assertion-time enforcement of structural constraints.
+- Do not raise the rdflib floor (`>=7.0.0,<8`). Fixes must work across the whole supported range; CI tests the floor explicitly.
+
+**Open decision — Task 4 only, resolve before starting it:** #294's fix direction. The issue records two options. **Recommendation: Direction 1** — on decode, split an IRI at the longest registered namespace URI that prefixes it, falling back to rdflib's `compute_qname` only for IRIs under no known namespace. It changes no output bytes, fixes reading documents produced by earlier prov versions, and keeps the encoder untouched. Direction 2 (percent-encode the offending character on encode) changes emitted output and would need its own round-trip story alongside the `_xHHHH_` convention PROV-XML now uses for the analogous problem. Confirm with the maintainer at Task 4 start; do not let a subagent pick.
+
+**Process rules:** one task = one PR = green CI = merge commit; `Fixes #N` footers; verify with `uv run pytest -q`, `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src`; behaviour changes update `docs/upgrading-3.0.md` + `HISTORY.rst` in the same PR; marker-inventory changes update CLAUDE.md's Tests section in the same PR; CI watch via `gh run list`/`gh run watch`; Codacy advisory; never add AI attribution; commit/PR paragraphs stay unwrapped; shipped docs describe changes by release, never by "Task N"/"batch".
+
+**Review gate (carried over from batch 2b, where it caught three real defects):** the implementer's task ends when the PR is open with CI green. **The implementer does not merge.** Spec review and code-quality review run against the branch, and the PR merges only after both pass. Findings become revisions to that PR, not follow-ups in the next one. Raw RDF output is not byte-stable (rdflib mints random bnode labels) — compare documents by equality or graphs by isomorphism, never by diffing raw output.
+
+---
+
+## Verification baseline (before Task 1)
+
+Re-confirm at execution start: `uv run pytest -q` and record counts. Expected skip inventory is unchanged from 2b — **24 skips, 0 xfails**:
+
+| Marker | Where | Issue | This plan's action |
+|---|---|---|---|
+| 14 skips (`RDF_SCRUFFY_SKIP`) | `test_statements.py` | #217 | **Not touched** — permanent documented limitation |
+| `_RDF_UNSPLITTABLE_TRAILING` filter on `local_part` | `strategies.py` | #294 | **Task 4 removes it** — the only marker this batch lifts |
+| 10 remaining skips (minimal-install, dot/graph, `bundle-*` corpus, XML-schema format limits) | various | — | Not touched |
+
+---
+
+### Task 1: Restore find_diff's ability to see single-triple differences (#304)
+
+**Goal:** `find_diff` reports a mismatch whenever two graphs differ, including by exactly one triple per side, so `test_json_to_ttl_match` regains its fixture safety net before Tasks 2–4 start changing decode output.
+
+**Files:**
+- Modify: `src/prov/tests/test_rdf.py` — `find_diff`'s `[1:]` slices, plus a regression test
+- Modify: `HISTORY.rst` only if the maintainer wants a test-infrastructure note; no `docs/upgrading-3.0.md` row (test-only, no public behaviour change)
+
+**Acceptance Criteria:**
+- [ ] `find_diff` reports a mismatch for two single-triple graphs with transposed subject/object, and for two-triple graphs differing in exactly one triple (both currently return "match").
+- [ ] A regression test asserts this. It must use graphs that genuinely differ — a naive "identical graphs match" test passes against the broken helper and proves nothing.
+- [ ] `test_json_to_ttl_match` still passes over the whole `json/`+`rdf/` fixture corpus. **If restoring the helper makes it fail, STOP and report** — that means a fixture expectation is genuinely wrong and was being masked, which is a finding, not something to paper over by adjusting the fixture.
+- [ ] Full suite, ruff, format, mypy green; skip count 24, xfail 0.
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py && uv run pytest -q && uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src`
+
+**Steps:**
+- [ ] **Step 1: Branch** — `fix-304-find-diff-blindness`.
+- [ ] **Step 2: Red.** Add the regression test using the issue's two-graph reproduction. Run → it fails (helper reports a match).
+- [ ] **Step 3: Fix.** Replace `sorted(...)[1:]` with an explicit blank-line filter, e.g. `sorted(line for line in ... .splitlines() if line.strip())`. Confirm why the slice existed (a leading blank line in the `nt` serialization) and that filtering handles that case.
+- [ ] **Step 4: Sweep.** Run the full fixture corpus. Report whether any previously-passing fixture comparison now fails, and if so stop per the AC.
+- [ ] **Step 5: Verify**, then commit, push, open PR (`Fixes #304`), CI green, **STOP — do not merge.**
+
+---
+
+### Task 2: Decode binary time predicates onto the Start/End formal time slot (#299)
+
+**Goal:** `prov:startedAtTime`/`prov:endedAtTime` on a qualified `prov:Start`/`prov:End` node land in the relation's formal `prov:time` slot instead of being misfiled as extra attributes named `prov:startTime`/`prov:endTime`.
+
+**Context:** `ProvStart`/`ProvEnd`'s `FORMAL_ATTRIBUTES` declare the generic `PROV_ATTR_TIME` (`prov:time`), but `PREDICATE_MAP` maps the two binary predicates to the distinct `PROV_ATTR_STARTTIME`/`PROV_ATTR_ENDTIME`, and `_DECODE_PREDICATE_REWRITES` has no entry mapping them back. prov's own encoder emits `prov:atTime` for the qualified form, so its own round trips never take this path — which is why it went unnoticed. `ProvRecord.__eq__` compares the union of formal and extra attributes, so a misfiled time still compares equal to itself and the round-trip suite cannot see it.
+
+**Files:**
+- Modify: `src/prov/serializers/provrdf.py` — `_DECODE_PREDICATE_REWRITES` entries for `PROV_START`/`PROV_END`
+- Modify: `src/prov/tests/test_rdf.py` — decode tests asserting the formal slot, not just document equality
+- Modify: `HISTORY.rst`, `docs/upgrading-3.0.md`
+
+**Acceptance Criteria:**
+- [ ] The issue's reproduction decodes with `prov:time` holding the datetime and no `prov:startTime` extra attribute; same for `prov:endedAtTime`/End.
+- [ ] Tests assert `formal_attributes` directly. **Document equality is not a valid assertion here** — it holds even with the bug, which is exactly why this was invisible.
+- [ ] prov's own `prov:atTime` qualified form still decodes correctly (regression guard), and encode output is unchanged — the encoder must keep emitting `prov:atTime`; this is decode-side only.
+- [ ] **The #217 machinery is not disturbed:** repeated values must not be routed into `unique_sets`. A duplicated `prov:startedAtTime` on a qualified node must raise the documented-limitation `ProvException`, not produce two same-identifier records. Add a test pinning this — it is the specific way this fix could accidentally resurrect the rejected permutation decode.
+- [ ] Full suite, ruff, format, mypy green; counts change only by added tests.
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py src/prov/tests/test_statements.py && uv run pytest -q && uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src`
+
+**Steps:**
+- [ ] **Step 1: Branch** — `fix-299-start-end-time-decode`.
+- [ ] **Step 2: Red.** Add the formal-slot assertions from the issue's reproduction. Run → `prov:time` is `None`, value sits in extras.
+- [ ] **Step 3: Fix.** Add the rewrites. Read `_DECODE_PREDICATE_REWRITES`' existing `PROV_START`/`PROV_END` entries (which already rewrite `entity`→`trigger`, `activity`→`starter`/`ender`) and follow their shape.
+- [ ] **Step 4: Guard #217.** Add the duplicated-`prov:startedAtTime` test and confirm it raises the documented-limitation message. Read the NOTE at `_decode_attribute_triple` before touching anything near it.
+- [ ] **Step 5: Verify**, docs + HISTORY, commit, push, PR (`Fixes #299`), CI green, **STOP — do not merge.**
+
+---
+
+### Task 3: Reconcile anonymous qualified relations into one record on decode (#303)
+
+**Goal:** An anonymous Communication, Attribution or Influence relation carrying extra attributes decodes into **one** record, not two, so the RDF round trip is an identity for all four qualifiable families.
+
+**Context:** For such a relation the encoder emits both the binary triple and a qualified node (PROV-O encourages both, and batch 2b's #250 work made the qualified node carry its influencer property). On decode the binary triple produces one record via a direct factory call and the qualified node is reconstructed into a second; nothing reconciles them. Delegation already escapes this via a special-cased decode path that looks up the qualifier bnode and merges. **The fix is to generalise Delegation's behaviour to the other three families — not to stop emitting one of the two forms**, which is deliberate and conformant.
+
+**Files:**
+- Modify: `src/prov/serializers/provrdf.py` — the decode-side reconciliation, generalised from the Delegation/Association branch
+- Modify: `src/prov/tests/test_rdf.py` — parametrized round-trip tests over the four families
+- Modify: `docs/reference/conformance.md` if any row describes this as a caveat
+- Modify: `HISTORY.rst`, `docs/upgrading-3.0.md`
+
+**Acceptance Criteria:**
+- [ ] All four families round-trip equal for the anonymous-with-extra-attributes shape: Communication, Attribution, Influence (currently 1→2 records) and Delegation (already correct — regression guard).
+- [ ] Parametrized over the four families, asserting both record count and document equality.
+- [ ] Identified (non-anonymous) variants unchanged; the anonymous-without-extra-attributes case unchanged.
+- [ ] Encode output unchanged — this is decode-side only; verify the emitted triples are byte-comparable via graph isomorphism against master.
+- [ ] Batch 2b's #250 influencer-property emission still holds (the qualified node still carries `prov:activity`/`prov:agent`/`prov:influencer`) — regression guard.
+- [ ] Full suite, ruff, format, mypy green; **skip count 24, xfail 0**; `uvx lizard -C 15 src/prov/serializers/provrdf.py` reports no new function over 15 (`decode_rdf_representation` at 19 remains the sole pre-declared exception).
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py && HYPOTHESIS_PROFILE=ci uv run pytest -q src/prov/tests/test_property_roundtrip.py && uv run pytest -q && uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src`
+
+**Steps:**
+- [ ] **Step 1: Branch** — `fix-303-anonymous-relation-reconcile`.
+- [ ] **Step 2: Red.** Parametrized round-trip tests over the four families. Run → three fail with 2 records.
+- [ ] **Step 3: Read the Delegation path first.** Understand exactly why it reconciles correctly before generalising. Note batch 2b (#226) modified its qualifier-bnode picker to prefer the candidate whose own influencer triple matches the binary triple's object, with a "last node seen" fallback for legacy input — preserve that fallback.
+- [ ] **Step 4: Generalise** into the shared relation decode path, driven by the descriptor table rather than four special cases.
+- [ ] **Step 5: Verify**, docs + HISTORY, commit, push, PR (`Fixes #303`), CI green, **STOP — do not merge.**
+
+---
+
+### Task 4: Decode qualified names whose local part ends in a metacharacter (#294)
+
+**Goal:** A qualified name whose local part ends with one of `= ' , : ; [ ]` survives the PROV-O round trip, and `strategies.py`'s `_RDF_UNSPLITTABLE_TRAILING` filter — the last generation-time exclusion masking a real defect — is removed.
+
+**Resolve the open decision first** (see the plan header). Recommendation is Direction 1: split the IRI at the longest registered namespace URI that prefixes it, falling back to `compute_qname` only for IRIs under no known namespace. **Confirm with the maintainer before implementing; do not pick unilaterally.**
+
+**Context:** Such a local part cannot be written as an abbreviated turtle/TriG name, so rdflib emits a full IRI and omits the prefix declaration; reading it back calls `compute_qname`, which refuses to split an IRI ending in a character it will not split on, and raises `ValueError: Can't split ...`. Only the final character matters — inner and leading occurrences round-trip. Encoding is fine; only decode fails, so prov cannot currently read its own output for these names.
+
+**Files:**
+- Modify: `src/prov/serializers/provrdf.py` — the decode-side IRI→QualifiedName split
+- Modify: `src/prov/tests/test_rdf.py` — round-trip and decode tests over the metacharacter set
+- Modify: `src/prov/tests/strategies.py` — **remove** `_RDF_UNSPLITTABLE_TRAILING` and its filter and comment block
+- Modify: `docs/reference/conformance.md` if a row describes this limitation
+- Modify: `HISTORY.rst`, `docs/upgrading-3.0.md`, and `CLAUDE.md` if its Tests section references the exclusion
+
+**Acceptance Criteria:**
+- [ ] Every character in `= ' , : ; [ ]` round-trips in trailing position, parametrized; inner and leading positions still round-trip (regression guard).
+- [ ] Reading RDF authored by other tools still works: an IRI under no registered namespace still decodes via the `compute_qname` fallback, and one that genuinely cannot be split raises a clear error rather than crashing obscurely.
+- [ ] **Encode output is unchanged** — this is decode-side only under Direction 1. Verify by graph isomorphism against master across the examples corpus.
+- [ ] `_RDF_UNSPLITTABLE_TRAILING` and its filter are **removed**, and the property suite is green at `HYPOTHESIS_PROFILE=ci` plus several default-profile runs. **If removing the filter surfaces a failure that is not #294, STOP and report** — do not reinstate a filter to get green. That is how this defect stayed hidden.
+- [ ] Full suite, ruff, format, mypy green; **skip count 24, xfail 0**.
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py && HYPOTHESIS_PROFILE=ci uv run pytest -q src/prov/tests/test_property_roundtrip.py && uv run pytest -q && uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src`
+
+**Steps:**
+- [ ] **Step 1: Confirm the fix direction with the maintainer.** Then branch — `fix-294-iri-split-decode`.
+- [ ] **Step 2: Red.** Parametrized round-trip tests over the metacharacter set in trailing position. Run → `ValueError: Can't split ...`.
+- [ ] **Step 3: Fix** per the confirmed direction.
+- [ ] **Step 4: Lift the exclusion.** Remove `_RDF_UNSPLITTABLE_TRAILING`; run the property suite repeatedly (fresh Hypothesis database each time, since a stale example database hides newly-reachable inputs).
+- [ ] **Step 5: Verify**, docs + HISTORY + CLAUDE.md, commit, push, PR (`Fixes #294`), CI green, **STOP — do not merge.**
+
+---
+
+## Batch close-out (after Task 4 merges)
+
+Coordinator actions: update the Phase 4 memory file (PR numbers, final tally, deviations, and the #294 direction decision verbatim). Confirm `gh issue list --milestone 3.0.0 --state open` shows only batch 3's unification set (#253, #34, #257) and batch 4's close-out set (#275), plus any stragglers. Confirm the marker inventory is 24 skips / 0 xfails with **no remaining issue-pinned generation exclusions** in `strategies.py` — that is this batch's headline outcome. Next: execute **batch 3** (`2026-07-19-3.0-batch3-unification-rework.md`).
+
+## Self-review notes
+
+- Scope is exactly the four defects batch 2b surfaced and deferred; nothing else is pulled in. All are pre-existing, none is a regression, and each carries a verified reproduction in its issue.
+- Sequencing rationale is load-bearing, not cosmetic: #304 first restores a broken safety net that the later fixture-affecting tasks depend on; #294 last because it is the only one needing a design decision and the only one that widens generation for every other test.
+- Two tasks sit adjacent to settled decisions and say so explicitly: Task 2 near #217's permutation-decode rejection, Task 3 near #250's dual-form emission. Both carry a regression guard for the decision they neighbour.
+- Every task states a STOP condition for the specific way it could go wrong by papering over a finding — a pattern batch 2b validated when Hypothesis surfaced #294 mid-batch and the exclusion-instead-of-fix reflex had to be resisted.

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -47,8 +47,16 @@ def find_diff(g_rdf, g0_rdf):
     in_both, in_first, in_second = graph_diff(
         _as_triple_graph(g_rdf), _as_triple_graph(g0_rdf)
     )
-    g1 = sorted(in_first.serialize(format="nt", encoding="utf-8").splitlines())[1:]
-    g2 = sorted(in_second.serialize(format="nt", encoding="utf-8").splitlines())[1:]
+    g1 = sorted(
+        line
+        for line in in_first.serialize(format="nt", encoding="utf-8").splitlines()
+        if line.strip()
+    )
+    g2 = sorted(
+        line
+        for line in in_second.serialize(format="nt", encoding="utf-8").splitlines()
+        if line.strip()
+    )
     # Compare literals
     if len(g1) != len(g2):
         graphs_equal = False
@@ -762,3 +770,48 @@ def test_legacy_qualified_delegation_without_influencer_still_parses():
     assert {
         str(value) for _, value in (d.formal_attributes[2] for d in delegations)
     } == {"ex:a"}
+
+
+def test_find_diff_detects_single_triple_difference():
+    # #304: find_diff must report a mismatch for graphs differing by a single
+    # triple. The [1:] slices that removed a leading blank line from nt
+    # serialization were too aggressive: after sorted(), when the difference
+    # was a single triple, the slice discarded the only real line, leaving both
+    # g1 and g2 empty, and the function returned the initial graphs_equal=True.
+    # Regression test for the fix: replace [1:] slices with explicit
+    # blank-line filtering.
+
+    # Case 1: Single-triple graphs with transposed subject/object
+    # (genuinely differ, not just formatting)
+    a = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    b = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:b ex:p ex:a .", format="turtle"
+    )
+    match, _, _, _ = find_diff(a, b)
+    assert not match, (
+        "Single-triple graphs with transposed subject/object should differ"
+    )
+
+    # Case 2: Two-triple graphs differing in exactly one triple
+    c = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b . ex:c ex:p ex:d .",
+        format="turtle",
+    )
+    d = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:b ex:p ex:a . ex:c ex:p ex:d .",
+        format="turtle",
+    )
+    match, _, _, _ = find_diff(c, d)
+    assert not match, "Two-triple graphs differing in exactly one triple should differ"
+
+    # Case 3: Identical graphs should still match (ensure fix doesn't over-correct)
+    e = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    f = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    match, _, _, _ = find_diff(e, f)
+    assert match, "Identical graphs should match"


### PR DESCRIPTION
## Summary

The `find_diff()` helper in `src/prov/tests/test_rdf.py` was blind to single-triple differences in RDF graphs, masking potential regressions in fixture expectations. The `[1:]` slices intended to remove a leading blank line from nt serialization were too aggressive: after `sorted()`, when the difference was exactly one triple, the slice discarded the only real line, leaving both `g1` and `g2` empty and the function returning `graphs_equal=True`.

## Changes

- Replace both `sorted(...)[1:]` slices with explicit blank-line filters that preserve every non-blank line (lines 50-59 of test_rdf.py).
- Add `test_find_diff_detects_single_triple_difference()` regression test covering single-triple transposition and two-triple differ-by-one cases.
- Update `HISTORY.rst` with a test-infrastructure note.
- Fixture corpus test (`test_json_to_ttl_match`) still passes, confirming no fixture expectations were masked.

## Test Results

- `uv run pytest -q`: 1316 passed, 24 skipped
- `uv run ruff check src/`: all checks passed
- `uv run ruff format --check src/`: all files formatted
- `uv run mypy src`: success, no issues

Fixes #304