### PR TITLE
Split ProvRecord.add_attributes into coercion and storage helpers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -157,6 +157,8 @@ History
   document's registered namespaces (or splits at the last ``#``/``/`` when the
   namespace is unknown) rather than relying on rdflib's ``compute_qname``,
   which refuses such splits. Encode output is unchanged (#294)
+* Internal: refactored ProvRecord.add_attributes below the complexity
+  threshold with byte-identical behaviour (#275)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -783,6 +783,86 @@ class ProvRecord:
         # No conversion possible, return the original value
         return literal
 
+    def _coerce_attribute_value(
+        self, attr: QualifiedName, original_value: Any
+    ) -> QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes:
+        # Normalise `original_value` to the datatype expected for `attr`.
+        #
+        # Raises:
+        #     ProvException: If the value is invalid for `attr`.
+
+        # the branches below bind `value` to different types
+        value: QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes
+
+        if attr in PROV_ATTRIBUTE_QNAMES:
+            # Expecting a qualified name
+            if isinstance(original_value, ProvRecord):
+                # Use the identifier of the record, which must exist, as the value for this attribute
+                qname = original_value.identifier
+                if qname is None:
+                    raise ProvException(
+                        f"Invalid value for attribute {attr}: {original_value}."
+                        f" The record has no identifier."
+                    )
+            else:
+                qname = original_value
+            value = self._bundle.mandatory_valid_qname(qname)
+        elif attr in PROV_ATTRIBUTE_LITERALS:
+            # Expecting a datetime object or a string that can be parsed as a datetime
+            if isinstance(original_value, str):
+                value = parse_xsd_datetime(original_value)
+            else:
+                value = original_value
+            if not isinstance(value, datetime.datetime):
+                raise ProvException(
+                    f"Invalid value for attribute {attr}: {original_value}. "
+                    f"Expected a datetime object or a string that can be parsed"
+                    f" as a datetime."
+                )
+        else:
+            value = self._auto_literal_conversion(original_value)
+
+        if value is None:
+            raise ProvException(f"Invalid value for attribute {attr}: {original_value}")
+
+        return value
+
+    def _store_attribute_value(
+        self,
+        attr: QualifiedName,
+        value: QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes,
+        is_collection: bool,
+    ) -> None:
+        # Add `value` for `attr`, enforcing single-valued (non-collection)
+        # attributes have at most one (distinct) value.
+        #
+        # Raises:
+        #     ProvException: If a second, different value is supplied for a
+        #         single-valued (non-collection) attribute.
+        if not is_collection and attr in PROV_ATTRIBUTES and self._attributes[attr]:
+            existing_value = first(self._attributes[attr])
+            is_not_same_value = True
+            # This duplicate-value branch runs at scale in
+            # _unified_records()'s merge loop (unified()/flattened() on
+            # large documents), where contextlib.suppress()'s per-call
+            # context-manager overhead adds up — the plain try/except
+            # stays here.
+            try:  # noqa: SIM105
+                is_not_same_value = value != existing_value
+            except TypeError:
+                # Cannot compare them
+                pass  # consider them different values
+
+            if is_not_same_value:
+                raise ProvException(
+                    f"Cannot have more than one value for attribute {attr}"
+                )
+            else:
+                # Same value, ignore it
+                return
+
+        self._attributes[attr].add(value)
+
     def add_attributes(self, attributes: RecordAttributesArg) -> None:
         """Add attributes to the record.
 
@@ -822,74 +902,9 @@ class ProvRecord:
                 # make sure the attribute name is valid
                 attr = self._bundle.mandatory_valid_qname(attr_name)
 
-                # the branches below bind `value` to different types
-                value: (
-                    QualifiedName
-                    | datetime.datetime
-                    | Literal
-                    | SupportedXSDParsedTypes
-                )
+                value = self._coerce_attribute_value(attr, original_value)
 
-                if attr in PROV_ATTRIBUTE_QNAMES:
-                    # Expecting a qualified name
-                    if isinstance(original_value, ProvRecord):
-                        # Use the identifier of the record, which must exist, as the value for this attribute
-                        qname = original_value.identifier
-                        if qname is None:
-                            raise ProvException(
-                                f"Invalid value for attribute {attr}: {original_value}."
-                                f" The record has no identifier."
-                            )
-                    else:
-                        qname = original_value
-                    value = self._bundle.mandatory_valid_qname(qname)
-                elif attr in PROV_ATTRIBUTE_LITERALS:
-                    # Expecting a datetime object or a string that can be parsed as a datetime
-                    if isinstance(original_value, str):
-                        value = parse_xsd_datetime(original_value)
-                    else:
-                        value = original_value
-                    if not isinstance(value, datetime.datetime):
-                        raise ProvException(
-                            f"Invalid value for attribute {attr}: {original_value}. "
-                            f"Expected a datetime object or a string that can be parsed"
-                            f" as a datetime."
-                        )
-                else:
-                    value = self._auto_literal_conversion(original_value)
-
-                if value is None:
-                    raise ProvException(
-                        f"Invalid value for attribute {attr}: {original_value}"
-                    )
-
-                if (
-                    not is_collection
-                    and attr in PROV_ATTRIBUTES
-                    and self._attributes[attr]
-                ):
-                    existing_value = first(self._attributes[attr])
-                    is_not_same_value = True
-                    # This duplicate-value branch runs at scale in
-                    # _unified_records()'s merge loop (unified()/flattened() on
-                    # large documents), where contextlib.suppress()'s per-call
-                    # context-manager overhead adds up — the plain try/except
-                    # stays here.
-                    try:  # noqa: SIM105
-                        is_not_same_value = value != existing_value
-                    except TypeError:
-                        # Cannot compare them
-                        pass  # consider them different values
-
-                    if is_not_same_value:
-                        raise ProvException(
-                            f"Cannot have more than one value for attribute {attr}"
-                        )
-                    else:
-                        # Same value, ignore it
-                        continue
-
-                self._attributes[attr].add(value)
+                self._store_attribute_value(attr, value, is_collection)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ProvRecord):


### PR DESCRIPTION
## Summary

`ProvRecord.add_attributes` had grown into a cyclomatic-complexity-18 loop body that resolved attribute names, coerced values to their expected datatype, and enforced single-valued-attribute cardinality all in one place. This splits it into two intent-named private helpers, both pure extractions with no logic changes: `_coerce_attribute_value` (qname/datetime/literal coercion) and `_store_attribute_value` (duplicate-value cardinality check and insertion). `add_attributes` keeps its exact public signature and docstring and now just orchestrates the two helpers.

Related to #275 (cyclomatic-complexity hotspot tracking issue; not closing it here — that happens once all seven refactors in the batch land).

Lizard (`-C 15`), before/after:

| function | before CCN | after CCN |
|---|---|---|
| `add_attributes` | 18 | 6 |
| `_coerce_attribute_value` | — | 8 |
| `_store_attribute_value` | — | 6 |

No warnings remain in `src/prov/model/records.py`.

## Parity evidence

Captured serialized output (json/xml/rdf/provn, plus dot) of all 8 canonical example documents before and after the refactor using the batch's parity harness:

```
diff -ru /tmp/parity-A /tmp/parity-B
```

Output: empty (byte-identical).

## Test plan

- [x] `uv run pytest -q` → 1390 passed, 24 skipped (unchanged from master baseline)
- [x] `uv run pytest -q src/prov/tests/test_property_roundtrip.py` (Hypothesis) → 3 passed
- [x] `uv run ruff check src/` → clean
- [x] `uv run ruff format --check src/` → clean
- [x] `uv run mypy src` → clean
- [x] `uvx lizard -C 15 src/prov/model/records.py` → no warnings
- [x] A/B serialization parity diff → empty