### PR TITLE
Amend the 3.0 close-out plan with its pre-execution validation outcome

### DIFF
--- a/docs/superpowers/plans/2026-07-19-3.0-batch4-closeout-release.md
+++ b/docs/superpowers/plans/2026-07-19-3.0-batch4-closeout-release.md
@@ -4,7 +4,7 @@
 
 **Goal:** Finish the 3.0.0 milestone — the remaining complexity-hotspot refactors (#275), the roadmap step-37 deprecation-sweep verification, docs finalisation against what actually landed, and the release cut (steps 38–39) through the 2.5.0-precedent flow with a hard maintainer gate before publishing.
 
-**Architecture:** Twelve tasks: five behaviour-preserving refactors (Tasks 1–5) + the #275 close-out (Task 6), the deprecation sweep (Task 7), two docs-finalisation PRs (Tasks 8–9), release prep (Task 10), the gated publish (Task 11), and the conda-forge bump (Task 12). Runs **only after batches 2a, 2b and 3 are merged**. This plan is written before those batches execute, so wherever a value depends on their outcomes (suite tallies, xfail/skip counts, HISTORY wording, conformance rows), the task specifies a concrete procedure to derive it from repo state at execution time — no guessed values.
+**Architecture:** Fifteen tasks: seven behaviour-preserving refactors (Tasks 1–5, 5a, 5b) + the #275 close-out (Task 6), the deprecation sweep (Task 7), two docs-finalisation PRs (Tasks 8–9), the `/simplify` quality pass (Task 9a), release prep (Task 10), the gated publish (Task 11), and the conda-forge bump (Task 12). Tasks 5a, 5b and 9a were added during the 2026-07-26 pre-execution validation — see "Step 0 validation outcome" below. Runs **only after batches 2a, 2b and 3 are merged**. This plan is written before those batches execute, so wherever a value depends on their outcomes (suite tallies, xfail/skip counts, HISTORY wording, conformance rows), the task specifies a concrete procedure to derive it from repo state at execution time — no guessed values.
 
 **Tech Stack:** Python 3.10–3.14 + PyPy 3.11, uv, ruff, mypy --strict, pytest + Hypothesis, Sphinx/furo, gh CLI, PyPI Trusted Publishing, conda-forge feedstock.
 
@@ -38,6 +38,64 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 
 ---
 
+## Step 0 validation outcome (2026-07-26, master `d7cdb8e`)
+
+The baseline above was run before Task 1. Results, and the amendments they forced:
+
+**Confirmed valid as written.** Suite baseline 1390 passed / 24 skipped / 0 xfailed. Marker
+inventory clean — all 24 skips cite out-of-scope reasons (4 minimal-install, 14 PROV-O `prov:time`
+under the #217 decision, 3 ProvToolbox `<prov:bundle>` dialect parse-failures, 3 PROV-XML/XSD
+spec limits); no marker cites an issue that batches 2/3 fixed, so no pre-task marker PR was
+needed. Milestone open = #275 only. Tasks 1–5's targets are all intact at their stated
+complexity — no batch-2/3 drift.
+
+**Corrections.**
+
+- `prov.read()` measures **CCN 22**, not the 20 quoted here and in #275; it has measured 22 since
+  before this plan was written. The acceptance criterion (decompose below 15) is unaffected —
+  but PR bodies must not quote 20.
+- Task 7 is largely **pre-satisfied**: `FutureWarning` no longer appears anywhere in `src/` or
+  `pyproject.toml`, `pyproject.toml` carries no `filterwarnings` key at all, and
+  `grep -rn "prov 3.0" src/` is empty. The only surviving `DeprecationWarning` mentions are
+  comments and docstrings describing *rdflib's own* warnings. What remains live is the errorized
+  suite run and its scoping around the ~7300 third-party rdflib warnings.
+- Tasks 8 and 9 are **narrowed**: batch 3 already moved ROADMAP.md's unification bullet to landed
+  tense, rewrote `docs/explanation/unification-flattening.md`, and corrected the stale future-tense
+  claims in `conformance.md`. That work is not to be redone. Genuinely still stale: `upgrading-3.0.md`
+  future tense (2 hits) plus its HISTORY-driven row audit; `conformance.md`'s 3.0.0 revision stamp
+  and per-row verification; ROADMAP.md's "python-dateutil is still to be dropped" line (it *was*
+  dropped), its 3.0.0 row status, and the 3.1.0 Python-floor note.
+
+**Two production hotspots the plan never covered.** `uvx lizard -C 15 src/prov/` reports nine
+warnings, but this plan's Tasks 1–5 discharge only five of them. Two more are production code and
+appear in neither this plan nor #275's ranked list, despite #275's scope sentence claiming all nine:
+
+| function | CCN | disposition |
+|---|---|---|
+| `provxml.py` `serialize_bundle` | 39 | **Task 5b** (added) — the codebase's worst hotspot |
+| `provrdf.py` `decode_rdf_representation` | 19 | **Task 5a** (added) — never in #274's scope, which was `encode_container`/`decode_container` |
+| `tests/strategies.py` `_populate` | 32 | deferred — test-only |
+| `tests/test_rdf.py` `find_diff` | 17 | deferred — test-only; regressed from 13 during batches 2a/2b/2c |
+
+Left unamended, **Task 6's close-out narrative would have been factually wrong on a public tracking
+issue** — it claims four of five production hotspots are discharged here and the rest by #274,
+which would have understated two live production functions and one deferred test-only one. Task 6
+is rewritten below accordingly.
+
+**Maintainer decisions (AskUserQuestion, 2026-07-26):**
+
+- Both undischarged production hotspots are **refactored inside this batch** (Tasks 5a and 5b),
+  not deferred. The two test-only functions are deferred.
+- #275 is **closed** with the full close-out table, and the two deferred test-only functions are
+  **spun off into a new labelled-backlog issue** (rather than retitling #275 to track them).
+
+This supersedes the header's "`_populate` may be explicitly deferred, in which case the close-out
+task re-scopes the tracking issue instead of closing it silently" — the deferral still stands, but
+the maintainer chose close-plus-spinoff as the bookkeeping form, which honours the same intent:
+nothing is silently dropped.
+
+---
+
 ### Task 1: Refactor `records.py` `add_attributes` (CCN 18)
 
 **Goal:** `ProvRecord.add_attributes` decomposed below CCN 15, behaviour-preserving — this is the hot path for every record built by every deserializer, so parity evidence is the deliverable.
@@ -64,7 +122,7 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 
 ---
 
-### Task 2: Refactor `prov.read()` (CCN 20)
+### Task 2: Refactor `prov.read()` (CCN 22 — measured; #275 and this plan both said 20)
 
 **Goal:** `read()` in `src/prov/__init__.py` decomposed (source-classification vs format-detection loop — the decomposition already sketched and deferred at the 2.5.0 post-release review), behaviour-preserving.
 
@@ -127,21 +185,85 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 
 ---
 
-### Task 6: #275 close-out — re-scope the tracking issue
+### Task 5a: Refactor `provrdf.py` `decode_rdf_representation` (CCN 19) — added 2026-07-26
 
-**Goal:** #275's disposition is recorded honestly: four of five production hotspots done here, provrdf done in batch 2b (#274), and the test-only `strategies.py` `_populate` (CCN 32) explicitly deferred — the issue is re-scoped, not silently closed.
+**Goal:** The RDF literal/term decoding ladder decomposed below CCN 15, behaviour-preserving. In
+#275's "nine issues left visible on Codacy" but absent from its ranked list, and never inside
+#274's scope (which was `encode_container`/`decode_container`).
+
+**Files:** `src/prov/serializers/provrdf.py`; `HISTORY.rst`.
+
+**Acceptance Criteria:**
+- [ ] `uvx lizard -C 15 src/prov/serializers/provrdf.py` clean for `decode_rdf_representation` and
+      its new helpers (`decode_container`/`encode_container` remain clean from #274).
+- [ ] `test_rdf.py` green; full suite counts unchanged; parity capture (rdf leg) diff-clean.
+- [ ] Pure moves only — the datatype dispatch ladder keeps its exact precedence order, since
+      which branch wins decides the decoded Python type.
+- [ ] mypy/ruff green; no public-surface change (helpers `_`-prefixed).
+
+**Verify:** `uv run pytest -q src/prov/tests/test_rdf.py && uv run pytest -q && uvx lizard -C 15 src/prov/serializers/provrdf.py` → clean.
+
+**Steps:** branch `refactor-275-decode-rdf-representation` → A-side capture → carve along the
+datatype arms → verify + parity → HISTORY internal bullet → PR (references #275), CI, merge, pull.
+
+---
+
+### Task 5b: Refactor `provxml.py` `serialize_bundle` (CCN 39) — added 2026-07-26
+
+**Goal:** The PROV-XML serialization walk decomposed below CCN 15, behaviour-preserving. **The
+highest-risk task in this batch**: CCN 39 is the worst hotspot in the codebase, and PROV-XML
+serialization sits on the round-trip path the entire shared test matrix depends on.
+
+**Files:** `src/prov/serializers/provxml.py`; `HISTORY.rst`.
+
+**Acceptance Criteria:**
+- [ ] Lizard clean for `serialize_bundle` and its new helpers.
+- [ ] Pure moves only (same rule as Task 1 Step 2) — no reordering of element emission, since
+      PROV-XML element order is part of the serialized output.
+- [ ] Full suite green with unchanged counts on the default interpreter **and** on 3.10; plus
+      `test_xml.py` and `test_xml_schema.py` green (the vendored W3C XSD closure is the external
+      check that emitted documents stay schema-valid).
+- [ ] Parity capture (xml leg) **byte-identical** — this is the deliverable, not a formality.
+- [ ] mypy/ruff green; no public-surface change.
+
+**Verify:** `uv run pytest -q src/prov/tests/test_xml.py src/prov/tests/test_xml_schema.py && uv run pytest -q && uvx lizard -C 15 src/prov/serializers/provxml.py` → clean.
+
+**Steps:** branch `refactor-275-serialize-bundle` → A-side capture → read the whole function and
+carve along its emission phases (namespace/prefix setup, per-record element emission, formal vs
+extra attribute emission, nested-bundle recursion) → triple verify + byte-identical parity →
+HISTORY internal bullet → PR (references #275), CI, merge, pull.
+
+---
+
+### Task 6: #275 close-out — close the issue, spin off the deferred test-only work
+
+**Goal:** #275's disposition is recorded honestly: **every production hotspot is discharged** — two
+by #274 in batch 2b (`encode_container`/`decode_container`) and seven here (Tasks 1–5, 5a, 5b) —
+and the two remaining findings are **test-only** and explicitly deferred to a new backlog issue.
 
 **Files:** none (repo actions via `gh`).
 
 **Acceptance Criteria:**
-- [ ] `uvx lizard -C 15 src/prov/` output captured; every remaining ≥15 finding is either `_populate` or newly-introduced (if newly-introduced: file a follow-up issue naming the function, don't fix here).
-- [ ] A close-out comment on #275: per-item before/after CCN table (from the Task 1–5 PR bodies + #274), the `_populate` deferral with its rationale quoted from the issue ("test-only … readability-only value, safe to defer indefinitely"), and the follow-up disposition.
-- [ ] #275 then **either** closed with `_populate` spun off into a new labelled-backlog issue, **or** kept open, retitled to track only `_populate`, and moved out of the 3.0.0 milestone to the backlog label — maintainer's pick via AskUserQuestion (both honour the brief; which bookkeeping form is their call).
+- [ ] `uvx lizard -C 15 src/prov/` output captured. Expected remaining findings: exactly
+      `tests/strategies.py` `_populate` (32) and `tests/test_rdf.py` `find_diff` (17). Any *other*
+      remaining finding is newly introduced by this batch — file a follow-up issue naming the
+      function; don't fix it here.
+- [ ] A close-out comment on #275 carrying the per-item before/after CCN table drawn from the
+      Task 1–5/5a/5b PR bodies plus #274, and stating the deferral of the two test-only functions
+      with the rationale quoted from the issue itself ("test-only … readability-only value, safe to
+      defer indefinitely"). The comment must state plainly that `serialize_bundle` (39) and
+      `decode_rdf_representation` (19) were inside the issue's original nine but missing from its
+      ranked list, and were picked up here.
+- [ ] #275 **closed**, with a new labelled-backlog issue filed naming both deferred test-only
+      functions, their CCNs, and the note that `find_diff` regressed from 13 to 17 during batches
+      2a/2b/2c (maintainer decision, 2026-07-26 — see Step 0 validation outcome).
 - [ ] Milestone check: `gh issue list --milestone 3.0.0 --state open` → empty after this task.
 
-**Verify:** `gh issue list --milestone 3.0.0 --state open` → empty; the #275 comment visible.
+**Verify:** `gh issue list --milestone 3.0.0 --state open` → empty; the #275 close-out comment and
+the new backlog issue both visible.
 
-**Steps:** run the lizard sweep → draft the table → **(coordinator)** AskUserQuestion on close-vs-retitle → apply via `gh issue comment` / `gh issue edit` / `gh issue close`.
+**Steps:** run the lizard sweep → draft the table → file the backlog spin-off → apply via
+`gh issue comment` / `gh issue close`.
 
 ---
 
@@ -204,6 +326,36 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 **Verify:** Sphinx build + `uv run pytest -q` (+ pin-change evidence in the PR).
 
 **Steps:** branch `docs-3.0-deps-roadmap` → pin re-audit with captured command output → ROADMAP/CLAUDE edits → PR, CI, merge, pull.
+
+---
+
+### Task 9a: `/simplify` quality pass over the 3.0 diff — added 2026-07-26
+
+**Goal:** A quality pass over the code 3.0 actually changed, applied before the release is cut.
+Maintainer-requested; not part of the original plan.
+
+**Position is deliberate and load-bearing:** after Tasks 1–5/5a/5b so it is not fighting the
+refactors over the same functions, and strictly before Task 10 so anything it changes is covered by
+the version bump, the finalised `HISTORY.rst`, and the full interpreter-matrix pre-flight — never
+after.
+
+**Files:** whatever the pass touches across `src/prov/model/`, `src/prov/serializers/`,
+`src/prov/__init__.py`, `src/prov/dot.py`, `src/prov/graph.py`.
+
+**Acceptance Criteria:**
+- [ ] Scoped **per area**, not pointed at everything at once — the 2.x → 3.0 diff is very large.
+      Frame each area with `git diff <2.x-release-tag>..HEAD -- <path>`.
+- [ ] Quality only: reuse, simplification, efficiency, altitude. Bug-hunting is `/code-review`'s
+      job and the batches already did it.
+- [ ] Own branch and PR per area (not one mega-PR, and **not** folded into Task 10's release-prep
+      PR), each with green CI and a review gate before merge.
+- [ ] Behaviour preservation held as strictly as Tasks 1–5: suite tally unchanged, no
+      serialized-output change, `test_public_api.py` green.
+- [ ] Any simplification that would change public behaviour is **parked as a 3.1 item and said so
+      in the PR body** — release eve is not the time.
+
+**Verify:** per area — `uv run pytest -q` (tally unchanged), the parity capture diff-clean,
+`uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src`.
 
 ---
 
@@ -285,8 +437,8 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 
 ## Task dependencies
 
-- Tasks 1–5: sequential in the written order (shared checkout; each rebases on the prior merge). Order within the five follows #275's own value/risk ranking (add_attributes first as ranked item 1; valid_qualified_name deliberately *not* last-minute — it sits at 4 with the heaviest verification, before the routine Task 5).
-- Task 6 blocked by 1–5. Task 7 blocked by 6 (the sweep must see final source). Tasks 8–9 blocked by 7. Task 10 blocked by 8–9. Task 11 blocked by 10 (and the maintainer gate). Task 12 blocked by 11.
+- Tasks 1–5, 5a, 5b: sequential in the written order (shared checkout; each rebases on the prior merge). They touch disjoint source files but all touch `HISTORY.rst`, so they are serialized. Order within the first five follows #275's own value/risk ranking (add_attributes first as ranked item 1; valid_qualified_name deliberately *not* last-minute — it sits at 4 with the heaviest verification, before the routine Task 5). The two added refactors go last within the group, riskiest (5b, CCN 39) last of all.
+- Task 6 blocked by 1–5b. Task 7 blocked by 6 (the sweep must see final source). Tasks 8–9 blocked by 7. **Task 9a blocked by 9; Task 10 blocked by 9a** — the `/simplify` pass must land before the version bump and the interpreter-matrix pre-flight, never after. Task 11 blocked by 10 (and the maintainer gate). Task 12 blocked by 11.
 
 ## Self-review notes
 
@@ -294,3 +446,4 @@ uvx lizard -C 15 src/prov/ | tail -20   # confirm the Task 1–5 targets are sti
 - Everything batch-2/3-dependent is expressed as a derivation procedure (HISTORY-driven row audit, closed-issue-driven matrix flip, marker-inventory reconciliation, tally recording) — no guessed counts or wording anywhere in this plan.
 - The Python-3.10 question is resolved by the roadmap's own policy and recorded publicly in Task 9's ROADMAP edit: keep 3.10 for 3.0.0 (EOL 2026-10-31 postdates the release), drop in 3.1.0.
 - The publish gate is a task-level acceptance criterion, banner-marked, coordinator-only, with the AskUserQuestion placed before any externally-visible action — matching the 2.5.0 precedent exactly.
+- **Amended 2026-07-26 before execution** (see "Step 0 validation outcome"): Tasks 5a/5b added for the two production hotspots this plan and #275's ranked list both missed, Task 6 rewritten because its close-out narrative would otherwise have misstated the disposition on a public issue, Task 9a added for the maintainer-requested `/simplify` pass, and Tasks 7–9 narrowed against work batch 3 had already done. The "derive it at execution time" discipline in the Architecture note is what surfaced all four.


### PR DESCRIPTION
Validating the close-out plan against master before executing it surfaced four things it could not have known when it was written — it was drafted immediately after batch 1, before batches 2a, 2b, 2c and 3 landed.

## Two production hotspots nothing covered

`uvx lizard -C 15 src/prov/` reports nine warnings on master. The plan's refactor tasks discharge five. Two of the remaining four are production code that appears in neither the plan nor the ranked list in #275:

| function | CCN | status before this amendment |
|---|---|---|
| `provxml.py` `serialize_bundle` | 39 | uncovered — worst hotspot in the codebase |
| `provrdf.py` `decode_rdf_representation` | 19 | uncovered — never inside #274's scope |

Both sit inside the nine findings #275's scope sentence claims to track; neither made its ranked list. They are added as Tasks 5a and 5b.

## The close-out narrative was wrong

Task 6 would have posted a comment on #275 stating that four of five production hotspots were discharged here and the rest by #274. That understates two live production functions and one deferred test-only one, on a public tracking issue. Its own verification step (milestone empty) would still have passed, so nothing downstream would have caught it. Task 6 is rewritten against what is actually true.

## Also in this amendment

- Task 9a adds the requested quality pass over the 3.0 diff, positioned after the refactors so it does not fight them over the same functions, and before release prep so anything it changes is covered by the version bump, the finalised changelog and the interpreter-matrix pre-flight.
- Tasks 7, 8 and 9 are narrowed against work batch 3 already did — no redoing the roadmap's unification bullet, the unification explanation page, or the conformance matrix's future-tense corrections.
- `prov.read()`'s complexity is corrected from the 20 quoted in both the plan and #275 to its measured 22.

The marker inventory came back clean: all 24 skips cite out-of-scope reasons and none cites an issue that batches 2 or 3 fixed.

Planning document only — no source, test or shipped-doc changes.