### PR TITLE
fix: resolve issue #299 - PROV-O decode: prov:startedAtTime/endedAtTime on a qualified Start/End node misfile as extra attributes

### DIFF
--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -292,8 +292,8 @@ _DECODE_PREDICATE_REWRITES: dict[
 ] = {
     PROV_COMMUNICATION: (("activity", PROV_ATTR_INFORMANT),),
     PROV_DELEGATION: (("agent", PROV_ATTR_RESPONSIBLE),),
-    PROV_END: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_ENDER)),
-    PROV_START: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_STARTER)),
+    PROV_END: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_ENDER), ("endTime", PROV_ATTR_TIME)),
+    PROV_START: (("entity", PROV_ATTR_TRIGGER), ("activity", PROV_ATTR_STARTER), ("startTime", PROV_ATTR_TIME)),
     PROV_DERIVATION: (("entity", PROV_ATTR_USED_ENTITY),),
 }
 


### PR DESCRIPTION
Fixes #299.

This PR addresses the technical issue reported in #299 (PROV-O decode: `prov:startedAtTime`/`prov:endedAtTime` on a qualified `prov:Start`/`prov:End` node misfile as extra attributes). 

Added `startTime`->`time` and `endTime`->`time` rewrites for `PROV_START` / `PROV_END` in `_DECODE_PREDICATE_REWRITES` so the decoded name successfully lands on the declared formal attribute slot.