### PR TITLE
Finalise the 3.0 upgrading guide and refresh the conformance matrix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,6 +62,12 @@ History
   PROV-O representational limitation — they serialize but do not round-trip
   through RDF, and deserializing such RDF now raises an error naming the
   limitation; all other formats are unaffected (#217)
+* PROV-O: a related gap is recorded, not fixed — an attribute key whose
+  local part ends in a #223 metacharacter can fail to round-trip through
+  RDF when another qualified name in the same document carries that same
+  character mid-string; the round-trip property test excludes this shape
+  at generation time so it does not mask other findings, and
+  ``docs/reference/conformance.md`` documents it as an open defect (#341)
 * The PROV-JSON deserializer raises ``ProvJSONException`` on structurally
   malformed input instead of leaking raw ``KeyError``/``AttributeError``
   (#228)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,10 +64,11 @@ History
   limitation; all other formats are unaffected (#217)
 * PROV-O: a related gap is recorded, not fixed — an attribute key whose
   local part ends in a #223 metacharacter can fail to round-trip through
-  RDF when another qualified name in the same document carries that same
-  character mid-string; the round-trip property test excludes this shape
-  at generation time so it does not mask other findings, and
-  ``docs/reference/conformance.md`` documents it as an open defect (#341)
+  RDF when its namespace has not already been registered by decoding some
+  other, cleanly-splitting qualified name under it; the round-trip
+  property test excludes this shape at generation time so it does not
+  mask other findings, and ``docs/reference/conformance.md`` documents it
+  as an open defect (#341)
 * The PROV-JSON deserializer raises ``ProvJSONException`` on structurally
   malformed input instead of leaking raw ``KeyError``/``AttributeError``
   (#228)

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -73,25 +73,35 @@ More caveats apply across many rows rather than to one:
   [#341](https://github.com/trungdong/prov/issues/341), a sibling of the #217 limitation above
   but **not** a decided/closed matter — it is a known defect, unfixed in 3.0): a qualified name
   used as an **attribute key** whose local part *ends* in one of the seven characters `=` `'`
-  `,` `:` `;` `[` `]` does not survive the PROV-O round trip *when* the same document also
-  contains any other qualified name — an identifier, another attribute key, or a QualifiedName
-  attribute *value* — carrying that same character *mid-string*. Of the nine #223 PROV-N
-  metacharacters, only `(` and `)` are unaffected in every position; the other seven all trigger
-  this in the trailing position. Neither half fails alone: the mid-string occurrence makes
-  rdflib's `compute_qname()` silently mis-split, e.g., `http://example.org/e:0` into namespace
-  `http://example.org/e:` plus local part `0` rather than raising, so the true namespace is
-  never registered from that identifier's decoding. Identifier decoding tolerates this via a
-  fallback (`_resolve_iri`, `src/prov/serializers/provrdf.py:536`), but attribute-key decoding
-  does not (`_decode_attribute_triple` → `mandatory_valid_qname`,
-  `src/prov/serializers/provrdf.py:1573`), so a key ending in one of the seven characters is
-  rejected once some other qualified name in the same document has already narrowed the
-  namespace pool. Qualified names used as attribute values are unaffected either way. As with
-  #217, PROV-N escapes these characters and PROV-JSON/PROV-XML both round-trip them — PROV-O is
-  the odd one out. #341's title names only the colon instance; the surface described here is
-  broader. Excluded from the Hypothesis round-trip property test at generation time
-  (`src/prov/tests/strategies.py`) so it does not mask other findings, but — unlike #217 and
-  #248 above — this is not a maintainer decision to leave as a permanent limitation; it remains
-  open for a future fix.
+  `,` `:` `;` `[` `]` can fail to survive the PROV-O round trip. An IRI ending in one of these
+  characters makes rdflib's `compute_qname()` raise, since nothing follows the character to
+  serve as a local part; decoding an *identifier* tolerates this via a fallback split in
+  `ProvRDFSerializer._resolve_iri`, but decoding an *attribute key* has no equivalent fallback —
+  it can only resolve such an IRI if that key's namespace is **already registered** by the time
+  the key is decoded, which happens only when some *other* qualified name under the same
+  namespace has already been decoded from an IRI that splits cleanly. A qualified name whose own
+  local part carries the character *mid-string* (e.g. `http://example.org/e:0`) does not help
+  register the namespace — `compute_qname()` silently mis-splits it into an over-narrow namespace
+  (`http://example.org/e:`) instead of raising — but it does no active harm either: a clean
+  sibling elsewhere in the same namespace still rescues the key regardless of whether a
+  mid-string occurrence is also present. So the failure condition is registration-based: an
+  attribute key whose local part ends in one of these seven characters, in a namespace that no
+  cleanly-splitting qualified name has registered by the time the key is decoded — a mid-string
+  occurrence of the character elsewhere is neither necessary nor sufficient for the failure. The
+  unguarded call lives in `ProvRecord.add_attributes`
+  (`src/prov/model/records.py`), reached while emitting decoded records in
+  `ProvRDFSerializer._emit_decoded_records` (`src/prov/serializers/provrdf.py`), with the raise
+  itself coming from `mandatory_valid_qname` (`src/prov/model/bundle.py`). Of the nine #223
+  PROV-N metacharacters, only `(` and `)` are unaffected in every position. Qualified names used
+  as attribute *values* are unaffected. As with #217, PROV-N escapes these characters and
+  PROV-JSON/PROV-XML both round-trip them — PROV-O is the odd one out. #341's title names only
+  the colon instance; the surface described here is broader. The round-trip property test
+  excludes attribute keys ending in one of these seven characters at generation time
+  (`src/prov/tests/strategies.py`) so it does not mask other findings — slightly more
+  conservative than the true rule, since such a key is actually safe whenever its namespace
+  happens to already be registered, but the generator cannot guarantee that in general. Unlike
+  #217 and #248 above, this is not a maintainer decision to leave as a permanent limitation; it
+  remains open for a future fix.
 
 The value-typing and literal-semantics gaps the audit recorded here — #77, #89, #168, #218,
 #223, #225, #235, #238, #244, #246, #249, #251, #256, #259 — were fixed in 3.0; see

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -3,8 +3,9 @@
 This page tracks how each PROV-DM concept maps onto `prov`'s classes and factory methods, and
 how well each serializer round-trips it. It is the audit artefact for Phase 3.5 of the
 [modernisation roadmap](https://github.com/trungdong/prov/blob/master/ROADMAP.md) (roadmap step
-28) and is **revisited at every release** as behaviour changes; a JSON-LD column is planned for
-3.1.0 once the PROV-JSONLD serializer lands. For prose background on PROV-DM's six components and
+28) and is **revisited at every release** as behaviour changes — last revised for the 3.0.0
+release (2026-07-26). A JSON-LD column is planned for 3.1.0 once the PROV-JSONLD serializer
+lands. For prose background on PROV-DM's six components and
 how they group in `prov.model`, see {doc}`../explanation/prov-dm`; this page is the detailed,
 verified-against-source reference underneath that explanation.
 
@@ -68,6 +69,29 @@ More caveats apply across many rows rather than to one:
   third-party XML document containing a literal `_xHHHH_`-shaped attribute name will be
   unescaped on read, since the convention cannot distinguish an intentional escape sequence
   from one that merely looks like one.
+- **PROV-O attribute-key metacharacter/namespace defect** (RDF, open — tracked as
+  [#341](https://github.com/trungdong/prov/issues/341), a sibling of the #217 limitation above
+  but **not** a decided/closed matter — it is a known defect, unfixed in 3.0): a qualified name
+  used as an **attribute key** whose local part *ends* in one of the seven characters `=` `'`
+  `,` `:` `;` `[` `]` does not survive the PROV-O round trip *when* the same document also
+  contains any other qualified name — an identifier, another attribute key, or a QualifiedName
+  attribute *value* — carrying that same character *mid-string*. Of the nine #223 PROV-N
+  metacharacters, only `(` and `)` are unaffected in every position; the other seven all trigger
+  this in the trailing position. Neither half fails alone: the mid-string occurrence makes
+  rdflib's `compute_qname()` silently mis-split, e.g., `http://example.org/e:0` into namespace
+  `http://example.org/e:` plus local part `0` rather than raising, so the true namespace is
+  never registered from that identifier's decoding. Identifier decoding tolerates this via a
+  fallback (`_resolve_iri`, `src/prov/serializers/provrdf.py:536`), but attribute-key decoding
+  does not (`_decode_attribute_triple` → `mandatory_valid_qname`,
+  `src/prov/serializers/provrdf.py:1573`), so a key ending in one of the seven characters is
+  rejected once some other qualified name in the same document has already narrowed the
+  namespace pool. Qualified names used as attribute values are unaffected either way. As with
+  #217, PROV-N escapes these characters and PROV-JSON/PROV-XML both round-trip them — PROV-O is
+  the odd one out. #341's title names only the colon instance; the surface described here is
+  broader. Excluded from the Hypothesis round-trip property test at generation time
+  (`src/prov/tests/strategies.py`) so it does not mask other findings, but — unlike #217 and
+  #248 above — this is not a maintainer decision to leave as a permanent limitation; it remains
+  open for a future fix.
 
 The value-typing and literal-semantics gaps the audit recorded here — #77, #89, #168, #218,
 #223, #225, #235, #238, #244, #246, #249, #251, #256, #259 — were fixed in 3.0; see

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -1,10 +1,10 @@
 # Upgrading to 3.0
 
 3.0 is the one release in the `prov` roadmap allowed to break compatibility. Every
-change below is signposted in 2.4.0 (with a runtime warning where that is feasible), so
-most code that only sees a `DeprecationWarning`/`FutureWarning` today needs no change to
-keep working right up until 3.0 ships; this page lists what to do for each planned
-change. See [ROADMAP.md](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for
+change below was signposted in 2.4.0 (with a runtime warning where that was feasible), so
+code that only saw a `DeprecationWarning`/`FutureWarning` under 2.4.0 needed no change to
+keep working right up to 3.0; this page lists what to do for each change 3.0 makes.
+See [ROADMAP.md](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for
 the release-by-release plan and the
 [modernisation roadmap design](https://github.com/trungdong/prov/blob/master/docs/superpowers/specs/2026-07-03-modernisation-roadmap-design.md)
 for the full rationale.
@@ -129,7 +129,7 @@ generic `ProvException` the merge used to raise), whereas `prov_to_graph()` lets
 3.0 removes everything 2.4.0 marked deprecated:
 
 - The unconditional `pydot`/`networkx` dependencies (superseded by the `dot`/`graph`
-  extras above) — `import prov.dot` / `import prov.graph` will raise
+  extras above) — `import prov.dot` / `import prov.graph` raises
   `ModuleNotFoundError` if the corresponding extra isn't installed, rather than working
   out of the box.
 - `python-dateutil` as a runtime dependency (superseded by the stdlib swap above), along

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -85,38 +85,43 @@ attr_values = st.one_of(
 
 
 # Attribute keys draw from `local_part` too, but with their *trailing*
-# character restricted -- the failing shape found for #341 needs both an
-# attribute key ending in one of `= ' , : ; [ ]` and *any* other qualified
-# name (an identifier, another attribute key, or a QualifiedName value)
-# carrying that same character mid-string under the same namespace. Two
-# separate weaknesses combine to cause it:
+# character restricted -- the failing shape found for #341 is an attribute
+# key whose local part ends in one of `= ' , : ; [ ]`, decoded in a
+# namespace that no *other*, cleanly-splitting qualified name has already
+# registered by that point in decoding. Two separate weaknesses combine to
+# cause it:
 #
-# 1. rdflib's ``compute_qname()`` only raises when a #223 metacharacter is
-#    the very last character of an IRI with nothing after it; when one
-#    occurs mid-string (e.g. "http://example.org/e:0"), it silently
-#    mis-splits instead, folding the metacharacter into what it thinks is
-#    the namespace ("http://example.org/e:", local "0"). That mis-split is
-#    harmless for the identifier that caused it -- its reassembled URI still
-#    matches -- but it means the true "http://example.org/" namespace never
-#    gets registered from decoding that identifier.
-# 2. Decoding an *identifier* tolerates this: ``_resolve_iri``
-#    (provrdf.py:536) falls back to splitting at the last "/" or "#" itself
-#    whenever ``compute_qname()`` raises, which recovers the true namespace
-#    for any identifier whose own metacharacter is trailing (nothing follows
-#    it, so it does raise). Decoding an attribute *key* does not: its
-#    predicate is resolved via ``mandatory_valid_qname``
-#    (``_decode_attribute_triple``, provrdf.py:1573), which only matches
-#    already-registered namespaces and has no equivalent fallback. So a key
-#    ending in one of those seven characters -- every #223 metacharacter
-#    except `(` and `)` -- fails outright once some other qualified name's
-#    mid-string occurrence has already poisoned the namespace pool with an
-#    over-narrow registration instead of the true one.
+# 1. rdflib's ``compute_qname()`` raises when a #223 metacharacter is the
+#    very last character of an IRI, since nothing follows it to serve as a
+#    local part. Decoding an *identifier* tolerates this: ``_resolve_iri``
+#    falls back to splitting at the last "/" or "#" itself whenever
+#    ``compute_qname()`` raises, so the true namespace still gets
+#    registered from decoding that identifier.
+# 2. Decoding an attribute *key* has no such fallback: its predicate is
+#    resolved via ``mandatory_valid_qname``, reached from
+#    ``ProvRecord.add_attributes`` while emitting decoded records
+#    (``ProvRDFSerializer._emit_decoded_records``), which only matches an
+#    *already-registered* namespace. So a key ending in one of those seven
+#    characters -- every #223 metacharacter except `(` and `)` -- fails
+#    outright unless some other qualified name under the same namespace has
+#    already been decoded from an IRI that splits cleanly, registering the
+#    true namespace first.
 #
-# This excludes only that one shape: identifiers, mid-string occurrences in
-# other keys, and QualifiedName *values* are all unaffected and keep full
-# #223/#294 coverage. `(` and `)` are unaffected too -- rdflib splits them
-# correctly regardless of position -- so they stay reachable as key endings.
-# Excluding it is a generation-validity narrowing, not a serializer change.
+# A qualified name whose own local part carries the metacharacter
+# *mid-string* (e.g. "http://example.org/e:0") does not help: rdflib
+# mis-splits it into an over-narrow namespace ("http://example.org/e:")
+# instead of raising, so it never registers the true one -- but it does no
+# active harm either, since a clean sibling elsewhere in the same namespace
+# still rescues the key regardless. This excludes only the shape that
+# actually fails: identifiers, mid-string occurrences in other keys, and
+# QualifiedName *values* are all unaffected and keep full #223/#294
+# coverage. `(` and `)` are unaffected too -- rdflib splits them correctly
+# regardless of position -- so they stay reachable as key endings. Excluding
+# trailing-metacharacter key endings entirely is slightly more conservative
+# than the true rule (such a key is actually safe whenever its namespace
+# happens to already be registered), but the generator cannot guarantee that
+# in general, so this is a generation-validity narrowing, not a serializer
+# change.
 _KEY_SAFE_ENDING = string.ascii_lowercase + string.digits + "()"
 
 attribute_key_part = st.builds(


### PR DESCRIPTION
## Summary

`docs/upgrading-3.0.md` reads as shipped fact throughout now: the opening paragraph no longer calls its changes "planned" and the extras-removal section no longer says `import prov.dot`/`import prov.graph` "will raise" `ModuleNotFoundError` — both now describe landed, present-tense behaviour, verified by actually triggering each `ModuleNotFoundError` against the real guard code in `src/prov/dot.py`/`src/prov/graph.py`.

`docs/reference/conformance.md` gets its 3.0.0 revision stamp on the "revisited at every release" note, plus a new caveat for a PROV-O defect characterised during release close-out: an attribute key whose local part ends in one of the seven affected PROV-N metacharacters (`= ' , : ; [ ]`; `(` and `)` are unaffected) can fail to round-trip through RDF. The actual condition is namespace registration: the key's namespace must already have been registered by decoding some other, cleanly-splitting qualified name under it by the time the key itself is decoded, otherwise it fails outright. It's tracked as #341, which stays open — the row explicitly distinguishes it from the neighbouring #217 and #248 rows, which record settled maintainer decisions, by stating this one is a known, unfixed defect. A short HISTORY.rst bullet records the same fact as #217's sibling, and the comment in `src/prov/tests/strategies.py` documenting the same property-test exclusion is corrected to match (prose only — the exclusion itself is unchanged and correct as shipped).

Docs-only apart from that one comment; no behaviour anywhere under `src/` changed.

## HISTORY-bullet-to-guide-row audit (evidence)

Every bullet under `HISTORY.rst`'s `3.0.0 (unreleased)` section was checked against `docs/upgrading-3.0.md` for a matching present-tense row. All of them already had one except two wording fixes (below); the internal-refactor bullets (#274, #275, and the unnumbered dead-branch removal) and the test-only #304 bullet correctly have no guide row, since they change no user-facing behaviour. #248's bullet also correctly has no guide row — it documents that bare `mentionOf` output is unchanged from 2.x, so nothing follows for a caller upgrading; it's covered instead by `conformance.md`'s Mention row.

- [x] `#34` (attribute value retention + first-wins dedup for #77/#259) — guide row present, present tense.
- [x] `#253` (PROV-CONSTRAINTS `unified()` rework, both the value-conflict and incompatible-type cases, `FutureWarning` removal) — "Unification rework" section, present tense; live-verified (`ProvUnificationError` raised in both cases).
- [x] `#224` (PROV-XML empty-string round trip) — guide row present; live-verified.
- [x] `#289` (PROV-XML NCName `_xHHHH_` escaping) — guide row present; live-verified.
- [x] `#217` (PROV-O scruffy-statement limitation) — guide row present, matches the maintainer's documented-limitation decision.
- [x] `#228` (`ProvJSONException` on malformed input) — guide row present; live-verified.
- [x] extras moves (`dot`/`graph`) and `rdflib>=7.0.0` floor — guide rows present; live-verified (both `ModuleNotFoundError` messages, rdflib 7.6.0 installed).
- [x] `#237` (python-dateutil dropped) — guide row present; live-verified (`ProvException` on a non-ISO string, hour-24 end-of-day form accepted).
- [x] `#235`/`#249`/`#251` (numeric datatype fidelity) and `#244`/`#246`/`#256` (magnitude typing, string `$`) — guide rows present; live-verified.
- [x] `#168`/`#238` (PROV-JSON `xsd:QName`) — guide row present; live-verified.
- [x] `#89`/`#77`/`#259` (literal semantics) — guide rows present; live-verified.
- [x] `#218`/`#225` (RDF datatype fidelity, full-precision double) — guide row present; live-verified.
- [x] `#223` (PROV-N metacharacter escaping) — guide row present; live-verified.
- [x] `#250`/`#226` (PROV-O influencer property) — guide row present.
- [x] `#258` (`alternateOf` argument order) — guide row present; live-verified.
- [x] `#288` (base64Binary decode) — guide row present; live-verified.
- [x] `#96` (bundle-local namespace binding) — guide row present; live-verified.
- [x] `#273` (PROV-XML XXE hardening) — guide row present.
- [x] `#299`/`#303`/`#294` (RDF decode fidelity) — guide rows present.
- [x] `#248` (bare `mentionOf`), internal `#274`/`#275`, test-only `#304` — correctly no guide row.

## Conformance matrix derivation

```
gh issue list --milestone 3.0.0 --state closed --search "closed:>2026-07-18" --limit 100 --json number,title,closedAt
```

returned 34 issues. Cross-referenced each against `docs/reference/conformance.md`: #217, #248, #257, #253, #258, #218/#77, #289, and the previously-fixed value-typing/literal-semantics group (#77, #89, #168, #218, #223, #225, #235, #238, #244, #246, #249, #251, #256, #259) already read correctly — present tense, decisions stated as decided, nothing left to flip. #304, #299, #294, #288, #275, #274, #273, #250, #226, #228, #224, #96, #34 have no pre-existing finding text in the matrix to flip (they closed after the audit that originally populated this page, or are internal/security fixes with no PROV-DM-concept angle), so nothing needed changing for them. The only substantive change here is the new #341 row and the header's 3.0.0 revision stamp.

## #341 row correction

The #341 row, HISTORY.rst bullet, and `strategies.py` comment as first written cited a line number (`provrdf.py:1573`) that isn't actually on the failing path for a generic attribute key, and described the trigger as needing a sibling qualified name to carry the same metacharacter mid-string. Both claims were wrong. Re-derived by execution against master (four documents, captured tracebacks): the failing call is `ProvRecord.add_attributes` → `mandatory_valid_qname`, reached from `ProvRDFSerializer._emit_decoded_records`, not `_decode_attribute_triple`; and a mid-string occurrence elsewhere is neither necessary nor sufficient — the real condition is that the key's own namespace must not yet be registered by any other, cleanly-splitting qualified name at the time the key is decoded. All three artefacts, plus the GitHub comment on #341 recording the same (now corrected) finding, are updated to state the mechanism this way, citing functions rather than line numbers so the citation doesn't drift again.

## Verification

`uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html` → `build succeeded.` with no warnings suffix (0 warnings).

`uv run pytest -q` → `1391 passed, 24 skipped` — matches the baseline exactly, tally unmoved.

`grep -inE "will (change|be|raise)|likely|planned" docs/upgrading-3.0.md` → no output (exit 1) after the two wording fixes above.

`uv run ruff check src/` and `uv run ruff format --check src/` → both clean, after the `strategies.py` comment edit.

Every guide claim naming an exception type or a message string was executed as a snippet against this checkout's own installed package (extras-absence simulated by blocking `pydot`/`networkx` imports before importing `prov.dot`/`prov.graph`, exercising the real guard code) rather than paraphrased — 20 snippets total, covering both `ModuleNotFoundError` messages, the dateutil-swap `ProvException`/hour-24 acceptance, both `ProvUnificationError` shapes, `ProvJSONException`, the PROV-JSON `xsd:QName` encoding, the undecorated RDF string literal, `xsd:decimal`/language-tag equality, PROV-N metacharacter escaping, `alternateOf` argument order, `base64Binary` decode, magnitude typing, PROV-XML empty-string and NCName-escaping round trips, bundle-local namespace binding, and full-precision `xsd:double` output. The #341 mechanism correction above was independently re-derived by execution (four documents, one captured traceback) rather than copied from the material it corrects.

## Test plan

- [x] Sphinx build clean (0 warnings)
- [x] `uv run pytest -q` → 1391 passed / 24 skipped, unmoved
- [x] Future-tense grep clean
- [x] `ruff check` / `ruff format --check` clean
- [x] Guide claims executed as snippets, real output matches every claim
- [x] #341 mechanism re-derived by execution against master, matches the corrected text
