### PR TITLE
Quality pass over src/prov/model/: fewer duplicate lookups, one alias for an unresolved attribute pair, one for a coerced value

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -191,6 +191,13 @@ History
 * BREAKING: the misspelled ``prov.model.GenrationRef`` type alias is renamed
   ``GenerationRef``; the old spelling is removed rather than kept as a
   deprecated alias
+* Internal: ``src/prov/model/`` quality pass — collapsed repeated dict
+  subscripts in ``ProvRecord._store_attribute_value``, removed a duplicated
+  base-type computation between ``_unify_record_group`` and
+  ``ProvBundle._unified_records``, and added the ``CoercedAttributeValue``
+  and ``AttributePair`` type aliases (the latter now public, alongside
+  ``NameValuePair``) to stop spelling out the same unions repeatedly;
+  behaviour is unchanged
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -138,7 +138,8 @@ also has.
 Revision, quotation, and primary source are PROV-DM *subtypes* of derivation, not separate PROV-N
 records: `prov` implements all four with the single {py:class}`~prov.model.ProvDerivation` class,
 and the three subtype factories call `derivation()` then add the corresponding `prov:type`
-(confirmed by inspection of `bundle.py:1011-1146`, and by running `get_provn()` on a `revision()`
+(confirmed by inspection of `ProvBundle.derivation`, `.revision`, `.quotation`, and
+`.primary_source` in `bundle.py`, and by running `get_provn()` on a `revision()`
 record — it emits `wasDerivedFrom(..., [prov:type='prov:Revision'])`, not a `wasRevisionOf(...)`
 keyword). `ADDITIONAL_N_MAP` does carry a `wasRevisionOf`/`wasQuotedFrom`/`hadPrimarySource`
 keyword mapping for contexts (such as PROV-XML) that treat these as top-level types; PROV-N

--- a/src/prov/model/__init__.py
+++ b/src/prov/model/__init__.py
@@ -43,6 +43,7 @@ from prov.model.records import (
     XSD_DATATYPE_PARSERS as XSD_DATATYPE_PARSERS,
     ActivityRef as ActivityRef,
     AgentRef as AgentRef,
+    AttributePair as AttributePair,
     DatetimeOrStr as DatetimeOrStr,
     EntityRef as EntityRef,
     GenerationRef as GenerationRef,

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -73,6 +73,7 @@ from prov.model.records import (
     PROV_REC_CLS,
     ActivityRef,
     AgentRef,
+    AttributePair,
     DatetimeOrStr,
     EntityRef,
     GenerationRef,
@@ -257,7 +258,7 @@ def _unify_same_type_group(records: list[ProvRecord]) -> ProvRecord:
     return PROV_REC_CLS[record_type](first_record.bundle, identifier, attributes)
 
 
-def _unify_record_group(records: list[ProvRecord]) -> dict[QualifiedName, ProvRecord]:
+def _unify_record_group(records: list[ProvRecord]) -> dict[ProvRecord, ProvRecord]:
     """Merge records sharing an identifier by PROV-CONSTRAINTS term unification.
 
     Records are first partitioned by base record type (:data:`PROV_BASE_CLS`,
@@ -272,10 +273,9 @@ def _unify_record_group(records: list[ProvRecord]) -> dict[QualifiedName, ProvRe
             assertion order.
 
     Returns:
-        A mapping from each base record type present in the group to the
-        single, newly created record that stands for that type's records.
-        Usually one entry; more than one when the identifier legitimately
-        carries more than one type (e.g. an agent that is also an entity).
+        A mapping from each original record in the group to the single,
+        newly created record that stands for its base type. Records of the
+        same base type map to the same merged record.
 
     Raises:
         ProvUnificationError: If two records of the same type hold different
@@ -295,9 +295,12 @@ def _unify_record_group(records: list[ProvRecord]) -> dict[QualifiedName, ProvRe
                 f"cannot unify {identifier}: incompatible types {type_a} and {type_b}"
             )
 
-    return {
-        base_type: _unify_same_type_group(group) for base_type, group in groups.items()
-    }
+    merged_records: dict[ProvRecord, ProvRecord] = {}
+    for group in groups.values():
+        merged = _unify_same_type_group(group)
+        for record in group:
+            merged_records[record] = merged
+    return merged_records
 
 
 class ProvBundle:
@@ -583,12 +586,7 @@ class ProvBundle:
                 # more than one record having the same identifier: unify them,
                 # per base record type (usually one type, but PROV-CONSTRAINTS
                 # permits an id to carry more than one, e.g. agent + entity)
-                merged_by_type = _unify_record_group(records)
-                # map each original record to its own type's merged record
-                for record in records:
-                    merged_records[record] = merged_by_type[
-                        PROV_BASE_CLS[record.get_type()]
-                    ]
+                merged_records.update(_unify_record_group(records))
         if not merged_records:
             # No merging done, just return the list of original records
             return list(self._records)
@@ -697,7 +695,7 @@ class ProvBundle:
         Returns:
             The newly created and added :class:`ProvRecord`.
         """
-        attr_list = []  # type: list[tuple[QualifiedNameCandidate, Any]]
+        attr_list: list[AttributePair] = []
         if attributes:
             if isinstance(attributes, dict):
                 attr_list.extend((attr, value) for attr, value in attributes.items())

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -93,10 +93,9 @@ ActivityRef = Union["ProvActivity", QualifiedNameCandidate]  # type: typing.Type
 AgentRef = Union["ProvAgent", "ProvEntity", "ProvActivity", QualifiedNameCandidate]  # type: typing.TypeAlias
 GenerationRef = Union["ProvGeneration", QualifiedNameCandidate]  # type: typing.TypeAlias
 UsageRef = Union["ProvUsage", QualifiedNameCandidate]  # type: typing.TypeAlias
-RecordAttributesArg = (
-    dict[QualifiedNameCandidate, Any] | Iterable[tuple[QualifiedNameCandidate, Any]]
-)  # type: typing.TypeAlias
 NameValuePair = tuple[QualifiedName, Any]  # type: typing.TypeAlias
+AttributePair = tuple[QualifiedNameCandidate, Any]  # type: typing.TypeAlias
+RecordAttributesArg = dict[QualifiedNameCandidate, Any] | Iterable[AttributePair]  # type: typing.TypeAlias
 DatetimeOrStr = datetime.datetime | str  # type: typing.TypeAlias
 NSCollection = dict[str, str] | Iterable[Namespace]  # type: typing.TypeAlias
 PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
@@ -504,6 +503,13 @@ class Literal:
             return f"{quoted_value} %% {self._datatype!s}"
 
 
+# Depends on `Literal` and `SupportedXSDParsedTypes` above, so it cannot join
+# the "Type aliases for convenience" block near the top of the module.
+CoercedAttributeValue = (
+    QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes
+)  # type: typing.TypeAlias
+
+
 # Exceptions and warnings
 class ProvException(Error):
     """Base class for PROV model exceptions."""
@@ -785,14 +791,14 @@ class ProvRecord:
 
     def _coerce_attribute_value(
         self, attr: QualifiedName, original_value: Any
-    ) -> QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes:
+    ) -> CoercedAttributeValue:
         # Normalise `original_value` to the datatype expected for `attr`.
         #
         # Raises:
         #     ProvException: If the value is invalid for `attr`.
 
         # the branches below bind `value` to different types
-        value: QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes
+        value: CoercedAttributeValue
 
         if attr in PROV_ATTRIBUTE_QNAMES:
             # Expecting a qualified name
@@ -830,7 +836,7 @@ class ProvRecord:
     def _store_attribute_value(
         self,
         attr: QualifiedName,
-        value: QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes,
+        value: CoercedAttributeValue,
         is_collection: bool,
     ) -> None:
         # Add `value` for `attr`, enforcing single-valued (non-collection)
@@ -839,8 +845,15 @@ class ProvRecord:
         # Raises:
         #     ProvException: If a second, different value is supplied for a
         #         single-valued (non-collection) attribute.
-        if not is_collection and attr in PROV_ATTRIBUTES and self._attributes[attr]:
-            existing_value = first(self._attributes[attr])
+        #
+        # `_attributes` is a defaultdict(TypedValueSet): every code path below
+        # ends up subscripting `self._attributes[attr]` at least once (the
+        # early-return and raise paths via the guard/`first()`, the fall-through
+        # path via `.add()`), so binding it once up front auto-vivifies the
+        # entry no earlier than it would have been created anyway.
+        existing_values = self._attributes[attr]
+        if not is_collection and attr in PROV_ATTRIBUTES and existing_values:
+            existing_value = first(existing_values)
             is_not_same_value = True
             # This duplicate-value branch runs at scale in
             # _unified_records()'s merge loop (unified()/flattened() on
@@ -861,7 +874,7 @@ class ProvRecord:
                 # Same value, ignore it
                 return
 
-        self._attributes[attr].add(value)
+        existing_values.add(value)
 
     def add_attributes(self, attributes: RecordAttributesArg) -> None:
         """Add attributes to the record.


### PR DESCRIPTION
## Summary

Four small internal changes to `src/prov/model/`, plus one docs correction, ahead of the 3.0.0 release. Behaviour, the serialized output, and the public API surface are all unchanged; `dir(prov.model)` gains exactly one name.

- `ProvRecord._store_attribute_value` bound `self._attributes[attr]` once instead of subscripting it up to three times per call. `_attributes` is a `defaultdict(TypedValueSet)`; every code path already ended up creating the entry by the time the function returns, so binding it earlier only changes when auto-vivification happens, not whether it happens.
- `_unify_record_group` now returns `{original_record: merged_record}` directly, built from the by-base-type `groups` dict it already constructs. Its only caller, `ProvBundle._unified_records`, previously re-walked the same records recomputing `PROV_BASE_CLS[record.get_type()]` a second time just to get back to that shape; it now just does `merged_records.update(_unify_record_group(records))`.
- Added `CoercedAttributeValue`, a private alias for the four-part union `ProvRecord._coerce_attribute_value` returns and `_store_attribute_value` takes as its `value` parameter, previously spelled out three times. It sits just after the `Literal` class rather than in the alias block near the top of `records.py`, because it depends on `Literal` and `SupportedXSDParsedTypes`, both defined later in the module — placing it earlier would be a `NameError` at import time.
- Added `AttributePair`, a public alias for the unresolved `(name, value)` attribute pair shape, distinct from the already-public `NameValuePair` (the resolved form). Adopted at `ProvBundle.new_record`'s `attr_list` and folded into `RecordAttributesArg`'s second arm. Re-exported from `prov.model` alongside the rest of that alias block, which turned out to be re-exported as a complete group.
- `docs/reference/conformance.md`'s citation for the revision/quotation/primary-source claim pointed at `bundle.py:1011-1146`, a range that (checked by inspection) actually covers unrelated methods — the tail of `communication()`, then `agent()`, `attribution()`, `association()`, `delegation()`, and the start of `influence()`. Replaced with a citation naming the four methods the claim is actually about: `ProvBundle.derivation`/`.revision`/`.quotation`/`.primary_source`.

## Verification

- `uv run pytest -q` → 1391 passed, 24 skipped, 0 xfailed (matches the pre-existing baseline)
- `uv run pytest -q src/prov/tests/test_unification_constraints.py src/prov/tests/test_public_api.py` → 169 passed, 3 skipped
- `uv run ruff check src/` and `uv run ruff format --check src/` → clean
- `uv run mypy src` → no issues
- `uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html -W` → build succeeded, zero warnings
- Byte-parity harness (`PYTHONHASHSEED=0`, base vs branch) → `diff -ru` empty
- `uvx lizard -C 15 src/prov/` → exactly 2 warnings, both test-only (`_populate`, `find_diff` — tracked as #336)

## Test plan

- [x] Full suite green at the documented tally
- [x] Unification-specific and public-API tests run and named explicitly
- [x] Lint/format/type checks clean
- [x] Docs build with zero warnings
- [x] Serialized-output byte parity confirmed against master