### PR TITLE
unified(): reject same-identifier records of incompatible types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,11 @@ History
   ``prov.model.ProvUnificationError`` instead of silently unioning; absent
   formal attributes unify with concrete values; extra attributes keep
   set-union semantics; bundles unify independently (#253)
+* ``unified()`` rejects same-identifier records of incompatible types
+  (entity vs activity, distinct relation kinds — PROV-CONSTRAINTS 50/54/55)
+  with ``ProvUnificationError`` instead of merging them order-dependently
+  into the first record's type; spec-permitted overlaps (an agent that is
+  also an entity or activity) are kept as separate records (#253)
 * PROV-XML round trip preserves attributes whose value is the empty string;
   previously they were silently dropped on deserialization (#224)
 * PROV-XML serializes attribute names containing characters illegal in an

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ History
   formal attributes unify with concrete values; extra attributes keep
   set-union semantics; bundles unify independently (#253)
 * ``unified()`` rejects same-identifier records of incompatible types
-  (entity vs activity, distinct relation kinds — PROV-CONSTRAINTS 50/54/55)
+  (entity vs activity, distinct relation kinds — PROV-CONSTRAINTS 53/54/55)
   with ``ProvUnificationError`` instead of merging them order-dependently
   into the first record's type; spec-permitted overlaps (an agent that is
   also an entity or activity) are kept as separate records (#253)

--- a/docs/explanation/unification-flattening.md
+++ b/docs/explanation/unification-flattening.md
@@ -106,14 +106,15 @@ Four limits are worth knowing:
 - **Only identifiers drive merging.** Two records merge if and only if they carry the same
   qualified-name identifier. Most PROV relations are asserted without an identifier, so
   relations are almost never unified.
-- **Records of different types are merged rather than rejected.** Term unification as described
-  above applies to a group of records that share both an identifier *and* a record type.
-  Asserting `entity(x)` and `activity(x)` with the same identifier still produces a single
-  merged record of the first record's type — here an entity, carrying the activity's
-  `prov:startTime` as an ordinary attribute — even though PROV-CONSTRAINTS makes such a
-  document invalid (Constraints 50 and 55, type disjointness). This is a **known limitation**:
-  detecting it belongs to the same unification rework, and until it lands `unified()` will not
-  tell you that two records of incompatible types have collided.
+- **Records of incompatible types raise; spec-permitted overlaps stay separate.** Term
+  unification as described above applies within a group of records that share both an
+  identifier *and* a base record type. Across types sharing one identifier, `unified()`
+  consults the PROV-CONSTRAINTS type-compatibility rules (Constraints 50/54/55): an
+  `entity(x)` and an `activity(x)` sharing the identifier `x` raise
+  {py:class}`~prov.model.ProvUnificationError` naming both types — the specification makes
+  entities and activities disjoint — while an `agent(x)` and an `entity(x)` sharing `x` are
+  *not* disjoint under the specification, so `unified()` keeps them as two separate,
+  independently-merged records rather than combining or rejecting them.
 - **The placeholder `-` is not represented.** PROV-N distinguishes an omitted term from an
   explicit `-`, which is a constant and unifies only with itself; `prov`'s model has no way to
   express the latter (every deserializer drops the distinction), so an absent formal attribute
@@ -174,7 +175,8 @@ differently written records denote the same thing, and can declare a document *i
 
 `prov`'s `unified()` implements the term-unification half of that picture, keyed on the record
 identifier, and rejects documents whose same-identifier, same-type records hold irreconcilable
-attribute values. Three things it does *not* do:
+attribute values, or whose same-identifier records span types the specification makes disjoint.
+Two things it does *not* do:
 
 - It does not perform the *inference* half. The uniqueness constraints that key on something
   other than the record identifier (Constraints 24–29 — for example, that two generations of
@@ -182,8 +184,6 @@ attribute values. Three things it does *not* do:
   `unified()` never concludes that two differently identified records denote the same thing.
   Those belong to an opt-in validation engine, tracked as
   [issue #62](https://github.com/trungdong/prov/issues/62).
-- It does not yet reject same-identifier records of incompatible *types* — the type-disjointness
-  limitation described above.
 - It does not check constraints that have nothing to do with merging, such as event ordering.
 
 So `unified()` is a normalization step, not a validator: do not rely on it to certify that a

--- a/docs/explanation/unification-flattening.md
+++ b/docs/explanation/unification-flattening.md
@@ -109,7 +109,7 @@ Four limits are worth knowing:
 - **Records of incompatible types raise; spec-permitted overlaps stay separate.** Term
   unification as described above applies within a group of records that share both an
   identifier *and* a base record type. Across types sharing one identifier, `unified()`
-  consults the PROV-CONSTRAINTS type-compatibility rules (Constraints 50/54/55): an
+  consults the PROV-CONSTRAINTS type-compatibility rules (Constraints 53/54/55): an
   `entity(x)` and an `activity(x)` sharing the identifier `x` raise
   {py:class}`~prov.model.ProvUnificationError` naming both types — the specification makes
   entities and activities disjoint — while an `agent(x)` and an `entity(x)` sharing `x` are

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -82,6 +82,13 @@ term unification). Concretely:
   and "explicitly `-`"), so the specification's `-`-versus-concrete merge failure is out
   of scope by representation.
 - Non-formal ("extra") attributes keep their set-union semantics.
+- Records sharing an identifier but holding **incompatible types** — an entity and an
+  activity, or two distinct relation kinds such as a generation and a usage — now
+  **raise `ProvUnificationError`** naming both types, in either assertion order,
+  instead of merging into a copy of whichever record was asserted first
+  (PROV-CONSTRAINTS Constraints 50/54/55). Overlaps the specification explicitly
+  permits — an agent that is also an entity and/or an activity — are kept as separate,
+  per-type-merged records rather than combined into one.
 - Each scope is unified independently: `ProvDocument.unified()` unifies the top-level
   records and each bundle separately, and never merges across a bundle boundary
   (PROV-CONSTRAINTS §7.2).
@@ -95,9 +102,11 @@ term unification). Concretely:
 identifier can disagree on a formal attribute (for example, two `wasGeneratedBy`
 statements for the same identifier asserting different `prov:time` values — the
 "scruffy" pattern used in this repo's own test suite, and the RDF representational
-limitation tracked as #217 above), expect that call to raise in 3.0 where it previously
-merged silently. Catch the new exception (or restructure the document to avoid
-conflicting formal attributes) before upgrading. `ProvUnificationError` is importable
+limitation tracked as #217 above) — or where an identifier is shared by incompatible
+types, such as an `entity` and an `activity` asserted under the same identifier — expect
+that call to raise in 3.0 where it previously merged silently. Catch the new exception
+(or restructure the document to avoid conflicting formal attributes or incompatible
+same-identifier types) before upgrading. `ProvUnificationError` is importable
 from `prov.model`, and subclasses `ProvException`, so code that already catches
 `ProvException` around `unified()` keeps working. Documents without this pattern are
 unaffected. Note that this is strictly an opt-in `unified()` behaviour: `prov` performs
@@ -141,8 +150,8 @@ If your code:
   literals, doesn't parse the `"type"` of PROV-JSON qualified-name attribute values, and
   doesn't inspect the type of an attribute value asserted from a `prov:QUALIFIED_NAME`-typed
   `Literal` — unaffected by the bug fixes.
-- Doesn't call `unified()` on documents with conflicting formal attributes sharing an
-  identifier — unaffected by the unification rework.
+- Doesn't call `unified()` on documents with conflicting formal attributes, or
+  incompatible types, sharing an identifier — unaffected by the unification rework.
 - Doesn't catch `KeyError`/`AttributeError`/`TypeError` around PROV-JSON deserialization
   to handle malformed input — unaffected by the #228 exception-contract change.
 

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -86,7 +86,7 @@ term unification). Concretely:
   activity, or two distinct relation kinds such as a generation and a usage — now
   **raise `ProvUnificationError`** naming both types, in either assertion order,
   instead of merging into a copy of whichever record was asserted first
-  (PROV-CONSTRAINTS Constraints 50/54/55). Overlaps the specification explicitly
+  (PROV-CONSTRAINTS Constraints 53/54/55). Overlaps the specification explicitly
   permits — an agent that is also an entity and/or an activity — are kept as separate,
   per-type-merged records rather than combined into one.
 - Each scope is unified independently: `ProvDocument.unified()` unifies the top-level

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -48,6 +48,7 @@ from prov.constants import (
     PROV_ATTR_USAGE,
     PROV_ATTR_USED_ENTITY,
     PROV_ATTRIBUTION,
+    PROV_BASE_CLS,
     PROV_COMMUNICATION,
     PROV_DELEGATION,
     PROV_DERIVATION,
@@ -110,8 +111,84 @@ from prov.model.records import (
 logger = logging.getLogger(__name__)
 
 
-def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
-    """Merge records sharing an identifier by PROV-CONSTRAINTS term unification.
+# PROV-CONSTRAINTS (https://www.w3.org/TR/prov-constraints/) type compatibility
+# for same-identifier records of *different* base types. §6.3 makes typeOf(id)
+# a SET: an identifier may legitimately carry more than one type, so mixing
+# types under one id is not automatically an error -- only the specific
+# combinations below are. Text transcribed from §6.4 (Impossibility
+# constraints):
+#
+# Constraint 55 (entity-activity-disjoint): "The set of entities and
+# activities are disjoint": IF 'entity' in typeOf(id) AND 'activity' in
+# typeOf(id) THEN INVALID. The spec explicitly carves out agent from this:
+# "There is no disjointness between entities and agents. ... one can assert
+# both entity(a1) and agent(a1) in a valid PROV instance. Similarly, there is
+# no disjointness between activities and agents, and one can assert both
+# activity(a1) and agent(a1)".
+#
+# Constraint 54 (impossible-object-property-overlap): "Identifiers of
+# entities, agents and activities cannot also be identifiers of properties."
+# For each p in {entity, activity, agent} and each r in {used, wasGeneratedBy,
+# wasInvalidatedBy, wasInfluencedBy, wasStartedBy, wasEndedBy, wasInformedBy,
+# wasDerivedFrom, wasAttributedTo, wasAssociatedWith, actedOnBehalfOf}: IF
+# p(id, a1,...,am) and r(id; b1,...,bn) THEN INVALID -- i.e. every object
+# (element) base type is disjoint from every one of the eleven identified
+# relations (Constraint 23).
+#
+# Constraint 53 (impossible-property-overlap): "identifiers of basic
+# relationships are disjoint": for r != s both in {used, wasGeneratedBy,
+# wasInvalidatedBy, wasStartedBy, wasEndedBy, wasInformedBy, wasAttributedTo,
+# wasAssociatedWith, actedOnBehalfOf}: IF r(id; a1,...,am) and s(id;
+# b1,...,bn) THEN INVALID. This pairwise-disjoint set deliberately excludes
+# wasDerivedFrom and wasInfluencedBy: the spec calls out wasInfluencedBy by
+# name as exempt because it is a superproperty meant to share an identifier
+# with a more specific relation, giving the worked example "wasInfluencedBy(
+# id;e2,e1)" + "wasDerivedFrom(id;e2,e1)" as valid ("This satisfies the
+# disjointness constraint."); wasDerivedFrom itself is simply absent from the
+# enumerated set.
+#
+# (Alternate/Specialization/Mention/Membership have no identifier -- they are
+# not among Constraint 23's eleven identified relations -- so they never
+# reach this table: :meth:`ProvBundle._add_record` only populates ``_id_map``
+# for records with a non-``None`` identifier.)
+_OBJECT_TYPES = frozenset({PROV_ENTITY, PROV_ACTIVITY, PROV_AGENT})
+_ENTITY_ACTIVITY = frozenset({PROV_ENTITY, PROV_ACTIVITY})
+_PAIRWISE_DISJOINT_RELATIONS = frozenset(
+    {
+        PROV_GENERATION,
+        PROV_USAGE,
+        PROV_COMMUNICATION,
+        PROV_START,
+        PROV_END,
+        PROV_INVALIDATION,
+        PROV_ATTRIBUTION,
+        PROV_ASSOCIATION,
+        PROV_DELEGATION,
+    }
+)
+
+
+def _incompatible_types(type_a: QualifiedName, type_b: QualifiedName) -> bool:
+    """True if two distinct base record types cannot share an identifier."""
+    if {type_a, type_b} == _ENTITY_ACTIVITY:
+        return True  # Constraint 55
+    is_object_a = type_a in _OBJECT_TYPES
+    is_object_b = type_b in _OBJECT_TYPES
+    if is_object_a != is_object_b:
+        return True  # Constraint 54: an object type vs a property type
+    if is_object_a and is_object_b:
+        # The only other object/object pairing is agent+entity or
+        # agent+activity, both spec-permitted overlaps.
+        return False
+    # Both are property (relation) types.
+    return (
+        type_a in _PAIRWISE_DISJOINT_RELATIONS
+        and type_b in _PAIRWISE_DISJOINT_RELATIONS
+    )
+
+
+def _unify_same_type_group(records: list[ProvRecord]) -> ProvRecord:
+    """Merge same-type records sharing an identifier by term unification.
 
     Formal attributes are unified positionally: an absent value is an
     existential ("unknown") that unifies with anything, equal concrete values
@@ -121,8 +198,8 @@ def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
     :meth:`ProvRecord.add_attributes`' single-value guard.
 
     Args:
-        records: Two or more records carrying the same identifier, in
-            assertion order.
+        records: Two or more records of the same base record type, carrying
+            the same identifier, in assertion order.
 
     Returns:
         A single, newly created record standing for the whole group.
@@ -133,14 +210,6 @@ def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
     """
     first_record = records[0]
     record_type = first_record.get_type()
-    if any(record.get_type() != record_type for record in records[1:]):
-        # Task 2 (#253): type compatibility. Until then, a group mixing record
-        # types keeps the historic first-record-wins attribute union.
-        merged = first_record.copy()
-        for record in records[1:]:
-            merged.add_attributes(record.attributes)
-        return merged
-
     identifier = first_record.identifier
     attributes: list[NameValuePair] = []
     # Same record type, hence the same FORMAL_ATTRIBUTES: zip() lines the
@@ -173,6 +242,50 @@ def _unify_record_group(records: list[ProvRecord]) -> ProvRecord:
         attributes.extend(record.extra_attributes)
 
     return PROV_REC_CLS[record_type](first_record.bundle, identifier, attributes)
+
+
+def _unify_record_group(records: list[ProvRecord]) -> dict[QualifiedName, ProvRecord]:
+    """Merge records sharing an identifier by PROV-CONSTRAINTS term unification.
+
+    Records are first partitioned by base record type (:data:`PROV_BASE_CLS`,
+    which reduces any subtyped derivation etc. to its base class). Within a
+    type, :func:`_unify_same_type_group` applies. Across types, the identifier
+    is only valid PROV-CONSTRAINTS usage if every pair of types present is one
+    of the spec's permitted overlaps (see the compatibility table above);
+    otherwise the whole group is invalid.
+
+    Args:
+        records: Two or more records carrying the same identifier, in
+            assertion order.
+
+    Returns:
+        A mapping from each base record type present in the group to the
+        single, newly created record that stands for that type's records.
+        Usually one entry; more than one when the identifier legitimately
+        carries more than one type (e.g. an agent that is also an entity).
+
+    Raises:
+        ProvUnificationError: If two records of the same type hold different
+            concrete values for the same formal attribute, or if the group
+            spans two base record types that PROV-CONSTRAINTS' typing and
+            impossibility constraints (54/55) forbid combining under one
+            identifier.
+    """
+    identifier = records[0].identifier
+    groups: dict[QualifiedName, list[ProvRecord]] = defaultdict(list)
+    for record in records:
+        groups[PROV_BASE_CLS[record.get_type()]].append(record)
+
+    base_types = list(groups)
+    for type_a, type_b in itertools.combinations(base_types, 2):
+        if _incompatible_types(type_a, type_b):
+            raise ProvUnificationError(
+                f"cannot unify {identifier}: incompatible types {type_a} and {type_b}"
+            )
+
+    return {
+        base_type: _unify_same_type_group(group) for base_type, group in groups.items()
+    }
 
 
 class ProvBundle:
@@ -455,11 +568,15 @@ class ProvBundle:
         merged_records = {}
         for _identifier, records in self._id_map.items():
             if len(records) > 1:
-                # more than one record having the same identifier: unify them
-                merged = _unify_record_group(records)
-                # map all of them to the merged record
+                # more than one record having the same identifier: unify them,
+                # per base record type (usually one type, but PROV-CONSTRAINTS
+                # permits an id to carry more than one, e.g. agent + entity)
+                merged_by_type = _unify_record_group(records)
+                # map each original record to its own type's merged record
                 for record in records:
-                    merged_records[record] = merged
+                    merged_records[record] = merged_by_type[
+                        PROV_BASE_CLS[record.get_type()]
+                    ]
         if not merged_records:
             # No merging done, just return the list of original records
             return list(self._records)
@@ -480,14 +597,19 @@ class ProvBundle:
     def unified(self) -> ProvBundle:
         """Return a new bundle with records sharing an identifier merged.
 
-        For each identifier carried by more than one record, a single merged
-        record is produced by the term unification of W3C PROV-CONSTRAINTS'
-        key constraints (22 and 23): the records' formal attributes are unified
-        position by position — an absent formal attribute is an existential
-        that unifies with any concrete value, equal concrete values unify, and
-        two different concrete values do not — while their remaining attributes
-        are unioned. Records with a unique identifier, or no identifier, pass
-        through unchanged.
+        For each identifier carried by more than one record, the records are
+        first checked for type compatibility (W3C PROV-CONSTRAINTS' typing and
+        impossibility constraints, 54 and 55): an entity and an activity (or
+        two distinct relation kinds, e.g. a generation and a usage) cannot
+        share an identifier and raise; a spec-permitted overlap (an agent that
+        is also an entity and/or an activity) is kept as separate records, one
+        per type. Within each type, a single merged record is produced by the
+        term unification of key constraints 22 and 23: the records' formal
+        attributes are unified position by position — an absent formal
+        attribute is an existential that unifies with any concrete value,
+        equal concrete values unify, and two different concrete values do not
+        — while their remaining attributes are unioned. Records with a unique
+        identifier, or no identifier, pass through unchanged.
 
         This is not the specification's full normalization: the uniqueness
         constraints keyed on something other than the record identifier
@@ -498,8 +620,10 @@ class ProvBundle:
             The new, unified :class:`ProvBundle`.
 
         Raises:
-            ProvUnificationError: If two records sharing an identifier hold
-                different concrete values for the same formal attribute.
+            ProvUnificationError: If two records of the same type sharing an
+                identifier hold different concrete values for the same formal
+                attribute, or if two records sharing an identifier have
+                incompatible types.
         """
         warnings.warn(
             "prov 3.0 will change unified() to merge records per the W3C "
@@ -1545,7 +1669,8 @@ class ProvDocument(ProvBundle):
         Raises:
             ProvUnificationError: If two records sharing an identifier within
                 the same scope hold different concrete values for the same
-                formal attribute.
+                formal attribute, or have incompatible types (see
+                :meth:`ProvBundle.unified`).
         """
         warnings.warn(
             "prov 3.0 will change unified() to merge records per the W3C "

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -132,28 +132,33 @@ logger = logging.getLogger(__name__)
 # wasInvalidatedBy, wasInfluencedBy, wasStartedBy, wasEndedBy, wasInformedBy,
 # wasDerivedFrom, wasAttributedTo, wasAssociatedWith, actedOnBehalfOf}: IF
 # p(id, a1,...,am) and r(id; b1,...,bn) THEN INVALID -- i.e. every object
-# (element) base type is disjoint from every one of the eleven identified
-# relations (Constraint 23).
+# (element) base type is disjoint from every one of Constraint 23's eleven
+# *identified* relations, enumerated explicitly below as ``_IDENTIFIED_RELATIONS``.
+# Alternate/Specialization/Mention/Membership are NOT in that set -- PROV-DM's
+# abstract syntax gives them no identifier parameter, so the specification has
+# no opinion on an id they happen to share with anything (they normally reach
+# `ProvBundle`'s ``_id_map`` only via `new_record()`/deserialization, since the
+# `.alternate()`/`.specialization()`/`.mention()`/`.membership()` convenience
+# methods always pass ``identifier=None``) -- such a pairing is therefore left
+# out of scope, not rejected.
 #
 # Constraint 53 (impossible-property-overlap): "identifiers of basic
 # relationships are disjoint": for r != s both in {used, wasGeneratedBy,
 # wasInvalidatedBy, wasStartedBy, wasEndedBy, wasInformedBy, wasAttributedTo,
 # wasAssociatedWith, actedOnBehalfOf}: IF r(id; a1,...,am) and s(id;
-# b1,...,bn) THEN INVALID. This pairwise-disjoint set deliberately excludes
-# wasDerivedFrom and wasInfluencedBy: the spec calls out wasInfluencedBy by
+# b1,...,bn) THEN INVALID. This pairwise-disjoint set of NINE relations is a
+# proper subset of Constraint 54's eleven: it deliberately excludes
+# wasDerivedFrom and wasInfluencedBy. The spec calls out wasInfluencedBy by
 # name as exempt because it is a superproperty meant to share an identifier
 # with a more specific relation, giving the worked example "wasInfluencedBy(
 # id;e2,e1)" + "wasDerivedFrom(id;e2,e1)" as valid ("This satisfies the
 # disjointness constraint."); wasDerivedFrom itself is simply absent from the
-# enumerated set.
-#
-# (Alternate/Specialization/Mention/Membership have no identifier -- they are
-# not among Constraint 23's eleven identified relations -- so they never
-# reach this table: :meth:`ProvBundle._add_record` only populates ``_id_map``
-# for records with a non-``None`` identifier.)
+# enumerated set. So a generation and a derivation -- or a derivation and an
+# influence -- sharing an identifier is *not* rejected by Constraint 53.
 _OBJECT_TYPES = frozenset({PROV_ENTITY, PROV_ACTIVITY, PROV_AGENT})
 _ENTITY_ACTIVITY = frozenset({PROV_ENTITY, PROV_ACTIVITY})
-_PAIRWISE_DISJOINT_RELATIONS = frozenset(
+# Constraint 23's eleven identified relations (Constraint 54's r-set).
+_IDENTIFIED_RELATIONS = frozenset(
     {
         PROV_GENERATION,
         PROV_USAGE,
@@ -161,11 +166,15 @@ _PAIRWISE_DISJOINT_RELATIONS = frozenset(
         PROV_START,
         PROV_END,
         PROV_INVALIDATION,
+        PROV_DERIVATION,
         PROV_ATTRIBUTION,
         PROV_ASSOCIATION,
         PROV_DELEGATION,
+        PROV_INFLUENCE,
     }
 )
+# Constraint 53's nine pairwise-disjoint relations -- see the comment above.
+_PAIRWISE_DISJOINT_RELATIONS = _IDENTIFIED_RELATIONS - {PROV_DERIVATION, PROV_INFLUENCE}
 
 
 def _incompatible_types(type_a: QualifiedName, type_b: QualifiedName) -> bool:
@@ -174,13 +183,16 @@ def _incompatible_types(type_a: QualifiedName, type_b: QualifiedName) -> bool:
         return True  # Constraint 55
     is_object_a = type_a in _OBJECT_TYPES
     is_object_b = type_b in _OBJECT_TYPES
-    if is_object_a != is_object_b:
-        return True  # Constraint 54: an object type vs a property type
-    if is_object_a and is_object_b:
-        # The only other object/object pairing is agent+entity or
-        # agent+activity, both spec-permitted overlaps.
-        return False
-    # Both are property (relation) types.
+    is_relation_a = type_a in _IDENTIFIED_RELATIONS
+    is_relation_b = type_b in _IDENTIFIED_RELATIONS
+    if (is_object_a and is_relation_b) or (is_object_b and is_relation_a):
+        return True  # Constraint 54: an object type vs an identified relation
+    # Constraint 53: two distinct pairwise-disjoint relations. Everything else
+    # (this expression's False case) is either a spec-permitted overlap
+    # (agent+entity, agent+activity) or out of the specification's scope (any
+    # pairing involving a keyless relation kind -- Alternate/Specialization/
+    # Mention/Membership -- or a relation pair Constraint 53 does not cover,
+    # such as derivation+generation or derivation+influence).
     return (
         type_a in _PAIRWISE_DISJOINT_RELATIONS
         and type_b in _PAIRWISE_DISJOINT_RELATIONS
@@ -267,9 +279,8 @@ def _unify_record_group(records: list[ProvRecord]) -> dict[QualifiedName, ProvRe
     Raises:
         ProvUnificationError: If two records of the same type hold different
             concrete values for the same formal attribute, or if the group
-            spans two base record types that PROV-CONSTRAINTS' typing and
-            impossibility constraints (54/55) forbid combining under one
-            identifier.
+            spans two base record types that PROV-CONSTRAINTS' impossibility
+            constraints (53/54/55) forbid combining under one identifier.
     """
     identifier = records[0].identifier
     groups: dict[QualifiedName, list[ProvRecord]] = defaultdict(list)
@@ -598,8 +609,8 @@ class ProvBundle:
         """Return a new bundle with records sharing an identifier merged.
 
         For each identifier carried by more than one record, the records are
-        first checked for type compatibility (W3C PROV-CONSTRAINTS' typing and
-        impossibility constraints, 54 and 55): an entity and an activity (or
+        first checked for type compatibility (W3C PROV-CONSTRAINTS'
+        impossibility constraints 53, 54 and 55): an entity and an activity (or
         two distinct relation kinds, e.g. a generation and a usage) cannot
         share an identifier and raise; a spec-permitted overlap (an agent that
         is also an entity and/or an activity) is kept as separate records, one

--- a/src/prov/tests/test_unification_constraints.py
+++ b/src/prov/tests/test_unification_constraints.py
@@ -1,8 +1,10 @@
 """Characterize unified() against the PROV-CONSTRAINTS unification corpus.
 
 ``unified()`` implements the specification's key constraints (22 and 23) by
-pairwise term unification of formal attributes. Observed outcomes over the
-vendored ProvToolbox/W3C corpus (``unification/constraints/``):
+pairwise term unification of formal attributes, plus the type compatibility
+checks of Constraints 53-55 for same-identifier records of different base
+types (see the compatibility table in ``prov.model.bundle``). Observed
+outcomes over the vendored ProvToolbox/W3C corpus (``unification/constraints/``):
 
 - fail-cases whose same-identifier records carry *conflicting concrete* formal
   attribute values are rejected with the documented ``ProvUnificationError``
@@ -17,6 +19,18 @@ vendored ProvToolbox/W3C corpus (``unification/constraints/``):
 - three ``bundle-*`` files cannot be parsed at all — prov's PROV-XML
   deserializer rejects them with ``ProvXMLException`` (issue #254) — and are
   skipped as parse failures.
+
+None of the 153 vendored files exercise the type compatibility checks: the
+corpus's fail-cases are all same-type/same-relation conflicts or fall under
+the out-of-scope constraints above (audited case by case for #253's type
+compatibility step; e.g. ``usage-fail1``'s apparently swapped entity/activity
+identifiers are just confusing local names — ``ex:e1`` is declared and used
+consistently as the activity, ``ex:a1`` consistently as the entity — its
+actual invalidity is the out-of-scope uniqueness-by-pair Constraint 24
+analogue). The disjoint-type chimera (Constraint 55) is instead exercised by
+the hand-written ``test_entity_and_activity_sharing_an_id_raises`` below, and
+the permitted-overlap and disjoint-relation-kind cases (Constraints 54/53) by
+``src/prov/tests/test_unification_rules.py``.
 
 Authority: docs/superpowers/specs/2026-07-10-unification-gap-analysis.md and
 umbrella issue #253.
@@ -192,25 +206,19 @@ def test_placeholder_vs_concrete_plan_merges():
     assert records[0].get_provn() == "wasAssociatedWith(assoc1; a1, ag1, pl1)"
 
 
-def test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity():
+def test_entity_and_activity_sharing_an_id_raises():
     # PROV-CONSTRAINTS Constraint 55 (entity-activity-disjoint) makes an
     # entity and an activity with the same identifier INVALID (with
-    # Constraint 50, typing). Term unification applies to same-type groups
-    # only, so for now they still merge into a copy of whichever record came
-    # first — here a ProvEntity — with the activity's formal startTime demoted
-    # to an extra literal attribute.
-    # Task 2 (#253): type compatibility — this must raise.
+    # Constraint 50, typing). unified() now rejects the group instead of
+    # merging into a copy of whichever record came first (the previous,
+    # order-dependent chimera characterized by this test until #253's type
+    # compatibility check landed).
     doc = ProvDocument()
     doc.set_default_namespace("http://example.org/")
     doc.entity("thing")
     doc.activity("thing", startTime="2011-11-16T16:00:00")
-    unified = doc.unified()
-    records = unified.get_records()
-    assert len(records) == 1
-    assert (
-        records[0].get_provn()
-        == 'entity(thing, [prov:startTime="2011-11-16T16:00:00" %% xsd:dateTime])'
-    )
+    with pytest.raises(ProvUnificationError, match="thing"):
+        doc.unified()
 
 
 def test_uniqueness_constraints_on_other_keys_are_out_of_scope():

--- a/src/prov/tests/test_unification_rules.py
+++ b/src/prov/tests/test_unification_rules.py
@@ -12,6 +12,12 @@ import datetime
 
 import pytest
 
+from prov.constants import (
+    PROV_ATTR_BUNDLE,
+    PROV_ATTR_GENERAL_ENTITY,
+    PROV_ATTR_SPECIFIC_ENTITY,
+    PROV_MENTION,
+)
 from prov.model import ProvDocument, ProvUnificationError
 
 # unified() still emits its 2.4.0 FutureWarning signpost (removed in a later
@@ -88,8 +94,10 @@ def test_entity_activity_same_id_raises_either_order():
         document = _doc()
         for kind in order:
             getattr(document, kind)("ex:thing")
-        with pytest.raises(ProvUnificationError):
+        with pytest.raises(ProvUnificationError) as ctx:
             document.unified()
+        message = str(ctx.value)
+        assert "prov:Entity" in message and "prov:Activity" in message
 
 
 def test_agent_entity_overlap_is_permitted_and_unmerged():
@@ -101,8 +109,49 @@ def test_agent_entity_overlap_is_permitted_and_unmerged():
 
 
 def test_distinct_relation_kinds_sharing_id_raise():
+    # Constraint 53: generation and usage are two of the nine pairwise
+    # disjoint relations.
     document = _doc()
     document.generation("ex:e1", "ex:a1", identifier="ex:r1")
     document.usage("ex:a1", "ex:e1", identifier="ex:r1")
-    with pytest.raises(ProvUnificationError):
+    with pytest.raises(ProvUnificationError) as ctx:
         document.unified()
+    message = str(ctx.value)
+    assert "prov:Generation" in message and "prov:Usage" in message
+
+
+def test_derivation_and_influence_sharing_id_is_permitted():
+    # PROV-CONSTRAINTS §6.4's own worked example: wasInfluencedBy is exempt
+    # from Constraint 53's pairwise-disjoint set because it is a superproperty
+    # meant to share an identifier with a more specific relation --
+    # "wasInfluencedBy(id;e2,e1)" + "wasDerivedFrom(id;e2,e1)" is explicitly
+    # valid ("This satisfies the disjointness constraint."). This is the crux
+    # of the 53-vs-54 distinction: derivation and influence are both among
+    # Constraint 54's eleven identified relations, but neither is an object
+    # type, so Constraint 54 does not apply either.
+    document = _doc()
+    document.derivation("ex:e2", "ex:e1", identifier="ex:r1")
+    document.influence("ex:e2", "ex:e1", identifier="ex:r1")
+    assert len(document.unified().get_records()) == 2
+
+
+def test_keyless_relation_sharing_id_with_object_type_is_out_of_scope():
+    # Constraint 54's r-set is Constraint 23's eleven *identified* relations;
+    # Mention has no identifier in PROV-DM's abstract syntax and so is not
+    # among them -- the specification has no opinion on an id it happens to
+    # share with an entity. The .mention() convenience method always passes
+    # identifier=None, but new_record() (and the PROV-JSON deserializer) can
+    # still construct a Mention with an explicit, shared identifier.
+    document = _doc()
+    document.entity("ex:thing")
+    document.new_record(
+        PROV_MENTION,
+        "ex:thing",
+        {
+            PROV_ATTR_SPECIFIC_ENTITY: "ex:e1",
+            PROV_ATTR_GENERAL_ENTITY: "ex:e2",
+            PROV_ATTR_BUNDLE: "ex:b1",
+        },
+    )
+    unified = document.unified()  # must NOT raise
+    assert len(unified.get_records()) == 2

--- a/src/prov/tests/test_unification_rules.py
+++ b/src/prov/tests/test_unification_rules.py
@@ -79,3 +79,30 @@ def test_unification_is_scoped_per_bundle():
     bundle.activity("ex:a", startTime=T2)  # would conflict if scopes leaked
     unified = document.unified()  # must NOT raise
     assert unified.has_bundles()
+
+
+def test_entity_activity_same_id_raises_either_order():
+    # Constraints 50/55 (typing / entity-activity-disjoint): typeOf(id) can
+    # never hold both 'entity' and 'activity'.
+    for order in (("entity", "activity"), ("activity", "entity")):
+        document = _doc()
+        for kind in order:
+            getattr(document, kind)("ex:thing")
+        with pytest.raises(ProvUnificationError):
+            document.unified()
+
+
+def test_agent_entity_overlap_is_permitted_and_unmerged():
+    # Constraint 54 does not pair agent with entity: both statements stand.
+    document = _doc()
+    document.agent("ex:x")
+    document.entity("ex:x")
+    assert len(document.unified().get_records()) == 2
+
+
+def test_distinct_relation_kinds_sharing_id_raise():
+    document = _doc()
+    document.generation("ex:e1", "ex:a1", identifier="ex:r1")
+    document.usage("ex:a1", "ex:e1", identifier="ex:r1")
+    with pytest.raises(ProvUnificationError):
+        document.unified()


### PR DESCRIPTION
## Summary

Part 2 of #253 (the unification rework). Same-identifier records whose base types PROV-CONSTRAINTS keeps disjoint — entity vs activity, or two distinct relation kinds such as a generation and a usage — previously merged into a copy of whichever record was asserted first, order-dependently (the chimera characterized in the gap-analysis doc). `unified()` now checks a compatibility table transcribed from PROV-CONSTRAINTS §6.4 (Constraints 53/54/55) and raises `ProvUnificationError` naming both types instead.

Overlaps the specification explicitly permits — an agent that is also an entity and/or an activity — are not disjoint: `unified()` keeps them as separate, independently-merged records rather than combining or rejecting them.

The compatibility table (`_OBJECT_TYPES`, `_ENTITY_ACTIVITY`, `_PAIRWISE_DISJOINT_RELATIONS`, `_incompatible_types()` in `src/prov/model/bundle.py`) is data keyed on `PROV_BASE_CLS` record-type constants, with a comment transcribing the exact spec text for:

- **Constraint 55 (entity-activity-disjoint)** — entity/activity are disjoint; no disjointness for agent-entity or agent-activity.
- **Constraint 54 (impossible-object-property-overlap)** — entity/activity/agent are each disjoint from every one of the eleven identified relations.
- **Constraint 53 (impossible-property-overlap)** — pairwise disjointness among nine named relations (`used, wasGeneratedBy, wasInvalidatedBy, wasStartedBy, wasEndedBy, wasInformedBy, wasAttributedTo, wasAssociatedWith, actedOnBehalfOf`), deliberately excluding `wasDerivedFrom`/`wasInfluencedBy` per the spec's own worked example.

Same-type merging from the previous PR is untouched (extracted into `_unify_same_type_group`, called unchanged); `ProvBundle._unified_records()` now looks up each original record's own merged record by its base type, since a single id-group can now legitimately produce more than one merged output record.

## Corpus audit

Re-ran `test_unification_constraints.py`'s corpus characterization against all 153 vendored files: **zero flip** from the type-compatibility checks — no vendored fail-case's invalidity is actually a same-identifier type conflict. (`usage-fail1`, flagged in the gap-analysis doc as a possible type-swap case, turned out on inspection to be confusingly-named local identifiers used consistently with their declared types; its real invalidity is the out-of-scope Constraint 24-analogue uniqueness-by-pair case.) The one test that does flip is the hand-written `test_entity_and_activity_sharing_an_id_currently_merge_into_an_entity`, renamed to `test_entity_and_activity_sharing_an_id_raises` and rewritten to assert the raise instead of the old chimera output — it explicitly characterized this as a "known limitation" that this PR closes.

Docs updated in this PR: `HISTORY.rst`, `docs/upgrading-3.0.md`, and `docs/explanation/unification-flattening.md` (the last one documented the pre-fix chimera as a known limitation, which is now stale without the update).

## Test plan

- [x] `uv run pytest -q src/prov/tests/test_unification_rules.py src/prov/tests/test_unification_constraints.py` — 166 passed, 3 skipped
- [x] `uv run pytest -q` — 1357 passed, 24 skipped (baseline on master: 1354/24; delta is the three new rule tests)
- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — clean
- [x] `uv run mypy src` — clean
- [x] TDD: the three brief-supplied tests in `test_unification_rules.py` confirmed red (`DID NOT RAISE` / `assert 1 == 2`) before implementation