### PR TITLE
Unify same-identifier records by PROV-CONSTRAINTS term unification

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,13 @@ History
 
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
+* BREAKING: ``ProvBundle.unified()`` / ``ProvDocument.unified()`` implement
+  PROV-CONSTRAINTS key constraints (22/23) with pairwise term unification of
+  formal attributes: records sharing an identifier whose formal attributes
+  hold different concrete values now raise the new documented
+  ``prov.model.ProvUnificationError`` instead of silently unioning; absent
+  formal attributes unify with concrete values; extra attributes keep
+  set-union semantics; bundles unify independently (#253)
 * PROV-XML round trip preserves attributes whose value is the empty string;
   previously they were silently dropped on deserialization (#224)
 * PROV-XML serializes attribute names containing characters illegal in an

--- a/docs/explanation/unification-flattening.md
+++ b/docs/explanation/unification-flattening.md
@@ -101,11 +101,19 @@ document's top-level records and, independently, to each contained bundle, **pre
 bundle structure (unlike `flattened()`) — nothing is merged across a bundle boundary.
 {py:meth}`ProvBundle.unified() <prov.model.ProvBundle.unified>` does it for a single bundle.
 
-Three limits are worth knowing:
+Four limits are worth knowing:
 
 - **Only identifiers drive merging.** Two records merge if and only if they carry the same
   qualified-name identifier. Most PROV relations are asserted without an identifier, so
   relations are almost never unified.
+- **Records of different types are merged rather than rejected.** Term unification as described
+  above applies to a group of records that share both an identifier *and* a record type.
+  Asserting `entity(x)` and `activity(x)` with the same identifier still produces a single
+  merged record of the first record's type — here an entity, carrying the activity's
+  `prov:startTime` as an ordinary attribute — even though PROV-CONSTRAINTS makes such a
+  document invalid (Constraints 50 and 55, type disjointness). This is a **known limitation**:
+  detecting it belongs to the same unification rework, and until it lands `unified()` will not
+  tell you that two records of incompatible types have collided.
 - **The placeholder `-` is not represented.** PROV-N distinguishes an omitted term from an
   explicit `-`, which is a constant and unifies only with itself; `prov`'s model has no way to
   express the latter (every deserializer drops the distinction), so an absent formal attribute
@@ -165,14 +173,18 @@ type disjointness or event ordering. A conforming normalization can conclude tha
 differently written records denote the same thing, and can declare a document *invalid*.
 
 `prov`'s `unified()` implements the term-unification half of that picture, keyed on the record
-identifier, and rejects documents whose same-identifier records cannot be unified. It does not
-perform the *inference* half: the uniqueness constraints that key on something other than the
-record identifier (Constraints 24–29 — for example, that two generations of the same entity by
-the same activity must be the same generation) are not applied, so `unified()` never concludes
-that two differently identified records denote the same thing. Nor does it check the
-constraints that make a document invalid for reasons unrelated to merging, such as type
-disjointness or event ordering. Those belong to an opt-in validation engine, tracked as
-[issue #62](https://github.com/trungdong/prov/issues/62).
+identifier, and rejects documents whose same-identifier, same-type records hold irreconcilable
+attribute values. Three things it does *not* do:
+
+- It does not perform the *inference* half. The uniqueness constraints that key on something
+  other than the record identifier (Constraints 24–29 — for example, that two generations of
+  the same entity by the same activity must be the same generation) are not applied, so
+  `unified()` never concludes that two differently identified records denote the same thing.
+  Those belong to an opt-in validation engine, tracked as
+  [issue #62](https://github.com/trungdong/prov/issues/62).
+- It does not yet reject same-identifier records of incompatible *types* — the type-disjointness
+  limitation described above.
+- It does not check constraints that have nothing to do with merging, such as event ordering.
 
 So `unified()` is a normalization step, not a validator: do not rely on it to certify that a
 document is valid PROV, nor to reconcile records that do not already share an identifier. See

--- a/docs/explanation/unification-flattening.md
+++ b/docs/explanation/unification-flattening.md
@@ -5,8 +5,8 @@ documents accumulate structure that is convenient to build but awkward to consum
 entity described in two separate statements, or facts split across named bundles. `prov`
 offers two transformations that tidy this up: {py:meth}`~prov.model.ProvDocument.flattened`
 and {py:meth}`~prov.model.ProvBundle.unified`. This page explains what each one does, shows a
-worked example of each, and explains how the current `unified()` diverges from the
-W3C specification.
+worked example of each, and explains how far `unified()` goes towards the W3C
+specification's normalization.
 
 Both transformations are **non-destructive**: they return a new document (or bundle) and leave
 the original untouched.
@@ -80,30 +80,36 @@ thing described by more than one statement. When a document is built incremental
 from several sources, an entity or activity may be asserted several times, each assertion
 carrying a few attributes. Unification combines those into one record.
 
-### What `unified()` does today
+### What `unified()` does
 
-The current implementation is deliberately simple. For each **identifier** that appears on more
-than one record, `unified()` builds a single merged record: it starts from a copy of the first
-record with that identifier and adds ("unions") the attributes of every other record sharing
-the identifier. Records with a unique identifier, and records with no identifier at all, pass
-through untouched. Because attributes are held in a set, identical attribute values are
-deduplicated, but distinct values all accumulate on the merged record.
+For each **identifier** that appears on more than one record, `unified()` builds a single
+merged record by *term unification* of those records' formal attributes, following the key
+constraints of the W3C specification. Position by position:
+
+- an **absent** formal attribute is an existential ("unknown") and unifies with anything;
+- two **equal** concrete values unify to that value;
+- two **different** concrete values do not unify, and the merge raises
+  {py:class}`~prov.model.ProvUnificationError`.
+
+The records' remaining ("extra") attributes are unioned onto the merged record. Because those
+are held in a set, identical values are deduplicated while distinct values all accumulate.
+Records with a unique identifier, and records with no identifier at all, pass through
+untouched.
 
 {py:meth}`ProvDocument.unified() <prov.model.ProvDocument.unified>` applies this to the
-document's top-level records and, recursively, to each contained bundle, **preserving** the
-bundle structure (unlike `flattened()`). {py:meth}`ProvBundle.unified() <prov.model.ProvBundle.unified>`
-does it for a single bundle.
+document's top-level records and, independently, to each contained bundle, **preserving** the
+bundle structure (unlike `flattened()`) — nothing is merged across a bundle boundary.
+{py:meth}`ProvBundle.unified() <prov.model.ProvBundle.unified>` does it for a single bundle.
 
-Three consequences of this simplicity are:
+Three limits are worth knowing:
 
 - **Only identifiers drive merging.** Two records merge if and only if they carry the same
   qualified-name identifier. Most PROV relations are asserted without an identifier, so
   relations are almost never unified.
-- **No type or attribute conflicts are detected.** The first record's PROV type and class are
-  kept; attributes from the other records are unioned in regardless of whether they conflict.
-  Asserting `entity(x)` and `activity(x)` with the same identifier, or two entities with
-  contradictory values for the same functional attribute, produces a merged record rather than
-  an error.
+- **The placeholder `-` is not represented.** PROV-N distinguishes an omitted term from an
+  explicit `-`, which is a constant and unifies only with itself; `prov`'s model has no way to
+  express the latter (every deserializer drops the distinction), so an absent formal attribute
+  always behaves as an existential.
 - **No inference or key-based unification.** The model does not use PROV's *keys* (for example,
   the fact that an entity has at most one generation) to unify records that lack a shared
   identifier, and it draws no new conclusions.
@@ -158,15 +164,17 @@ rules force to be equal, and the rejection of documents that violate constraints
 type disjointness or event ordering. A conforming normalization can conclude that two
 differently written records denote the same thing, and can declare a document *invalid*.
 
-`prov`'s `unified()` does **none** of that inference or validation. It is a shallow,
-identifier-keyed attribute union — useful for tidying up incrementally built documents, but
-not a conformant implementation of PROV-CONSTRAINTS normalization. The source itself flags
-this, with a `TODO: Check unification rules in the PROV-CONSTRAINTS document` comment above
-`_unified_records`.
+`prov`'s `unified()` implements the term-unification half of that picture, keyed on the record
+identifier, and rejects documents whose same-identifier records cannot be unified. It does not
+perform the *inference* half: the uniqueness constraints that key on something other than the
+record identifier (Constraints 24–29 — for example, that two generations of the same entity by
+the same activity must be the same generation) are not applied, so `unified()` never concludes
+that two differently identified records denote the same thing. Nor does it check the
+constraints that make a document invalid for reasons unrelated to merging, such as type
+disjointness or event ordering. Those belong to an opt-in validation engine, tracked as
+[issue #62](https://github.com/trungdong/prov/issues/62).
 
-Fixing this is a **3.0** item: because a spec-conformant `unified()` would change behaviour
-(merging or rejecting documents that today pass through unchanged), it cannot land in the 2.x
-series under the API-stability promise. See the
-[roadmap](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for where this sits among
-the planned releases. Until then, treat `unified()` as the convenience it is, and do not rely
-on it to validate a document or to reconcile records that do not already share an identifier.
+So `unified()` is a normalization step, not a validator: do not rely on it to certify that a
+document is valid PROV, nor to reconcile records that do not already share an identifier. See
+the [roadmap](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for where the
+validation engine sits among the planned releases.

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -153,4 +153,8 @@ below.
 .. autoclass:: prov.model.ProvElementIdentifierRequired
    :members:
    :show-inheritance:
+
+.. autoclass:: prov.model.ProvUnificationError
+   :members:
+   :show-inheritance:
 ```

--- a/docs/superpowers/plans/2026-07-19-3.0-batch3-unification-rework.md
+++ b/docs/superpowers/plans/2026-07-19-3.0-batch3-unification-rework.md
@@ -10,7 +10,7 @@
 
 **Authorities (in order):** `docs/superpowers/specs/2026-07-10-unification-gap-analysis.md` — THE authority for this batch (rule-by-rule gaps, §6's seven requirements for step 36b); the 153-case corpus `src/prov/tests/unification/constraints/` locked by `src/prov/tests/test_unification_constraints.py` (acceptance authority); PROV-CONSTRAINTS REC §4/§6.1/§7.2; issue #253 (umbrella), #34; design doc steps 36/36b; `docs/upgrading-3.0.md` §"Unification rework" (the promised public contract — this batch makes it true).
 
-**Assumption:** Batches 1, 2a, 2b merged. Suite tally will have moved — **record the actual `uv run pytest -q` baseline (passed/skipped/xfailed) at execution start** and reconcile the corpus-test inventory (`uv run pytest -q -rsx src/prov/tests/test_unification_constraints.py`) before Task 1. Expected corpus state inherited from the gap analysis: 3 skipped `bundle-*` files (unparseable ProvToolbox dialect, post-#254 wording), 25 `CARDINALITY_GUARD_REJECTS` cases, 42 silent merge/pass cases, 83 clean successes.
+**Assumption:** Batches 1, 2a, 2b, 2c merged. **Baseline verified against master `7c80928` on 2026-07-24** (pre-implementation verification pass): `uv run pytest -q` → **1349 passed, 24 skipped, 0 xfailed**; `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src` all clean; `gh issue list --milestone 3.0.0 --state open` → **#275, #257, #253, #34** (exactly as expected). Corpus state confirmed against the code: 153 `.xml` files + a `README.md` in `src/prov/tests/unification/constraints/`, `PARSE_FAILURES` = 3 skipped `bundle-*` files (unparseable ProvToolbox dialect, #254), `CARDINALITY_GUARD_REJECTS` = 25 members, 42 silent merge/pass cases, 83 clean successes — identical to the gap analysis §5 table.
 
 **User decisions (already made):**
 - Scope (brief, 2026-07-19): "key constraints + term unification; placeholders unify with concrete values; non-unifiable formal attributes raise a documented exception instead of silent merging; bundles unify independently." Read together with the gap analysis §3.1: the model cannot represent the spec's `-` placeholder (deserializers drop the distinction), so **an absent formal attribute is treated as an existential ("unknown") that unifies with any concrete value** — the spec's `-`-vs-concrete failure is documented as unrepresentable, and the 12 placeholder corpus fail-cases stay non-failing with that documented reason. This is the brief's locked reading; no `-` representation is added to the model.
@@ -28,7 +28,12 @@
 
 **Process rules:** as batches 2a/2b — one task = one PR = green CI = merge commit; `Fixes #N` footers; verify with `uv run pytest -q`, `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src`; behaviour changes update `docs/upgrading-3.0.md` + `HISTORY.rst` (`3.0.0 (unreleased)`) in the same PR; CLAUDE.md updated in the same PR where a task changes what its Tests section describes.
 
-**Known blast radius (read before Task 1):** `prov_to_dot()` and `prov_to_graph()` call `unified()` internally (documented in upgrading-3.0.md), so after Task 1 a document with conflicting formal attributes **raises** on dot/graph export where it previously merged silently. Audit the test suite for scruffy documents flowing into dot/graph paths (`grep -rn "prov_to_dot\|prov_to_graph" src/prov/tests/`) and into `flattened().unified()` (`test_model.py::test_unifying` over `unification/*.json` — those fixtures are single-instance PASS cases and must keep merging cleanly).
+**Known blast radius (verified 2026-07-24 — narrower than first written):** both `prov_to_dot()` and `prov_to_graph()` call `unified()` internally, but they differ:
+
+- **`prov_to_dot()` is already safe.** `src/prov/dot.py:445-450` wraps `bundle.unified()` in `except ProvException:` and falls back to rendering the non-unified bundle. Because `ProvUnificationError` subclasses `ProvException`, dot export keeps working unchanged, and `src/prov/tests/test_dot.py::test_unresolvable_unification_falls_back_to_original_bundle` (which deliberately builds a scruffy two-generation document to exercise that fallback) **stays green** — only its docstring/comment need updating to name the new exception instead of the generic cardinality `ProvException`.
+- **`prov_to_graph()` is the real regression surface.** `src/prov/graph.py:99` calls `prov_document.unified()` with **no** guard, so a document with conflicting formal attributes now raises out of graph export. Audit `src/prov/tests/test_graphs.py` (note `test_round_trip_against_unified_document` at line 28 calls `prov_org.unified()` directly on `primer_example()` — conflict-free, so expected to stay green) and decide in the PR whether `prov_to_graph()` should gain the same documented fallback as dot or propagate the error (propagating is the default; a change here needs its own upgrading-3.0.md note).
+
+Also audit `flattened().unified()` (`test_model.py::test_unifying` over `unification/*.json` — those fixtures are single-instance PASS cases and must keep merging cleanly) and `test_model.py::test_unified_with_no_bundles` (line ~712, conflict-free).
 
 ---
 
@@ -43,11 +48,12 @@ Execute and record in this file's execution log / memory: `uv run pytest -q` →
 **Goal:** `unified()` merges same-identifier records of the same record type by pairwise unification of formal attributes — absent unifies with concrete (existential semantics), equal concretes unify, unequal concretes raise the new documented `ProvUnificationError` — replacing the accidental `add_attributes` cardinality-guard rejection. Extra attributes keep set-union semantics. Per-bundle scoping is preserved.
 
 **Files:**
-- Modify: `src/prov/model/records.py` — new `ProvUnificationError(ProvException)` next to the existing exception hierarchy (`grep -n "class Prov.*Exception\|class Prov.*Error" src/prov/model/records.py`)
-- Modify: `src/prov/model/bundle.py` — `_unified_records()` (line ~383) rewritten around a new merge helper; `unified()` docstrings (both classes) rewritten to the new semantics (keep the FutureWarning emission untouched until Task 4)
+- Modify: `src/prov/model/records.py` — new `ProvUnificationError(ProvException)` next to the existing exception hierarchy (verified: `ProvException` at line 434, `ProvExceptionInvalidQualifiedName` at 442, `ProvElementIdentifierRequired` at 460)
+- Modify: `src/prov/model/bundle.py` — `_unified_records()` (verified at line **387**, body 387–417) rewritten around a new merge helper; `unified()` docstrings (`ProvBundle` at 419, `ProvDocument` at 1462) rewritten to the new semantics (keep the FutureWarning emission untouched until Task 4)
 - Modify: `src/prov/model/__init__.py` — re-export `ProvUnificationError` (public name addition)
 - Modify: `src/prov/tests/test_public_api.py` — add the new name to the guarded inventory (additions are allowed; removals are not)
-- Modify: `src/prov/tests/test_unification_constraints.py` — the 25 `CARDINALITY_GUARD_REJECTS` cases flip to asserting `ProvUnificationError`; the §6.1 worked-example test and success-case characterizations updated where messages/paths changed
+- Modify: `src/prov/tests/test_unification_constraints.py` — the 25 `CARDINALITY_GUARD_REJECTS` cases flip to asserting `ProvUnificationError`; the §6.1 worked-example test and success-case characterizations updated where messages/paths changed. **Stale line refs to correct while rewriting:** the module docstring and several test comments cite the cardinality guard as `records.py:622-643` — it is actually at **`records.py:748-772`**; `_unified_records()` is cited as `bundle.py:384-414` / `bundle.py:1455-1480` and `_id_map` as `bundle.py:469-475` — actual: **387–417**, **1462–1487**, **472–478**
+- Modify: `src/prov/tests/test_dot.py` — `test_unresolvable_unification_falls_back_to_original_bundle` (line 106) keeps passing (dot catches `ProvException`), but its docstring/comment must name `ProvUnificationError`
 - Create: `src/prov/tests/test_unification_rules.py` — hand-written per-rule tests (spec §6.1 worked example, absent-vs-concrete, concrete conflict per relation type, per-bundle scoping)
 - Modify: `HISTORY.rst`, `docs/upgrading-3.0.md`
 
@@ -100,14 +106,13 @@ def _doc():
 def test_spec_worked_example_merges():
     # PROV-CONSTRAINTS §6.1 worked example (Constraint 22).
     document = _doc()
-    document.activity("ex:a", startTime=T1, other_attributes={"ex:a": 1})
-    document.activity("ex:a", endTime=T2, other_attributes={"ex:b": 2})
+    document.activity("ex:a", startTime=T1, other_attributes={"ex:x": 1})
+    document.activity("ex:a", endTime=T2, other_attributes={"ex:y": 2})
     unified = document.unified()
     (activity,) = unified.get_records()
     assert activity.get_startTime() == T1
     assert activity.get_endTime() == T2
-    assert dict(activity.extra_attributes)  # both ex:a and ex:b present
-    assert len(activity.extra_attributes) == 2
+    assert len(activity.extra_attributes) == 2  # both ex:x and ex:y present
 
 
 def test_conflicting_concrete_formal_attributes_raise():
@@ -150,7 +155,9 @@ def test_unification_is_scoped_per_bundle():
     assert unified.has_bundles()
 ```
 
-(check the factory keyword names — `identifier=` vs positional — against `bundle.py` signatures and adjust; `association`'s signature is `association(activity, agent=None, plan=None, …)`.) Run → red: worked example passes today (union happens to match) but conflict cases raise the *wrong* exception type and message; assert-shape failures confirm.
+**Factory signatures verified 2026-07-24 — all snippets above are correct as written:** `entity(identifier, other_attributes=None)`, `agent(identifier, other_attributes=None)`, `activity(identifier, startTime=None, endTime=None, other_attributes=None)`, `generation(entity, activity=None, time=None, identifier=None, other_attributes=None)`, `usage(activity, entity=None, time=None, identifier=None, other_attributes=None)`, `association(activity, agent=None, plan=None, identifier=None, other_attributes=None)`. `has_bundles()` exists on both classes (`bundle.py:300`, `1426`).
+
+**Current behaviour of each snippet, probed against master `7c80928`:** worked example → already merges correctly (T1, T2, 2 extra attrs) so that assertion passes today; conflicting startTime → `ProvException: Cannot have more than one value for attribute prov:startTime`; conflicting generation endpoints → `ProvException: … prov:entity`; absent-vs-concrete → 1 record (already merges); per-bundle scoping → `True` (already conforms). So Step 2 goes red **only** on the two `pytest.raises(ProvUnificationError)` cases (wrong exception type) — that is the expected red, and it is enough.
 
 - [ ] **Step 3: Flip the corpus expectations.** In `test_unification_constraints.py`: rename `CARDINALITY_GUARD_REJECTS` → `UNIFICATION_REJECTS` (same 25 members), change its assertion from the generic `ProvException`+cardinality-message characterization to `pytest.raises(ProvUnificationError)`; update the module docstring (current behaviour → 3.0 behaviour, keeping the scope notes); leave the 42 silent-pass cases' characterizations in place for now (Task 2 moves some, Task 4 finalises wording). Run → red (old exception raised).
 
@@ -263,18 +270,22 @@ Run → red (today: silent first-record-wins chimera / passthrough).
 
 ### Task 3: Type-aware extra-attribute storage (#34)
 
-**Goal:** Python-equal-but-differently-typed attribute values (`2` vs `2.0` vs `True`) no longer collapse in a record's extra-attribute set — at construction, in `add_attributes`, and through `unified()`'s attribute union.
+**Goal:** Python-equal-but-differently-typed attribute values (`2` vs `2.0`, `1` vs `True`) no longer collapse in a record's extra-attribute storage — at construction, in `add_attributes`, and through `unified()`'s attribute union — **and record equality/hash can tell the resulting records apart.**
+
+**Actual storage (verified 2026-07-24 — the earlier sketch in this plan was wrong):** `ProvRecord._attributes` is **`dict[QualifiedName, set[Any]] = defaultdict(set)`** (`records.py:493`) — a dict keyed by attribute *name* whose values are sets of that attribute's values. It is **not** a set of `(attr, value)` tuples. Collapsing therefore happens inside the per-attribute value set, and the fix is to make that per-attribute container type-aware; no re-keying of the outer dict is needed. Probe of current behaviour: `entity("ex:e", [("ex:v", 2), ("ex:v", 2.0), ("ex:v", True)])` → `{True, 2}` (`2.0` collapses into `2`; `True` survives because `True == 1 ≠ 2`). **`grep` confirms `_attributes` is touched nowhere outside `records.py`** — the change is fully encapsulated, which is what makes this tractable.
 
 **Files:**
-- Modify: `src/prov/model/records.py` — the extra-attribute set storage (`_attributes` handling in `add_attributes` / the record constructor; find the set-insertion sites with `grep -n "_attributes" src/prov/model/records.py`)
-- Create/extend: `src/prov/tests/test_attribute_merging.py` (new; old-vs-new behaviour)
+- Modify: `src/prov/model/records.py` — the per-attribute value container (`_attributes` init at `:493`; the single insertion site `self._attributes[attr].add(value)` at `:774`; the single-valued guard at `:748-772`), **plus `ProvRecord.__eq__` (`:776-784`) and `ProvRecord.__hash__` (`:497-498`)** — see the equality AC below
+- Create: `src/prov/tests/test_attribute_merging.py` (new; old-vs-new behaviour)
 - Modify: `HISTORY.rst`, `docs/upgrading-3.0.md` (#34 row exists — update to landed)
 
 **Acceptance Criteria:**
-- [ ] `d.entity("ex:e", [("ex:v", 2), ("ex:v", 2.0)])` retains **both** values; likewise `1` vs `True`; likewise via a second `add_attributes` call; likewise when `unified()` unions two records' attributes.
+- [ ] `d.entity("ex:e", [("ex:v", 2), ("ex:v", 2.0)])` retains **both** values; likewise `1` vs `True` (the genuine bool/int collapsing pair — note `2` vs `True` does *not* collapse today and is not a regression case); likewise via a second `add_attributes` call; likewise when `unified()` unions two records' attributes.
 - [ ] Genuine duplicates still deduplicate: `[("ex:v", 2), ("ex:v", 2)]` → one value; `Literal` dedup semantics unchanged (value-space for decimals per 2a Task 4).
-- [ ] Serialization round-trips of a mixed `{2, 2.0, True}` multi-value attribute are equal across json/xml/rdf (each format renders distinct typed literals — `xsd:int`, `xsd:double`, `xsd:boolean` — so the shapes are distinguishable; use the `roundtrip` fixture).
-- [ ] Record equality/hash still consistent: two records built with the same mixed values in different orders compare equal.
+- [ ] **`ProvRecord.__eq__`/`__hash__` distinguish the retained values.** Both currently funnel through `self.attributes` — `set(self.attributes)` at `records.py:784` and `frozenset(self.attributes)` at `:498` — which re-collapses `2`/`2.0` regardless of what the storage holds. **Verified today: a record built with `[("ex:v", 2), ("ex:v", 2.0)]` compares equal to one built with `[("ex:v", 2)]`, and a storage-only fix leaves that true.** Assert explicitly that after the fix a record holding `{2, 2.0}` is **not** equal to one holding only `{2}`, and that hashes differ. Without this, the round-trip AC below is vacuous (a lossy round-trip would still compare equal) and `ProvBundle.__eq__` (which compares records) inherits the blindness.
+- [ ] Serialization round-trips of a mixed `{2, 2.0}` multi-value attribute are equal across json/xml/rdf (each format renders distinct typed literals — `xsd:int`, `xsd:double` — so the shapes are distinguishable; use the `roundtrip` fixture). This AC is only meaningful once the equality AC above holds.
+- [ ] Record equality/hash still order-insensitive: two records built with the same mixed values in different orders compare equal and hash equal.
+- [ ] **Public accessors decided deliberately, not incidentally:** `get_attribute()` (`records.py:544`), `get_asserted_types()` (`:520`) and `.value` (`:616`) each return the internal per-attribute container directly (annotated `set[Any]` / `set[QualifiedName]`), `add_asserted_type()` mutates it via `.add()` (`:528`), and `ProvActivity.__init__` assigns raw sets (`self._attributes[PROV_ATTR_STARTTIME] = {startTime}`, `:1175/1177`). If the new container is a wrapper type it **must not leak** through those, or the change must be an explicit, documented 3.0 API change in `docs/upgrading-3.0.md` (`test_public_api.py` guards names, not return types, so it will not catch this).
 - [ ] Full suite, ruff, format, mypy green.
 
 **Verify:** `uv run pytest -q src/prov/tests/test_attribute_merging.py && uv run pytest -q && uv run mypy src` → green.
@@ -283,15 +294,16 @@ Run → red (today: silent first-record-wins chimera / passthrough).
 
 - [ ] **Step 1: Branch** — `fix-34-typed-attribute-storage`.
 - [ ] **Step 2: Failing tests** — `test_attribute_merging.py` with the AC cases (construction, add_attributes, unified-union, dedup-of-true-duplicates, round-trip via `roundtrip`); include the docstring note that 2.x collapsed to whichever was inserted first. Run → red.
-- [ ] **Step 3: Implement.** The storage is a `set` of `(attr, value)` tuples whose hashing uses Python value equality (`2 == 2.0 == True` with equal hashes). Fix by keying on type identity as well: store values wrapped so the set key is `(attr, type(value), value)` while iteration still yields the raw values — the cleanest shape given the code is an internal keying change (e.g. keep `_attributes` as a `dict[(attr, type, value) → (attr, value)]` or a set of a small `_TypedValue` wrapper with `__eq__`/`__hash__` over `(type(v), v)`). Constraints: (a) the public `attributes`/`extra_attributes` iteration API and its ordering behaviour must not change shape (tuples of `(QualifiedName, value)`); (b) `bool` must key distinctly from `int` (`type(True) is bool` — the tuple key handles it); (c) `Literal`/`QualifiedName`/`datetime` values are unaffected (their types differ from primitives already). Read `ProvRecord.__eq__`/`__hash__` and `sorted_attributes` (`bundle.py`) for consumers of the storage before choosing the exact structure.
+- [ ] **Step 3: Implement.** `_attributes` is `dict[QualifiedName, set[Any]]` (`records.py:493`); the per-attribute `set` collapses values that are Python-equal with equal hashes (`2 == 2.0`, `1 == True`). Fix by making that inner container key on `(type(v), v)` while iteration still yields the raw values — e.g. replace the inner `set` with a small `_TypedValueSet` (a `dict[(type, value) → value]` behind a set-like façade) or store a `_TypedValue` wrapper with `__eq__`/`__hash__` over `(type(v), v)`. Constraints: (a) the public `attributes`/`extra_attributes` iteration API must keep yielding plain `(QualifiedName, value)` tuples in the same order; (b) `bool` must key distinctly from `int` (`type(True) is bool` — the type key handles it); (c) `Literal`/`QualifiedName`/`datetime` values are unaffected (their types already differ from the primitives); (d) the accessors listed in the ACs (`get_attribute`, `get_asserted_types`, `.value`, `add_asserted_type`, `ProvActivity.__init__`'s raw `= {startTime}` assignments) all touch the inner container directly — either keep them returning/accepting plain sets or make the API change explicit. **Then fix `__eq__`/`__hash__`** so the retained distinctions survive comparison: they hash/compare `frozenset(self.attributes)` and `set(self.attributes)`, which collapse the pairs again; key those on `(attr, type(value), value)` too. Also read `sorted_attributes` (`bundle.py:1713`) — it consumes `(name, value)` pairs and sorts by `(str, str)`, so it is unaffected by the storage change but will now see more pairs.
 - [ ] **Step 4: Verify** — full suite (watch `test_statements`/`test_attributes` shared matrices — they assert multi-value behaviour), ruff/format/mypy, Hypothesis property suite.
 - [ ] **Step 5: Docs + HISTORY** — update the #34 upgrading row to landed wording. HISTORY:
 
 ```rst
 * Attribute values that are Python-equal but differently typed (``2`` vs
-  ``2.0`` vs ``True``) are all retained on a record instead of silently
+  ``2.0``, ``1`` vs ``True``) are all retained on a record instead of silently
   collapsing to whichever was asserted first — at construction, in
-  ``add_attributes()``, and through ``unified()`` (#34)
+  ``add_attributes()``, and through ``unified()``; record equality and hashing
+  distinguish them accordingly (#34)
 ```
 
 - [ ] **Step 6: Commit, PR (`Fixes #34`), CI, merge, pull.**
@@ -303,8 +315,10 @@ Run → red (today: silent first-record-wins chimera / passthrough).
 **Goal:** The 2.4.0 signposting is retired (the rework landed), the unification docs describe the new semantics, the corpus test module's prose matches reality, and #253 and #257 are closed out.
 
 **Files:**
-- Modify: `src/prov/model/bundle.py` — delete both `FutureWarning` blocks (`grep -n FutureWarning src/prov/model/bundle.py` → the `unified()` sites at ~line 435 and ~1475) and any now-unused `warnings` import
-- Modify: `pyproject.toml` — delete `"ignore:prov 3.0 will change unified:FutureWarning"` from `[tool.pytest.ini_options] filterwarnings` (leaving the list empty or removing the key if empty)
+- Modify: `src/prov/model/bundle.py` — delete both `FutureWarning` blocks (verified at lines **433-441** in `ProvBundle.unified()` and **1473-1481** in `ProvDocument.unified()`) and the `warnings` import at line **11** (confirmed: those two blocks are its only users in the file)
+- Modify: `pyproject.toml` — delete `"ignore:prov 3.0 will change unified:FutureWarning"` from `[tool.pytest.ini_options] filterwarnings` (lines 159-161; it is the **only** entry, so the list becomes empty — remove the key)
+- **Delete (or gut): `src/prov/tests/test_deprecations.py`** — *missing from the original file list; it will fail otherwise.* Both its tests (`test_bundle_unified_warns_future`, `test_document_unified_warns_future`) assert `pytest.warns(FutureWarning, match="PROV-CONSTRAINTS")`, and `pytest.warns` raises when no warning is emitted. They are the module's entire content (its docstring already records that the `prov.dot`/`prov.graph` signposts came true in 3.0.0.dev0 and moved to `test_minimal_install.py`), so deleting the module is the natural close-out — state that explicitly in the PR body rather than leaving it as silent test removal
+- Modify: `src/prov/tests/test_unification_constraints.py` — *also* remove `pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")` (lines 36-39, comment included); the grep-clean AC below requires it
 - Modify: `docs/explanation/unification-flattening.md` — rewrite from "today's behaviour diverges from the spec" to the 3.0 semantics (22/23 + type compatibility; absent=existential; 24–29 → #62; `flattened().unified()` documented as a deliberate single-instance view outside PROV-CONSTRAINTS semantics — gap analysis §4)
 - Modify: `docs/upgrading-3.0.md` — final pass over the unification section (the FutureWarning sentences are now historical: rephrase "Calling unified() today already emits a FutureWarning" appropriately)
 - Modify: `src/prov/tests/test_unification_constraints.py` — final docstring/reason wording (every remaining silent-pass case cites its out-of-scope constraint and #62)
@@ -325,7 +339,7 @@ Run → red (today: silent first-record-wins chimera / passthrough).
 **Steps:**
 
 - [ ] **Step 1: Branch** — `fix-253-closeout-remove-futurewarning`.
-- [ ] **Step 2: Remove the warnings + ignore**; run `uv run pytest -q -W error::FutureWarning` → green proves nothing else depended on the ignore.
+- [ ] **Step 2: Remove the warnings + ignore + the two now-impossible signpost tests** (`test_deprecations.py`, and the `filterwarnings` pytestmark in `test_unification_constraints.py`); run `uv run pytest -q -W error::FutureWarning` → green proves nothing else depended on the ignore. Expect the suite count to drop by 2 from the `test_deprecations.py` removal — state that delta in the PR body.
 - [ ] **Step 3: Fixture/coverage sweep** — table the implemented rules (22, 23, 50/54/55, absent-existential) against existing fixtures/tests; write the missing hand-made fixtures; wire them in.
 - [ ] **Step 4: Docs rewrite** (explanation page, upgrading section, corpus module prose, CLAUDE.md if applicable) + HISTORY:
 

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -69,11 +69,26 @@ In 3.0, `unified()` is reimplemented to follow the merging rules of
 [W3C PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) (key constraints and
 term unification). Concretely:
 
-- Calling `unified()` today already emits a `FutureWarning` naming this page and
-  ROADMAP.md.
-- Records sharing an identifier that also have **conflicting formal attributes** will
-  **raise a documented exception** in 3.0 instead of having their attributes silently
-  unioned.
+- Calling `unified()` in 2.4.0 and later already emits a `FutureWarning` naming this
+  page and ROADMAP.md.
+- Records sharing an identifier are merged by unifying their formal attributes position
+  by position. Two records that hold **different concrete values for the same formal
+  attribute** now **raise `prov.model.ProvUnificationError`** (a `ProvException`
+  subclass) instead of having their attributes silently unioned.
+- An **absent** formal attribute is treated as an existential ("unknown") and unifies
+  with any concrete value, so partial records still merge — this is PROV-CONSTRAINTS
+  §6.1's worked example, and it is unchanged from 2.x. `prov`'s model cannot represent
+  PROV-N's placeholder `-` (every deserializer drops the distinction between "absent"
+  and "explicitly `-`"), so the specification's `-`-versus-concrete merge failure is out
+  of scope by representation.
+- Non-formal ("extra") attributes keep their set-union semantics.
+- Each scope is unified independently: `ProvDocument.unified()` unifies the top-level
+  records and each bundle separately, and never merges across a bundle boundary
+  (PROV-CONSTRAINTS §7.2).
+- **Out of scope for `unified()`**: the uniqueness constraints keyed on something other
+  than the record identifier (Constraints 24–29) are not checked and never raise; they
+  belong to the opt-in validation engine tracked as
+  [#62](https://github.com/trungdong/prov/issues/62).
 - The `#34` attribute-merging fix above lands as part of this same rework.
 
 **What to do:** if your code calls `unified()` on documents where records sharing an
@@ -82,7 +97,9 @@ statements for the same identifier asserting different `prov:time` values — th
 "scruffy" pattern used in this repo's own test suite, and the RDF representational
 limitation tracked as #217 above), expect that call to raise in 3.0 where it previously
 merged silently. Catch the new exception (or restructure the document to avoid
-conflicting formal attributes) before upgrading. Documents without this pattern are
+conflicting formal attributes) before upgrading. `ProvUnificationError` is importable
+from `prov.model`, and subclasses `ProvException`, so code that already catches
+`ProvException` around `unified()` keeps working. Documents without this pattern are
 unaffected. Note that this is strictly an opt-in `unified()` behaviour: `prov` performs
 no structural validation at assertion/serialization time (see #257), so building and
 serializing a "scruffy" document remains legal in 3.0 — only calling `unified()` on one,
@@ -92,7 +109,11 @@ Note that `prov_to_dot()` (`prov.dot`) and `prov_to_graph()` (`prov.graph`, not
 `graph_to_prov()`, which does not unify) call `unified()` internally, so the
 `FutureWarning` above also fires on every call to those functions today — regardless of
 whether the document actually has conflicting attributes — so graphics/graph-export
-users will see it even without calling `unified()` themselves.
+users will see it even without calling `unified()` themselves. The two differ in how
+they handle a document that fails to unify: `prov_to_dot()` catches the exception and
+renders the original, non-unified bundle (as it has always done for the generic
+`ProvException` the merge used to raise), whereas `prov_to_graph()` lets
+`ProvUnificationError` propagate to the caller.
 
 ## Removal of names deprecated in 2.4.0
 

--- a/src/prov/model/__init__.py
+++ b/src/prov/model/__init__.py
@@ -74,6 +74,7 @@ from prov.model.records import (
     ProvRelation as ProvRelation,
     ProvSpecialization as ProvSpecialization,
     ProvStart as ProvStart,
+    ProvUnificationError as ProvUnificationError,
     ProvUsage as ProvUsage,
     ProvWarning as ProvWarning,
     QualifiedNameCandidate as QualifiedNameCandidate,

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -99,6 +99,7 @@ from prov.model.records import (
     ProvRecord,
     ProvSpecialization,
     ProvStart,
+    ProvUnificationError,
     ProvUsage,
     QualifiedNameCandidate,
     RecordAttributesArg,
@@ -107,6 +108,74 @@ from prov.model.records import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
+    """Merge records sharing an identifier by PROV-CONSTRAINTS term unification.
+
+    Formal attributes are unified positionally: an absent value is an
+    existential ("unknown") that unifies with anything, equal concrete values
+    unify, and two different concrete values do not unify. Non-formal ("extra")
+    attributes are unioned. The merged record is newly constructed from the
+    unified formal attributes, so no conflict is ever routed through
+    :meth:`ProvRecord.add_attributes`' single-value guard.
+
+    Args:
+        records: Two or more records carrying the same identifier, in
+            assertion order.
+
+    Returns:
+        A single, newly created record standing for the whole group.
+
+    Raises:
+        ProvUnificationError: If two of the records hold different concrete
+            values for the same formal attribute.
+    """
+    first_record = records[0]
+    record_type = first_record.get_type()
+    if any(record.get_type() != record_type for record in records[1:]):
+        # Task 2 (#253): type compatibility. Until then, a group mixing record
+        # types keeps the historic first-record-wins attribute union.
+        merged = first_record.copy()
+        for record in records[1:]:
+            merged.add_attributes(record.attributes)
+        return merged
+
+    identifier = first_record.identifier
+    attributes: list[NameValuePair] = []
+    # Same record type, hence the same FORMAL_ATTRIBUTES: zip() lines the
+    # records' formal attributes up position by position.
+    for pairs in zip(*(record.formal_attributes for record in records), strict=True):
+        attr_name = pairs[0][0]
+        unified_value = None
+        for _, value in pairs:
+            if value is None:
+                # An absent formal attribute is an existential variable: the
+                # model cannot express PROV-N's placeholder `-`, so absent
+                # unifies with any concrete value.
+                continue
+            if unified_value is None:
+                unified_value = value
+                continue
+            try:
+                differ = unified_value != value
+            except TypeError:
+                # Cannot compare them; consider them different values, as
+                # ProvRecord.add_attributes does.
+                differ = True
+            if differ:
+                raise ProvUnificationError(
+                    f"cannot unify {identifier}: {attr_name} has conflicting "
+                    f"values {unified_value!r} and {value!r}"
+                )
+        if unified_value is not None:
+            attributes.append((attr_name, unified_value))
+
+    # Extra attributes keep their set-union semantics.
+    for record in records:
+        attributes.extend(record.extra_attributes)
+
+    return PROV_REC_CLS[record_type](first_record.bundle, identifier, attributes)
 
 
 class ProvBundle:
@@ -386,16 +455,11 @@ class ProvBundle:
     # Transformations
     def _unified_records(self) -> list[ProvRecord]:
         """Returns a list of unified records."""
-        # TODO: Check unification rules in the PROV-CONSTRAINTS document
-        # This method simply merges the records having the same name
         merged_records = {}
         for _identifier, records in self._id_map.items():
             if len(records) > 1:
-                # more than one record having the same identifier
-                # merge the records
-                merged = records[0].copy()
-                for record in records[1:]:
-                    merged.add_attributes(record.attributes)
+                # more than one record having the same identifier: unify them
+                merged = _unify_record_group(records)
                 # map all of them to the merged record
                 for record in records:
                     merged_records[record] = merged
@@ -420,15 +484,25 @@ class ProvBundle:
         """Return a new bundle with records sharing an identifier merged.
 
         For each identifier carried by more than one record, a single merged
-        record is produced by unioning the attributes of all records with that
-        identifier onto a copy of the first. Records with a unique identifier,
-        or no identifier, pass through unchanged. This is a simple
-        identifier-keyed attribute union, not the full PROV-CONSTRAINTS
-        unification: no type/attribute conflicts are detected and no inference
-        is performed. The original bundle is left untouched.
+        record is produced by the term unification of W3C PROV-CONSTRAINTS'
+        key constraints (22 and 23): the records' formal attributes are unified
+        position by position — an absent formal attribute is an existential
+        that unifies with any concrete value, equal concrete values unify, and
+        two different concrete values do not — while their remaining attributes
+        are unioned. Records with a unique identifier, or no identifier, pass
+        through unchanged.
+
+        This is not the specification's full normalization: the uniqueness
+        constraints keyed on something other than the record identifier
+        (Constraints 24-29) are not checked and no inference is performed. The
+        original bundle is left untouched.
 
         Returns:
             The new, unified :class:`ProvBundle`.
+
+        Raises:
+            ProvUnificationError: If two records sharing an identifier hold
+                different concrete values for the same formal attribute.
         """
         warnings.warn(
             "prov 3.0 will change unified() to merge records per the W3C "
@@ -1462,13 +1536,19 @@ class ProvDocument(ProvBundle):
     def unified(self) -> ProvDocument:
         """Return a new document with records sharing an identifier merged.
 
-        The identifier-keyed attribute union (see :meth:`ProvBundle.unified`) is
-        applied to the document's top-level records and, recursively, to each
-        contained bundle, preserving the bundle structure. The original
+        The term unification of :meth:`ProvBundle.unified` is applied to the
+        document's top-level records and, independently, to each contained
+        bundle, preserving the bundle structure — as PROV-CONSTRAINTS §7.2
+        requires, nothing is merged across a bundle boundary. The original
         document is left untouched.
 
         Returns:
             The new, unified :class:`ProvDocument`.
+
+        Raises:
+            ProvUnificationError: If two records sharing an identifier within
+                the same scope hold different concrete values for the same
+                formal attribute.
         """
         warnings.warn(
             "prov 3.0 will change unified() to merge records per the W3C "

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -157,13 +157,10 @@ def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
             if unified_value is None:
                 unified_value = value
                 continue
-            try:
-                differ = unified_value != value
-            except TypeError:
-                # Cannot compare them; consider them different values, as
-                # ProvRecord.add_attributes does.
-                differ = True
-            if differ:
+            # Every formal attribute is in PROV_ATTRIBUTES, so add_attributes
+            # has already normalised its value to a QualifiedName or a
+            # datetime: != is always well defined here.
+            if unified_value != value:
                 raise ProvUnificationError(
                     f"cannot unify {identifier}: {attr_name} has conflicting "
                     f"values {unified_value!r} and {value!r}"

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -457,6 +457,14 @@ class ProvExceptionInvalidQualifiedName(ProvException):
         return f"Invalid Qualified Name: {self.qname}"
 
 
+class ProvUnificationError(ProvException):
+    """Raised by :meth:`ProvBundle.unified` when records sharing an
+    identifier cannot be merged under PROV-CONSTRAINTS term unification
+    (two different concrete values for the same formal attribute, or
+    records of incompatible types).
+    """
+
+
 class ProvElementIdentifierRequired(ProvException):
     """Exception for a missing element identifier."""
 

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -105,8 +105,9 @@ def test_show_element_attributes_false_skips_annotation():
 
 def test_unresolvable_unification_falls_back_to_original_bundle():
     """Covers prov_to_dot()'s ``except ProvException`` fallback when
-    ``bundle.unified()`` cannot merge two relations that share an identifier
-    but disagree on a formal attribute (the "scruffy" pattern -- see
+    ``bundle.unified()`` raises ``ProvUnificationError`` because two relations
+    share an identifier but disagree on a formal attribute (the "scruffy"
+    pattern -- see
     test_statements.py's RDF_SCRUFFY_SKIP cases for the same shape).
 
     Previously exercised incidentally by the pre-migration dot suite
@@ -126,9 +127,10 @@ def test_unresolvable_unification_falls_back_to_original_bundle():
         "ex:e1", "ex:a1", identifier="ex:gen1", time=datetime.datetime(2020, 1, 2)
     )
 
-    # bundle.unified() raises ProvException here (conflicting prov:time
-    # values for the same identifier); prov_to_dot() must catch it and fall
-    # back to rendering the original, non-unified bundle rather than raising.
+    # bundle.unified() raises ProvUnificationError here (conflicting prov:time
+    # values for the same identifier); prov_to_dot() must catch it — the
+    # exception is a ProvException — and fall back to rendering the original,
+    # non-unified bundle rather than raising.
     dot = prov_to_dot(doc)
     svg_content = dot.create(format="svg", encoding="utf-8")
     assert len(svg_content) > MIN_SVG_SIZE

--- a/src/prov/tests/test_public_api.py
+++ b/src/prov/tests/test_public_api.py
@@ -47,6 +47,7 @@ PUBLIC_API = {
         "ProvWarning",
         "ProvExceptionInvalidQualifiedName",
         "ProvElementIdentifierRequired",
+        "ProvUnificationError",
         # identifiers & literals (historically importable from prov.model too)
         "Namespace",
         "QualifiedName",

--- a/src/prov/tests/test_unification_constraints.py
+++ b/src/prov/tests/test_unification_constraints.py
@@ -1,37 +1,35 @@
-"""Characterize unified() against the PROV-CONSTRAINTS unification corpus (roadmap step 30b).
+"""Characterize unified() against the PROV-CONSTRAINTS unification corpus.
 
-2.x locks CURRENT behaviour: ``unified()`` is an identifier-keyed attribute
-union with no PROV-CONSTRAINTS term unification. Observed outcomes over the
+``unified()`` implements the specification's key constraints (22 and 23) by
+pairwise term unification of formal attributes. Observed outcomes over the
 vendored ProvToolbox/W3C corpus (``unification/constraints/``):
 
 - fail-cases whose same-identifier records carry *conflicting concrete* formal
-  attribute values are rejected, but only accidentally — ``ProvRecord.
-  add_attributes``'s cardinality guard (``src/prov/model/records.py:622-643``)
-  raises a generic ``ProvException("Cannot have more than one value for
-  attribute ...")`` mid-merge (``CARDINALITY_GUARD_REJECTS`` below);
-- every other fail-case silently merges (placeholder-vs-concrete conflicts,
-  which the model cannot represent) or passes through untouched (uniqueness
-  Constraints 24-29, mandatory-placeholder and impossibility cases, all keyed
-  on something other than the record identifier);
+  attribute values are rejected with the documented ``ProvUnificationError``
+  (``UNIFICATION_REJECTS`` below);
+- every other fail-case still merges (placeholder-vs-concrete conflicts, which
+  the model cannot represent — an absent formal attribute is an existential
+  that unifies with any concrete value) or passes through untouched
+  (uniqueness Constraints 24-29, mandatory-placeholder and impossibility
+  cases, all keyed on something other than the record identifier and hence
+  outside ``unified()``'s documented scope — they belong to the opt-in
+  validation engine, issue #62);
 - three ``bundle-*`` files cannot be parsed at all — prov's PROV-XML
   deserializer rejects them with ``ProvXMLException`` (issue #254) — and are
   skipped as parse failures.
 
-In 3.0 (roadmap step 36b, umbrella issue #253) ``unified()`` will implement
-the spec's merging: the key-constraint fail-cases below flip to asserting the
-documented merge-failure exception (fail-cases outside ``unified()``'s
-merging scope — ordering/impossibility/mandatory-placeholder validation —
-get their disposition decided in step 36b). Authority:
-docs/superpowers/specs/2026-07-10-unification-gap-analysis.md
+Authority: docs/superpowers/specs/2026-07-10-unification-gap-analysis.md and
+umbrella issue #253.
 """
 
+import datetime
 from pathlib import Path
 
 import pytest
 
 pytest.importorskip("lxml")
 
-from prov.model import ProvDocument, ProvException
+from prov.model import ProvDocument, ProvUnificationError
 
 # unified()'s FutureWarning (2.4.0 signpost for the 3.0 rework) is already
 # ignored via pyproject.toml's filterwarnings; the mark keeps these tests
@@ -50,11 +48,10 @@ PARSE_FAILURES = {
     "bundle-success2.xml",
 }
 
-# Fail-cases currently rejected by the accidental cardinality guard: their
-# same-identifier records carry two *different concrete* values for the same
-# formal attribute, so the merge's add_attributes() call raises. This is the
-# only rejection unified() performs today.
-CARDINALITY_GUARD_REJECTS = {
+# Fail-cases rejected by term unification: their same-identifier records carry
+# two *different concrete* values for the same formal attribute, so the records
+# cannot be merged. This is the only rejection unified() performs.
+UNIFICATION_REJECTS = {
     "association-fail1.xml",
     "association-fail2.xml",
     "association-fail3.xml",
@@ -90,11 +87,10 @@ def _n_records(document):
 
 
 def _expected_unified_count(document):
-    # The exact record count _unified_records() (bundle.py:384-414) produces,
-    # computed from the pre-merge document: per scope (toplevel and each
-    # bundle), identified records collapse to one per distinct identifier
-    # (regardless of record type or attribute conflicts), while anonymous
-    # records never enter _id_map (bundle.py:469-475) and ALL pass through
+    # The exact record count _unified_records() produces, computed from the
+    # pre-merge document: per scope (toplevel and each bundle), identified
+    # records collapse to one per distinct identifier (regardless of record
+    # type), while anonymous records never enter _id_map and ALL pass through
     # unchanged — not even exact duplicates are deduplicated.
     total = 0
     for scope in (document, *document.bundles):
@@ -126,8 +122,8 @@ def test_corpus_inventory():
     files = {p.name for p in CORPUS.glob("*.xml")}
     assert len(files) == 153
     assert files >= PARSE_FAILURES
-    assert files >= CARDINALITY_GUARD_REJECTS
-    assert all("-fail" in name for name in CARDINALITY_GUARD_REJECTS)
+    assert files >= UNIFICATION_REJECTS
+    assert all("-fail" in name for name in UNIFICATION_REJECTS)
 
 
 @pytest.mark.parametrize("xml_path, expected", list(_cases()))
@@ -143,17 +139,16 @@ def test_unified_corpus_characterization(xml_path, expected):
         # stay separate (gap analysis section 3.4).
         unified = document.unified()
         assert _n_records(unified) == _expected_unified_count(document)
-    elif xml_path.name in CARDINALITY_GUARD_REJECTS:
-        # Invalid instance rejected, but only via the accidental cardinality
-        # guard — not a documented merge-failure API.
-        # 3.0 triage (#253): must raise the documented merge-failure exception.
-        with pytest.raises(ProvException, match="more than one value"):
+    elif xml_path.name in UNIFICATION_REJECTS:
+        # Invalid instance rejected by term unification: two same-identifier
+        # records disagree on a formal attribute's concrete value.
+        with pytest.raises(ProvUnificationError):
             document.unified()
     else:
         # Invalid instance ("fail" per the corpus label) that unified()
         # nevertheless accepts, producing the plain identifier-keyed union —
-        # this silent acceptance IS the documented gap.
-        # 3.0 triage (#253): key-constraint fail-cases must raise instead.
+        # these fail on constraints outside unified()'s documented scope
+        # (see the module docstring).
         unified = document.unified()
         assert _n_records(unified) == _expected_unified_count(document)
 
@@ -161,33 +156,32 @@ def test_unified_corpus_characterization(xml_path, expected):
 # --- Hand-written per-rule gap examples (see the gap-analysis doc, section 3)
 
 
-def test_conflicting_start_times_currently_hit_the_cardinality_guard():
+def test_conflicting_start_times_fail_to_unify():
     # PROV-CONSTRAINTS Constraint 22 (key-object): two activity records with
     # the same id and different startTime values do not unify; the spec
-    # requires the merge (and thus normalization) to FAIL. Currently the
-    # attribute union trips ProvRecord.add_attributes's cardinality guard
-    # (records.py:622-643) — the right outcome class by accident, via an
-    # undocumented generic exception.
-    # 3.0 triage (#253): must raise the documented merge-failure exception.
+    # requires the merge (and thus normalization) to FAIL. unified() rejects
+    # them with the documented ProvUnificationError, naming the record, the
+    # formal attribute and both values.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.activity("a1", startTime="2011-11-16T16:00:00")
     doc.activity("a1", startTime="2012-01-01T00:00:00")
-    with pytest.raises(
-        ProvException, match="more than one value for attribute prov:startTime"
-    ):
+    with pytest.raises(ProvUnificationError, match="prov:startTime") as ctx:
         doc.unified()
+    message = str(ctx.value)
+    assert "a1" in message
+    assert repr(datetime.datetime(2011, 11, 16, 16, 0)) in message
+    assert repr(datetime.datetime(2012, 1, 1, 0, 0)) in message
 
 
-def test_placeholder_vs_concrete_plan_currently_merges_silently():
+def test_placeholder_vs_concrete_plan_merges():
     # PROV-CONSTRAINTS §4: the placeholder - is a constant; it unifies only
     # with itself or an existential variable, never with a concrete value.
     # Corpus analogue association-fail4: wasAssociatedWith(assoc1; a1, ag1,
     # ex:pl1) + wasAssociatedWith(assoc1; a1, ag1, -) must FAIL to merge.
-    # prov cannot represent -, so the absent plan merges silently with the
-    # concrete one.
-    # 3.0 triage (#253): 36b must decide the model's placeholder story and
-    # raise the documented merge-failure exception here.
+    # prov cannot represent - (deserializers drop the distinction), so an
+    # absent formal attribute is an existential and unifies with the concrete
+    # plan. Locked decision (#253): out of scope by representation.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.association("a1", agent="ag1", plan="pl1", identifier="assoc1")
@@ -201,10 +195,11 @@ def test_placeholder_vs_concrete_plan_currently_merges_silently():
 def test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity():
     # PROV-CONSTRAINTS Constraint 55 (entity-activity-disjoint) makes an
     # entity and an activity with the same identifier INVALID (with
-    # Constraint 50, typing). Currently they merge into a copy of whichever
-    # record came first — here a ProvEntity — with the activity's formal
-    # startTime demoted to an extra literal attribute.
-    # 3.0 triage (#253): must raise the documented merge-failure exception.
+    # Constraint 50, typing). Term unification applies to same-type groups
+    # only, so for now they still merge into a copy of whichever record came
+    # first — here a ProvEntity — with the activity's formal startTime demoted
+    # to an extra literal attribute.
+    # Task 2 (#253): type compatibility — this must raise.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.entity("thing")
@@ -218,14 +213,14 @@ def test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity():
     )
 
 
-def test_uniqueness_constraints_on_other_keys_are_currently_ignored():
+def test_uniqueness_constraints_on_other_keys_are_out_of_scope():
     # PROV-CONSTRAINTS Constraint 24 (unique-generation): two generations of
     # the same (entity, activity) pair must have equal identifiers — two
     # *different* constant identifiers cannot unify, so this instance is
     # INVALID (corpus analogue generation-fail1). unified() keys on the
-    # record identifier only and leaves both records untouched.
-    # 3.0 triage (#253): 36b must decide whether Constraints 24-29 are in
-    # unified()'s scope; if so this must raise.
+    # record identifier only and leaves both records untouched: Constraints
+    # 24-29 are documented as outside its scope and belong to the opt-in
+    # validation engine (#62).
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.entity("e1")
@@ -237,10 +232,10 @@ def test_uniqueness_constraints_on_other_keys_are_currently_ignored():
 
 
 def test_compatible_partial_information_merges_like_the_spec_example():
-    # The one case current behaviour gets right: PROV-CONSTRAINTS §6.1's
-    # worked example — activity(a, t1, _t, [ex:a=1]) + activity(a, _t, t2,
-    # [ex:b=2]) merge into activity(a, t1, t2, [ex:a=1, ex:b=2]) — because
-    # absent formal attributes union cleanly with concrete ones.
+    # PROV-CONSTRAINTS §6.1's worked example — activity(a, t1, _t, [ex:a=1]) +
+    # activity(a, _t, t2, [ex:b=2]) merge into activity(a, t1, t2, [ex:a=1,
+    # ex:b=2]) — because absent formal attributes unify with concrete ones and
+    # extra attributes are unioned.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.add_namespace("ex", "http://example.org/ns#")
@@ -260,10 +255,9 @@ def test_compatible_partial_information_merges_like_the_spec_example():
 
 def test_document_unified_scopes_unification_per_bundle():
     # PROV-CONSTRAINTS 7.2: each bundle is normalized independently; nothing
-    # merges across bundle boundaries. ProvDocument.unified()
-    # (bundle.py:1455-1480) conforms: the top level and each sub-bundle are
-    # unified independently of the document and of each other, even when
-    # they share record identifiers.
+    # merges across bundle boundaries. ProvDocument.unified() conforms: the
+    # top level and each sub-bundle are unified independently of the document
+    # and of each other, even when they share record identifiers.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.entity("e", {"prov:label": "top level"})
@@ -293,8 +287,8 @@ def test_flattened_unified_merges_across_bundle_boundaries():
     # The flattened().unified() idiom (as test_unifying in test_model.py uses)
     # merges same-id records ACROSS bundles — no PROV-CONSTRAINTS rule
     # licenses that (7.2 scopes constraints per bundle). Characterized here as
-    # spec-invalid usage; kept working in 2.x.
-    # 3.0 triage (#253): 36b must document this as outside PROV-CONSTRAINTS.
+    # spec-invalid usage that keeps working: flattened() discards the bundle
+    # structure first, so unified() only ever sees one scope.
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.entity("e", {"prov:label": "top level"})

--- a/src/prov/tests/test_unification_rules.py
+++ b/src/prov/tests/test_unification_rules.py
@@ -1,0 +1,81 @@
+"""PROV-CONSTRAINTS unification rules for unified() (3.0 rework, #253).
+
+Scope (documented): key constraints 22/23 + term unification. An absent
+formal attribute is an existential ("unknown") and unifies with any
+concrete value -- the model cannot represent the spec's placeholder `-`
+(deserializers drop the distinction; gap analysis §3.1), so `-`-vs-concrete
+failures are out of scope by representation. Constraints 24-29 are deferred
+to the #62 validation engine.
+"""
+
+import datetime
+
+import pytest
+
+from prov.model import ProvDocument, ProvUnificationError
+
+# unified() still emits its 2.4.0 FutureWarning signpost (removed in a later
+# step of the rework); pyproject.toml ignores it globally, and the mark keeps
+# this module self-contained should that filter ever change.
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+T1 = datetime.datetime(2011, 11, 16, 16, 0, 0)
+T2 = datetime.datetime(2011, 11, 16, 18, 0, 0)
+
+
+def _doc():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    return document
+
+
+def test_spec_worked_example_merges():
+    # PROV-CONSTRAINTS §6.1 worked example (Constraint 22).
+    document = _doc()
+    document.activity("ex:a", startTime=T1, other_attributes={"ex:x": 1})
+    document.activity("ex:a", endTime=T2, other_attributes={"ex:y": 2})
+    unified = document.unified()
+    (activity,) = unified.get_records()
+    assert activity.get_startTime() == T1
+    assert activity.get_endTime() == T2
+    assert len(activity.extra_attributes) == 2  # both ex:x and ex:y present
+
+
+def test_conflicting_concrete_formal_attributes_raise():
+    # Constraint 22: two concrete startTimes cannot unify.
+    document = _doc()
+    document.activity("ex:a", startTime=T1)
+    document.activity("ex:a", startTime=T2)
+    with pytest.raises(ProvUnificationError) as ctx:
+        document.unified()
+    message = str(ctx.value)
+    assert "ex:a" in message and "startTime" in message
+
+
+def test_conflicting_relation_endpoints_raise():
+    # Constraint 23: same-id generations of different entities cannot unify.
+    document = _doc()
+    document.generation("ex:e1", "ex:a1", identifier="ex:gen1")
+    document.generation("ex:e2", "ex:a1", identifier="ex:gen1")
+    with pytest.raises(ProvUnificationError):
+        document.unified()
+
+
+def test_absent_formal_attribute_unifies_with_concrete():
+    # Locked decision: absent == existential (the model cannot express `-`).
+    document = _doc()
+    document.association("ex:a1", agent="ex:ag1", plan="ex:pl1", identifier="ex:assoc1")
+    document.association("ex:a1", agent="ex:ag1", identifier="ex:assoc1")
+    unified = document.unified()
+    associations = [r for r in unified.get_records() if r.identifier is not None]
+    assert len(associations) == 1
+
+
+def test_unification_is_scoped_per_bundle():
+    # §7.2: bundles unify independently; nothing merges across boundaries.
+    document = _doc()
+    document.activity("ex:a", startTime=T1)
+    bundle = document.bundle("ex:b1")
+    bundle.activity("ex:a", startTime=T2)  # would conflict if scopes leaked
+    unified = document.unified()  # must NOT raise
+    assert unified.has_bundles()


### PR DESCRIPTION
Part 1 of #253.

`unified()` merged records sharing an identifier by replaying `add_attributes()` onto a copy of the first record, so a conflict between two concrete formal-attribute values surfaced as whatever `records.py`'s single-value cardinality guard happened to raise — a generic `ProvException("Cannot have more than one value for attribute prov:X")`. That rejection was an accident of the merge's implementation rather than a documented API, and it is what this PR replaces.

`_unified_records()` now merges each identifier group through a new module-level `_unify_record_group()` helper implementing the specification's key constraints (22 and 23). Formal attributes are unified position by position — absent unifies with anything, equal concrete values unify, two different concrete values raise the new `prov.model.ProvUnificationError` naming the record, the attribute and both values — and the merged record is then constructed from the unified tuple plus the union of the group's extra attributes, so no conflict is ever routed through the cardinality guard again. Extra attributes keep their set-union semantics and bundles still unify independently.

## Documented scope

- **Absent formal attribute = existential.** `prov`'s model cannot represent PROV-N's placeholder `-` (every deserializer drops the distinction between omitted and explicit `-`), so the specification's `-`-versus-concrete merge failure is out of scope by representation. This keeps PROV-CONSTRAINTS §6.1's worked example merging exactly as it did in 2.x.
- **Constraints 24-29 are out of scope** — the uniqueness constraints keyed on something other than the record identifier never raise here; they belong to the opt-in validation engine (#62).
- **Mixed-type identifier groups keep their historic first-record-wins union** for now; type compatibility follows in a later part of #253.
- **No assertion-time enforcement** (#257): constructors and factories are untouched, scruffy documents remain legal to build and serialize, and only `unified()` raises.

## `prov_to_graph()` decision

Left as-is: `prov_to_graph()` (`src/prov/graph.py`) calls `unified()` unguarded, so a document whose same-identifier records conflict now propagates `ProvUnificationError` to the caller instead of silently producing a graph built from a wrongly-merged record. `prov_to_dot()` keeps its long-standing `except ProvException` fallback to the non-unified bundle, which catches the new exception unchanged because it subclasses `ProvException`.

The two are deliberately different, and the difference is the pre-existing one: rendering a picture degrades gracefully, whereas a `MultiDiGraph` is a data structure callers compute over — quietly handing back edges derived from a merge the specification forbids is worse than raising. Adding a fallback would also be a new, undocumented behaviour for `prov_to_graph()` rather than the preservation of an existing one. `docs/upgrading-3.0.md` now states the divergence explicitly so neither is a surprise.

## Tests

New: `src/prov/tests/test_unification_rules.py` — five hand-written per-rule tests (§6.1 worked example, conflicting element formal attribute, conflicting relation endpoints, absent-vs-concrete, per-bundle scoping). The two `pytest.raises(ProvUnificationError)` cases were the failing tests this change was written against; the other three assert behaviour that must be *preserved*.

Existing tests changed:

- `src/prov/tests/test_unification_constraints.py` — `CARDINALITY_GUARD_REJECTS` renamed to `UNIFICATION_REJECTS` (same 25 members) and its 25 corpus cases flipped from `pytest.raises(ProvException, match="more than one value")` to `pytest.raises(ProvUnificationError)`; the module docstring rewritten from "2.x locks CURRENT behaviour" to the landed semantics; `test_conflicting_start_times_currently_hit_the_cardinality_guard` renamed to `test_conflicting_start_times_fail_to_unify` and now asserts the new exception carries the identifier, the formal attribute and both values; `test_placeholder_vs_concrete_plan_currently_merges_silently` renamed to `test_placeholder_vs_concrete_plan_merges` with the existential rationale replacing its "3.0 must decide" note; `test_uniqueness_constraints_on_other_keys_are_currently_ignored` renamed to `..._are_out_of_scope` and pointed at #62; the remaining "3.0 triage" comments replaced with the decisions they were waiting on. Stale source line references in the docstring and comments (`records.py:622-643`, `bundle.py:384-414`, `bundle.py:1455-1480`, `bundle.py:469-475`) were dropped rather than renumbered — they had already drifted once. The 83 success cases and their record-count assertions are untouched and still green.
- `src/prov/tests/test_dot.py` — `test_unresolvable_unification_falls_back_to_original_bundle` passes untouched (the new exception subclasses `ProvException`); only its docstring and inline comment were updated to name `ProvUnificationError` and to say why the `except ProvException` clause still catches it.
- `src/prov/tests/test_public_api.py` — `ProvUnificationError` added to the guarded `prov.model` inventory (an addition; nothing removed).

## Test-count delta

Baseline 1349 passed / 24 skipped / 0 xfailed → **1354 passed / 24 skipped / 0 xfailed**: +5, exactly the five new tests in `test_unification_rules.py`. No test was deleted, skipped or xfailed. Verified on the default interpreter and on the 3.10 floor (`uv run --python 3.10 --extra rdf --extra xml --extra dot --extra graph pytest -q`, same counts). `ruff check`, `ruff format --check` and `mypy src` are clean, and the Sphinx build is warning-free.

## Docs

`HISTORY.rst` gains the BREAKING entry under `3.0.0 (unreleased)`. `docs/upgrading-3.0.md`'s unification section replaces "will raise a documented exception" with the landed semantics, names `prov.model.ProvUnificationError`, and states the scope and the `prov_to_dot()`/`prov_to_graph()` divergence. `docs/reference/model.md` documents the new exception alongside the rest of the hierarchy.

`docs/explanation/unification-flattening.md` was also updated, which goes beyond the file list this change was planned around: the page described `unified()` as detecting no conflicts and cited the `TODO: Check unification rules in the PROV-CONSTRAINTS document` comment that this PR deletes, so leaving it would have shipped a page contradicting the code. The edit is confined to the claims this change falsifies — the worked example and the flattening half are untouched.