### PR TITLE
Specify the 3.0.0 changelog restructure and a composite-type sweep

### DIFF
--- a/docs/superpowers/plans/2026-07-19-3.0-batch4-closeout-release.md
+++ b/docs/superpowers/plans/2026-07-19-3.0-batch4-closeout-release.md
@@ -353,9 +353,46 @@ after.
       serialized-output change, `test_public_api.py` green.
 - [ ] Any simplification that would change public behaviour is **parked as a 3.1 item and said so
       in the PR body** — release eve is not the time.
+- [ ] **Composite types** — the named sweep below is carried out and its findings reported, whether
+      or not they lead to changes.
 
 **Verify:** per area — `uv run pytest -q` (tally unchanged), the parity capture diff-clean,
 `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src`.
+
+#### Composite types (maintainer-requested, 2026-07-26)
+
+As part of this pass, look for places where introducing a composite type would (1) replace a long
+type union in a function signature and (2) make the expected type *and its role* clearer to a
+reader. The test is **reduced cognitive load**, not alias count — a name that merely restates the
+union (`StrOrInt`) buys nothing; a name that says what the value *is for* (`EntityRef`) buys a lot.
+
+The codebase already has this vocabulary and it works well — `src/prov/model/records.py:89-102`
+defines `QualifiedNameCandidate`, `OptionalID`, `EntityRef`, `ActivityRef`, `AgentRef`, `UsageRef`,
+`NameValuePair`, `DatetimeOrStr`, `NSCollection`, `PathLike`, all re-exported from `prov.model`.
+So this is **extending an established pattern, not introducing one**. Match its spelling exactly,
+including the `# type: typing.TypeAlias` comment convention.
+
+Where to look, and what to respect:
+
+- Signatures carrying repeated inline unions that an existing alias already names — those are pure
+  wins, apply them.
+- Serializer and namespace-manager internals, which the existing aliases barely reach; these are
+  the likeliest source of genuine new aliases.
+- **An alias is only worth adding if it appears in more than one signature, or if a single
+  signature is genuinely unreadable without it.** A one-use alias usually just adds indirection.
+- **Do not change what any signature accepts or returns.** Aliases are names for existing types.
+  If defining the alias tempts you to widen or narrow a parameter, that is a behaviour change —
+  park it as a 3.1 item.
+- Every new alias must be reachable by `uv run mypy src` cleanly and must not alter the public
+  surface `test_public_api.py` guards. New aliases in `records.py` are only public if
+  `prov/model/__init__.py` re-exports them — decide deliberately which, and default to private.
+
+**One known finding to surface, not to fix unilaterally:** `GenrationRef` (`records.py:94`) is a
+misspelling of `GenerationRef`, and it is *deliberately re-exported* as public API from
+`prov/model/__init__.py:48` (`GenrationRef as GenrationRef`), used across `records.py` and
+`bundle.py`. Renaming it is therefore a public API change — permissible only in this release, and
+only as a maintainer decision. **Report it with the options (rename; rename with the old name kept
+as a deprecated alias; leave it) and ask; do not rename on your own initiative.**
 
 ---
 
@@ -365,7 +402,7 @@ after.
 
 **Files:**
 - Modify: `src/prov/__init__.py:14` (`"3.0.0.dev0"` → `"3.0.0"`)
-- Modify: `HISTORY.rst` (`3.0.0 (unreleased)` → `3.0.0 (YYYY-MM-DD)` with the actual date; bullets reordered: BREAKING first, then behaviour fixes by area, then internal — derive the final list from what Tasks/batches actually merged, checking every batch-2/3 PR appears)
+- Modify: `HISTORY.rst` (`3.0.0 (unreleased)` → `3.0.0 (YYYY-MM-DD)` with the actual date, **and restructured into labelled subsections — see "Changelog structure" below**; derive the final list from what the batches actually merged, checking every PR appears)
 - Modify: `ROADMAP.md` only if Task 9 left anything inconsistent
 
 **Acceptance Criteria:**
@@ -379,6 +416,59 @@ after.
 **Verify:** the matrix loop + `uv build && uvx twine check dist/*` → all green.
 
 **Steps:** branch `release-3.0.0` → edits → preflight battery (fix-forward anything red before merging; a red interpreter here is a release blocker, not a deviation) → commit `Prepare release 3.0.0` → PR (no `Fixes` footer), CI, merge, pull.
+
+#### Changelog structure (maintainer-requested, 2026-07-26)
+
+The 3.0.0 section accumulated **31 flat bullets** across batches 1–4, in merge order rather than
+importance order. At that length a flat list buries the four `BREAKING:` items among PROV-O
+round-trip minutiae, and a reader cannot tell what matters. Restructure it into labelled
+subsections, in this order:
+
+```rst
+3.0.0 (YYYY-MM-DD)
+^^^^^^^^^^^^^^^^^^
+
+<one short orientation paragraph: what this release is — the compatibility release, the
+conformance work behind it — and a pointer to docs/upgrading-3.0.md>
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Conformance and correctness fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Improvements
+~~~~~~~~~~~~
+
+Internal
+~~~~~~~~
+```
+
+Rules for the restructure:
+
+- **`~` is the correct underline character**: `HISTORY.rst` currently uses only `-` (title) and
+  `^` (version headers), so `~` is a free level. Confirm with the Sphinx build — `docs/history.rst`
+  is a bare `.. include:: ../HISTORY.rst`, so a malformed hierarchy shows up as a build warning.
+- **Only the 3.0.0 section is restructured.** Older sections stay flat: they are shipped history,
+  and reorganising them adds churn and rewrites what users already read.
+- **Breaking changes first, and complete.** All four current `BREAKING:` bullets belong here —
+  plus the type-aware attribute-storage change, which is behaviour-breaking in practice (accessor
+  write-through is gone) despite not carrying the label today. Once the section is named
+  "Breaking changes" the inline `BREAKING:` prefix on each bullet is redundant — drop it.
+- **Conformance and correctness fixes** groups the serializer and model fixes. There are enough to
+  warrant ordering *within* the subsection by format — model/datatype first, then PROV-XML,
+  PROV-JSON, PROV-O (RDF), PROV-N — rather than another 20-item flat run.
+- **Improvements** takes non-breaking betterments that are not bug fixes: the PROV-XML DTD/entity
+  security hardening, namespace-prefix binding in RDF output, diagnostic improvements.
+- **Internal** takes anything with no user-visible effect: the complexity refactors from this
+  batch and #274, the test-infrastructure changes, the `/simplify` pass's outcome.
+- **No "What's new" section** unless a genuinely additive, non-breaking feature lands before the
+  cut. 3.0.0 is a compatibility-and-conformance release; the one arguably-new public name
+  (`ProvUnificationError`) is inseparable from the breaking `unified()` rework and belongs with it.
+  An almost-empty "What's new" would mislead more than it helps.
+- Every issue number keeps its existing bullet — this is a **regrouping and rewording pass, not a
+  content cut**. The Task 10 acceptance criterion still stands: every milestone issue number
+  appears exactly once, cross-checked against `gh issue list --milestone 3.0.0 --state closed`.
 
 ---
 


### PR DESCRIPTION
Two additions to the close-out plan, both requested during execution.

## Changelog structure

The `3.0.0 (unreleased)` section is now **31 flat bullets** accumulated in merge order across batches 1-4. At that length the four `BREAKING:` items sit interleaved with PROV-O round-trip minutiae, and there is no way for a reader to tell significance apart from detail.

Release prep will restructure it into:

```
<orientation paragraph>
Breaking changes
Conformance and correctness fixes   (ordered within by format: model, PROV-XML, PROV-JSON, PROV-O, PROV-N)
Improvements
Internal
```

Decisions recorded in the plan so they are not re-litigated: `~` is the free underline level (the file uses only `-` and `^`); only the 3.0.0 section is restructured, since older sections are shipped history; the inline `BREAKING:` prefixes drop once the section names them; the type-aware attribute-storage change joins the breaking list, where it belongs in practice; and there is deliberately **no "What's new" section**, because this is a compatibility-and-conformance release and the one arguably-new public name is inseparable from the breaking change it accompanies. It is a regrouping and rewording pass — no bullet is cut, and the existing cross-check that every milestone issue appears exactly once still applies.

## Composite types in the quality pass

The quality pass gains an explicit sweep for composite types replacing long inline unions in signatures, where the name clarifies the value's *role* and not just its shape.

This extends an established pattern rather than introducing one: `records.py:89-102` already defines `QualifiedNameCandidate`, `EntityRef`, `ActivityRef`, `AgentRef`, `NSCollection` and others, all re-exported from `prov.model`. The plan sets a deliberately high bar — an alias earns its place by appearing in more than one signature, or by making a single genuinely unreadable signature clear — and forbids the pass from widening or narrowing any parameter while naming its type.

One finding is recorded to be **surfaced, not fixed**: `GenrationRef` is a misspelling of `GenerationRef` that is deliberately re-exported as public API (`prov/model/__init__.py:48`). Correcting it is a public API change that only this release may make, so the pass must present the options and ask rather than rename on its own initiative.

Planning document only — no source, test or shipped-doc changes.