### PR TITLE
Split prov.read() into source-resolution, stream-rewind, and format-detection helpers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -159,6 +159,8 @@ History
   which refuses such splits. Encode output is unchanged (#294)
 * Internal: refactored ProvRecord.add_attributes below the complexity
   threshold with byte-identical behaviour (#275)
+* Internal: refactored ``prov.read()`` below the complexity threshold with
+  byte-identical behaviour (#275)
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import warnings
+from collections.abc import Iterable
 from typing import IO, TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -18,6 +19,123 @@ __all__ = ["Error", "model", "read"]
 
 class Error(Exception):
     """Base class for all errors in this package."""
+
+
+def _resolve_source(
+    source: io.IOBase | IO[Any] | str | bytes | os.PathLike[str],
+) -> tuple[
+    io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None, str | bytes | None
+]:
+    """Split ``source`` into a ``(src, content)`` pair for deserialization.
+
+    A ``str``/``bytes`` source naming an existing file stays as ``src`` (a
+    path); any other ``str``/``bytes`` is returned as raw ``content``
+    instead, with ``src`` set to ``None``.
+    """
+    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None = source
+    content: str | bytes | None = None
+    if isinstance(src, (str, bytes)) and not os.path.isfile(src):
+        # Not a path to an existing file: treat the string itself as raw
+        # document content.
+        content, src = src, None
+    return src, content
+
+
+def _prepare_stream(
+    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None,
+) -> tuple[IO[Any] | None, int | None]:
+    """Identify a seekable stream in ``src`` and capture its start position.
+
+    A stream source (as opposed to a path) is duck-typed on read(),
+    matching ``ProvBundle.deserialize()``'s own convention (#240). Only a
+    seekable stream can be rewound between auto-detect attempts below; if
+    the stream's own ``seekable()``/``tell()`` misbehave, degrade
+    gracefully to the non-seekable behaviour (first candidate consumes the
+    stream) rather than failing before any deserializer gets a chance.
+    """
+    stream: IO[Any] | None = (
+        cast(IO[Any], src) if src is not None and hasattr(src, "read") else None
+    )
+    start_pos: int | None = None
+    if stream is not None and hasattr(stream, "seekable"):
+        try:
+            if stream.seekable():
+                start_pos = stream.tell()
+        except Exception:
+            start_pos = None
+    return stream, start_pos
+
+
+def _detect_and_parse(
+    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None,
+    content: str | bytes | None,
+    serializers: Iterable[str],
+    document_cls: type[ProvDocument],
+) -> ProvDocument:
+    """Try each registered format in turn, returning the first non-empty parse.
+
+    Raises:
+        TypeError: If no registered serializer produced a non-empty
+            document from ``src``/``content``.
+    """
+    stream, start_pos = _prepare_stream(src)
+
+    # Failed-candidate diagnostics (e.g. rdflib's "does not look like a
+    # valid URI" logger warnings) are noise by definition here: every
+    # candidate's exception is swallowed below, so nothing about a failed
+    # attempt is ever surfaced to the caller anyway. Raise rdflib's logger
+    # level for the duration of auto-detection only -- the explicit-format
+    # path in read() is unaffected and still shows real diagnostics. Note
+    # this mutation is process-global and not thread-safe: two concurrent
+    # auto-detecting read() calls can race on the level, but the impact is
+    # bounded to transient log noise, so a Filter/thread-local would be
+    # more machinery than warranted.
+    rdflib_term_logger = logging.getLogger("rdflib.term")
+    previous_level = rdflib_term_logger.level
+    rdflib_term_logger.setLevel(logging.ERROR)
+    try:
+        for format in serializers:
+            if start_pos is not None:
+                # start_pos is only ever set (above) when stream is not None.
+                if stream is None:  # pragma: no cover
+                    raise AssertionError("stream is None but start_pos is set")
+                try:
+                    stream.seek(start_pos)
+                except Exception:
+                    # A seek that fails mid-loop degrades to no-rewind for
+                    # the remaining attempts rather than aborting detection.
+                    start_pos = None
+            try:
+                document = document_cls.deserialize(
+                    source=src, content=content, format=format
+                )
+            except Exception:
+                # Any failure from a candidate deserializer means "not this
+                # format" -- move on to the next candidate.
+                continue
+            if document.get_records() or document.has_bundles():
+                return document
+            # A parse producing a completely empty document (e.g. rdflib
+            # accepts empty input, or the xml deserializer walking a
+            # childless foreign root) is treated as not detected. Registered
+            # namespaces are deliberately not consulted: the rdf deserializer
+            # always copies rdflib's own default-bound namespace prefixes onto
+            # the document on every successful parse, so that signal is always
+            # truthy and would defeat this check for the rdf format.
+    finally:
+        rdflib_term_logger.setLevel(previous_level)
+
+    message = (
+        "Could not read from the source. To get a proper "
+        "error message, specify the format with the 'format' "
+        "parameter."
+    )
+    if content is not None:
+        message += (
+            " Note: the source is not a path to an existing file and was "
+            "parsed as raw content."
+        )
+    raise TypeError(message)
 
 
 def read(
@@ -68,12 +186,7 @@ def read(
         raise AssertionError("Registry.serializers is not populated")
     serializers = Registry.serializers.keys()
 
-    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None = source
-    content: str | bytes | None = None
-    if isinstance(src, (str, bytes)) and not os.path.isfile(src):
-        # Not a path to an existing file: treat the string itself as raw
-        # document content.
-        content, src = src, None
+    src, content = _resolve_source(source)
 
     if format:
         try:
@@ -91,76 +204,4 @@ def read(
                 )
             raise
 
-    # A stream source (as opposed to a path) is duck-typed on read(),
-    # matching ProvBundle.deserialize()'s own convention (#240). Only a
-    # seekable stream can be rewound between auto-detect attempts below;
-    # if the stream's own seekable()/tell() misbehave, degrade gracefully
-    # to the non-seekable behaviour (first candidate consumes the stream)
-    # rather than failing before any deserializer gets a chance.
-    stream: IO[Any] | None = (
-        cast(IO[Any], src) if src is not None and hasattr(src, "read") else None
-    )
-    start_pos: int | None = None
-    if stream is not None and hasattr(stream, "seekable"):
-        try:
-            if stream.seekable():
-                start_pos = stream.tell()
-        except Exception:
-            start_pos = None
-
-    # Failed-candidate diagnostics (e.g. rdflib's "does not look like a
-    # valid URI" logger warnings) are noise by definition here: every
-    # candidate's exception is swallowed below, so nothing about a failed
-    # attempt is ever surfaced to the caller anyway. Raise rdflib's logger
-    # level for the duration of auto-detection only -- the explicit-format
-    # path above is unaffected and still shows real diagnostics. Note this
-    # mutation is process-global and not thread-safe: two concurrent
-    # auto-detecting read() calls can race on the level, but the impact is
-    # bounded to transient log noise, so a Filter/thread-local would be
-    # more machinery than warranted.
-    rdflib_term_logger = logging.getLogger("rdflib.term")
-    previous_level = rdflib_term_logger.level
-    rdflib_term_logger.setLevel(logging.ERROR)
-    try:
-        for format in serializers:
-            if start_pos is not None:
-                # start_pos is only ever set (above) when stream is not None.
-                if stream is None:  # pragma: no cover
-                    raise AssertionError("stream is None but start_pos is set")
-                try:
-                    stream.seek(start_pos)
-                except Exception:
-                    # A seek that fails mid-loop degrades to no-rewind for
-                    # the remaining attempts rather than aborting detection.
-                    start_pos = None
-            try:
-                document = ProvDocument.deserialize(
-                    source=src, content=content, format=format
-                )
-            except Exception:
-                # Any failure from a candidate deserializer means "not this
-                # format" -- move on to the next candidate.
-                continue
-            if document.get_records() or document.has_bundles():
-                return document
-            # A parse producing a completely empty document (e.g. rdflib
-            # accepts empty input, or the xml deserializer walking a
-            # childless foreign root) is treated as not detected. Registered
-            # namespaces are deliberately not consulted: the rdf deserializer
-            # always copies rdflib's own default-bound namespace prefixes onto
-            # the document on every successful parse, so that signal is always
-            # truthy and would defeat this check for the rdf format.
-    finally:
-        rdflib_term_logger.setLevel(previous_level)
-
-    message = (
-        "Could not read from the source. To get a proper "
-        "error message, specify the format with the 'format' "
-        "parameter."
-    )
-    if content is not None:
-        message += (
-            " Note: the source is not a path to an existing file and was "
-            "parsed as raw content."
-        )
-    raise TypeError(message)
+    return _detect_and_parse(src, content, serializers, ProvDocument)


### PR DESCRIPTION
## Summary

`read()` in `src/prov/__init__.py` measured cyclomatic complexity 22 (one of the hotspots tracked by #275). This decomposes it into three module-level helpers, derived from the seams already present in the function body, with no behaviour change:

- `_resolve_source(source)` -- classifies `source` as a path vs. raw string/bytes content
- `_prepare_stream(src)` -- identifies a seekable stream and captures its rewind position
- `_detect_and_parse(src, content, serializers, document_cls)` -- the per-format try loop, including the rdflib logger suppression and the `TypeError` raised when no candidate matches

`read()` keeps its exact public signature and docstring, and the explicit-`format=` branch (including its `warnings.warn` call and `stacklevel=2`) is untouched in place, since moving it would have shifted which frame the warning attributes to.

Lizard: `read()` 22 -> 5, plus `_detect_and_parse` 10, `_prepare_stream` 7, `_resolve_source` 1 -- all under the threshold of 15.

## Verification

- `uv run pytest -q src/prov/tests/test_read.py` -- 28 passed, unchanged (pins all three #239 behaviours: auto-detection, raw-content input, empty-input `TypeError`)
- `uv run pytest -q` -- 1390 passed, 24 skipped, identical to master's baseline
- `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src` -- all clean
- Parity capture (`.superpowers/sdd/2026-07-19-3.0-batch4-closeout-release/parity_capture.py`) over all 8 canonical examples in json/xml/rdf/provn/dot -- byte-identical before/after
- The all-deserializers-fail `TypeError` path was checked directly against master: same message, `__cause__ is None`, `__context__ is None`, `__suppress_context__ is False`, both for the empty-input case and for the mocked-all-candidates-raise case

Refers to #275.

## Test plan

- [x] `uv run pytest -q src/prov/tests/test_read.py`
- [x] `uv run pytest -q` (full suite)
- [x] `uv run ruff check src/` / `uv run ruff format --check src/`
- [x] `uv run mypy src`
- [x] `uvx lizard -C 15 src/prov/__init__.py`
- [x] parity capture diff