### PR TITLE
Quality pass over src/prov/serializers/

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -198,6 +198,15 @@ History
   and ``AttributePair`` type aliases (the latter now public, alongside
   ``NameValuePair``) to stop spelling out the same unions repeatedly;
   behaviour is unchanged
+* Internal: ``src/prov/serializers/`` quality pass — adopted the public
+  ``NameValuePair`` and ``AttributePair`` type aliases in ``provxml.py``,
+  ``provrdf.py`` and ``provjson.py`` in place of the shapes they spell out,
+  added ``provrdf.py``-local ``RelationMapper``/``PredicateMapper``/
+  ``RecordTypeLabels``/``RdfTerm``/``RdfSubject`` aliases for its own
+  repeated dict and RDF-term-union parameters, made ``provxml.py``'s
+  ``_ALWAYS_CHECK`` a ``frozenset``, and changed
+  ``_needs_xsd_type_inference`` to take a plain ``bool`` computed by its
+  caller instead of an XML element; behaviour is unchanged
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -11,6 +11,7 @@ from prov import Error
 from prov.constants import *
 from prov.identifier import Identifier, Namespace, QualifiedName
 from prov.model import (
+    AttributePair,  # noqa: F401 -- used by a `# type:` comment-annotation below
     Literal,
     ProvBundle,
     ProvDocument,
@@ -465,7 +466,7 @@ def _decode_record_instance(
             documented multi-entity ``hadMember`` (membership) hack.
     """
     attributes = {}  # type: dict[QualifiedNameCandidate, Any]
-    other_attributes = []  # type: list[tuple[QualifiedNameCandidate, Any]]
+    other_attributes = []  # type: list[AttributePair]
     # this is for the multiple-entity membership hack to come
     membership_extra_members = None
     for attr_name, values in element.items():

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -4,6 +4,7 @@ import base64
 import datetime
 import io
 import re
+import typing  # noqa: F401 -- used by `# type: typing.TypeAlias` comments below
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Generator
@@ -53,6 +54,16 @@ from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Satrajit S. Ghosh"
 __email__ = "satra@mit.edu"
+
+
+# Type aliases for convenience. Deliberately local to this module: records.py
+# carries no runtime dependency on rdflib, which is what makes the
+# minimal-install story work (see CLAUDE.md).
+RelationMapper = dict[URIRef, str]  # type: typing.TypeAlias
+PredicateMapper = dict[URIRef, pm.QualifiedName]  # type: typing.TypeAlias
+RecordTypeLabels = dict[pm.QualifiedName, str]  # type: typing.TypeAlias
+RdfTerm = URIRef | RDFLiteral  # type: typing.TypeAlias
+RdfSubject = URIRef | BNode  # type: typing.TypeAlias
 
 
 class ProvRDFException(Error):
@@ -344,9 +355,7 @@ class _DecodeState:
     unique_sets: dict[str, dict[pm.QualifiedName, list[Any]]] = field(
         default_factory=dict
     )
-    other_attributes: dict[str, list[tuple[pm.QualifiedNameCandidate, Any]]] = field(
-        default_factory=dict
-    )
+    other_attributes: dict[str, list[pm.AttributePair]] = field(default_factory=dict)
 
     def register(self, subj: str, prov_obj: pm.QualifiedName) -> None:
         """Record ``subj``'s type and seed its empty formal-attribute slots.
@@ -386,7 +395,7 @@ class ProvRDFSerializer(Serializer):
         self,
         stream: io.IOBase,
         rdf_format: str = "trig",
-        PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
+        PROV_N_MAP: RecordTypeLabels = PROV_N_MAP,
         **kwargs: Any,
     ) -> None:
         """Serialize ``self.document`` to `PROV-O <https://www.w3.org/TR/prov-o/>`_.
@@ -431,8 +440,8 @@ class ProvRDFSerializer(Serializer):
         self,
         stream: io.IOBase,
         rdf_format: str = "trig",
-        relation_mapper: dict[URIRef, str] = RELATION_MAP,
-        predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
+        relation_mapper: RelationMapper = RELATION_MAP,
+        predicate_mapper: PredicateMapper = PREDICATE_MAP,
         **kwargs: Any,
     ) -> pm.ProvDocument:
         """Deserialize a `PROV-O <https://www.w3.org/TR/prov-o/>`_ graph
@@ -489,7 +498,7 @@ class ProvRDFSerializer(Serializer):
         # through is safe despite its declared parameter type.
         return self.document.valid_qualified_name(value)  # type: ignore[union-attr, arg-type]
 
-    def encode_rdf_representation(self, value: Any) -> RDFLiteral | URIRef:
+    def encode_rdf_representation(self, value: Any) -> RdfTerm:
         """Encode a single attribute value to its RDF term representation.
 
         Args:
@@ -736,7 +745,7 @@ class ProvRDFSerializer(Serializer):
     def encode_document(
         self,
         document: pm.ProvDocument,
-        PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
+        PROV_N_MAP: RecordTypeLabels = PROV_N_MAP,
     ) -> Dataset:
         """Encode a whole :class:`~prov.model.ProvDocument`, including its named bundles.
 
@@ -810,7 +819,7 @@ class ProvRDFSerializer(Serializer):
     def encode_container(
         self,
         bundle: pm.ProvBundle,
-        PROV_N_MAP: dict[pm.QualifiedName, str] = PROV_N_MAP,
+        PROV_N_MAP: RecordTypeLabels = PROV_N_MAP,
         container: Graph | None = None,
         identifier: str | None = None,
     ) -> Graph:
@@ -916,17 +925,17 @@ class ProvRDFSerializer(Serializer):
             if value is None:
                 continue
             if isinstance(value, pm.ProvRecord):
-                obj: RDFLiteral | URIRef = URIRef(str(real_or_anon_id(value)))
+                obj: RdfTerm = URIRef(str(real_or_anon_id(value)))
             else:
                 #  Assuming this is a datetime value
                 obj = self.encode_rdf_representation(value)
-            pred: URIRef | RDFLiteral
+            pred: RdfTerm
             if attr == PROV["location"]:
                 pred = _prov_uri("atLocation")
                 container.add(
                     (
                         # elements always carry an identifier here
-                        cast("URIRef | BNode", identifier),
+                        cast(RdfSubject, identifier),
                         pred,
                         self.encode_rdf_representation(obj),
                     )
@@ -937,7 +946,7 @@ class ProvRDFSerializer(Serializer):
             else:
                 pred = self.encode_rdf_representation(attr)
             # elements always carry an identifier here
-            container.add((cast("URIRef | BNode", identifier), pred, obj))
+            container.add((cast(RdfSubject, identifier), pred, obj))
 
     def _encode_relation(
         self,
@@ -945,7 +954,7 @@ class ProvRDFSerializer(Serializer):
         record: pm.ProvRecord,
         rec_type: pm.QualifiedName,
         identifier: URIRef | None,
-        PROV_N_MAP: dict[pm.QualifiedName, str],
+        PROV_N_MAP: RecordTypeLabels,
     ) -> None:
         """Encode a relation using PROV-O's qualification pattern.
 
@@ -974,7 +983,7 @@ class ProvRDFSerializer(Serializer):
                 formal_qualifiers = True
         has_qualifiers = len(record.extra_attributes) > 0 or formal_qualifiers
 
-        node: URIRef | BNode | None = identifier
+        node: RdfSubject | None = identifier
         for attr, value in all_attributes:
             # The qualification head is (re)built until a blank node is minted
             # for it; for an identified relation no blank node is ever minted,
@@ -998,7 +1007,7 @@ class ProvRDFSerializer(Serializer):
                     (
                         # a qualified relation always has a URIRef or
                         # BNode identifier by this point
-                        cast("URIRef | BNode", node),
+                        cast(RdfSubject, node),
                         self._qualified_attr_predicate(rec_type, attr, formal_objects),
                         self.encode_rdf_representation(value),
                     )
@@ -1009,12 +1018,12 @@ class ProvRDFSerializer(Serializer):
         container: Graph,
         record: pm.ProvRecord,
         rec_type: pm.QualifiedName,
-        identifier: URIRef | BNode | None,
-        PROV_N_MAP: dict[pm.QualifiedName, str],
+        identifier: RdfSubject | None,
+        PROV_N_MAP: RecordTypeLabels,
         formal_objects: list[pm.QualifiedName],
         used_objects: list[pm.QualifiedName],
         has_qualifiers: bool,
-    ) -> tuple[URIRef | BNode | None, BNode | None, bool]:
+    ) -> tuple[RdfSubject | None, BNode | None, bool]:
         """Emit a relation's binary triple and its ``prov:qualified*`` node.
 
         Args:
@@ -1042,7 +1051,7 @@ class ProvRDFSerializer(Serializer):
             if val:
                 valid_formal_indices.add(idx)
         used_objects[:] = [record.formal_attributes[0][0]]
-        subj: URIRef | RDFLiteral | None = None
+        subj: RdfTerm | None = None
         if record.formal_attributes[0][1]:
             subj = URIRef(record.formal_attributes[0][1].uri)
         if identifier is None and subj is not None:
@@ -1075,7 +1084,7 @@ class ProvRDFSerializer(Serializer):
         record: pm.ProvRecord,
         rec_type: pm.QualifiedName,
         pred: URIRef,
-        subj: URIRef | RDFLiteral,
+        subj: RdfTerm,
         valid_formal_indices: set[int],
         used_objects: list[pm.QualifiedName],
         has_qualifiers: bool,
@@ -1111,7 +1120,7 @@ class ProvRDFSerializer(Serializer):
         # attribute directly (as a rewrite of the formal attribute).
         if not (rec_type in _BINARY_TRIPLE_INFLUENCER_RELATIONS and has_qualifiers):
             used_objects.append(record.formal_attributes[1][0])
-        obj_term: URIRef | RDFLiteral = self.encode_rdf_representation(obj_val)
+        obj_term: RdfTerm = self.encode_rdf_representation(obj_val)
         container.add((subj, pred, obj_term))
         if rec_type == PROV_MENTION:
             if record.formal_attributes[2][1]:
@@ -1131,9 +1140,9 @@ class ProvRDFSerializer(Serializer):
         container: Graph,
         record: pm.ProvRecord,
         rec_type: pm.QualifiedName,
-        identifier: URIRef | BNode | None,
-        subj: URIRef | RDFLiteral,
-    ) -> tuple[URIRef | BNode, BNode | None]:
+        identifier: RdfSubject | None,
+        subj: RdfTerm,
+    ) -> tuple[RdfSubject, BNode | None]:
         """Link (and, when anonymous, create and type) a ``prov:qualified*`` node.
 
         A ``prov:type`` of ``prov:Revision``/``prov:Quotation``/
@@ -1180,7 +1189,7 @@ class ProvRDFSerializer(Serializer):
         rec_type: pm.QualifiedName,
         attr: pm.QualifiedNameCandidate,
         formal_objects: list[pm.QualifiedName],
-    ) -> URIRef | RDFLiteral:
+    ) -> RdfTerm:
         """Return the PROV-O predicate for one attribute of a qualified relation.
 
         Picks a base predicate for ``attr``, then applies the common and
@@ -1195,7 +1204,7 @@ class ProvRDFSerializer(Serializer):
         Returns:
             The predicate term to use for ``attr``.
         """
-        pred: URIRef | RDFLiteral
+        pred: RdfTerm
         if attr in formal_objects:
             pred = attr2rdf(cast(QualifiedName, attr))
         elif isinstance(attr, pm.QualifiedName) and attr in _QUALIFIED_ATTR_PREDICATES:
@@ -1216,8 +1225,8 @@ class ProvRDFSerializer(Serializer):
         self,
         content: Dataset,
         document: pm.ProvDocument,
-        relation_mapper: dict[URIRef, str] = RELATION_MAP,
-        predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
+        relation_mapper: RelationMapper = RELATION_MAP,
+        predicate_mapper: PredicateMapper = PREDICATE_MAP,
     ) -> None:
         """Decode a whole RDF graph, including named subgraphs, into a document.
 
@@ -1280,8 +1289,8 @@ class ProvRDFSerializer(Serializer):
         self,
         graph: Graph,
         bundle: pm.ProvBundle,
-        relation_mapper: dict[URIRef, str] = RELATION_MAP,
-        predicate_mapper: dict[URIRef, pm.QualifiedName] = PREDICATE_MAP,
+        relation_mapper: RelationMapper = RELATION_MAP,
+        predicate_mapper: PredicateMapper = PREDICATE_MAP,
     ) -> None:
         """Decode a single RDF (sub)graph's triples into records added to a bundle.
 
@@ -1408,8 +1417,8 @@ class ProvRDFSerializer(Serializer):
         graph: Graph,
         bundle: pm.ProvBundle,
         state: "_DecodeState",
-        relation_mapper: dict[URIRef, str],
-        predicate_mapper: dict[URIRef, pm.QualifiedName],
+        relation_mapper: RelationMapper,
+        predicate_mapper: PredicateMapper,
     ) -> None:
         """Walk every triple, filling in relations and attributes.
 
@@ -1453,7 +1462,7 @@ class ProvRDFSerializer(Serializer):
         subj: str,
         pred: URIRef,
         obj: Node,
-        relation_mapper: dict[URIRef, str],
+        relation_mapper: RelationMapper,
     ) -> None:
         """Recreate one relation from its PROV-O binary triple.
 
@@ -1524,7 +1533,7 @@ class ProvRDFSerializer(Serializer):
         subj: str,
         pred: URIRef,
         obj: Node,
-        predicate_mapper: dict[URIRef, pm.QualifiedName],
+        predicate_mapper: PredicateMapper,
     ) -> None:
         """Decode one non-relation triple into a formal or extra attribute.
 
@@ -1660,7 +1669,7 @@ class ProvRDFSerializer(Serializer):
 
 def _repeated_formal_attribute(
     record_type: pm.QualifiedName,
-    attrs: list[tuple[pm.QualifiedNameCandidate, Any]] | None,
+    attrs: list[pm.AttributePair] | None,
 ) -> str | None:
     """Return the formal-attribute name repeated in ``attrs``, if any.
 

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -12,7 +12,12 @@ from lxml import etree
 import prov
 import prov.identifier
 from prov.constants import *
-from prov.model import DEFAULT_NAMESPACES, canonical_xsd_datatype, sorted_attributes
+from prov.model import (
+    DEFAULT_NAMESPACES,
+    NameValuePair,
+    canonical_xsd_datatype,
+    sorted_attributes,
+)
 from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Lion Krischer"
@@ -343,7 +348,7 @@ class ProvXMLSerializer(Serializer):
     def _derive_record_label(
         self,
         rec_type: prov.identifier.QualifiedName,
-        attributes: list[tuple[prov.identifier.QualifiedName, Any]],
+        attributes: list[NameValuePair],
     ) -> str:
         """Derive the PROV-XML element name for a record, honouring subtypes.
 
@@ -399,7 +404,8 @@ def _encode_attribute(
     )
     v = _encode_attribute_value(subelem, attr, value)
 
-    if _needs_xsd_type_inference(subelem, attr, value, v, force_types):
+    has_xsi_type = _ns_xsi("type") in subelem.attrib
+    if _needs_xsd_type_inference(has_xsi_type, attr, value, v, force_types):
         xsd_type, v = _infer_xsd_type(attr, value, v)
         if xsd_type is not None:
             subelem.attrib[_ns_xsi("type")] = str(xsd_type)
@@ -455,17 +461,19 @@ def _encode_attribute_value(
 # To enable a mapping of Python types to XML and back, the XSD type must be
 # written for values of these types. Membership is tested against the value's
 # exact type, deliberately not with isinstance().
-_ALWAYS_CHECK = {
-    bool,
-    datetime.datetime,
-    float,
-    int,
-    prov.identifier.Identifier,
-}
+_ALWAYS_CHECK = frozenset(
+    {
+        bool,
+        datetime.datetime,
+        float,
+        int,
+        prov.identifier.Identifier,
+    }
+)
 
 
 def _needs_xsd_type_inference(
-    subelem: etree._Element,
+    has_xsi_type: bool,
     attr: prov.identifier.QualifiedName,
     value: Any,
     v: str,
@@ -482,7 +490,8 @@ def _needs_xsd_type_inference(
     type.
 
     Args:
-        subelem: The attribute's XML element, as written so far.
+        has_xsi_type: Whether the attribute's XML element, as written so
+            far, already carries an ``xsi:type`` attribute.
         attr: The attribute's name.
         value: The attribute's value.
         v: The value's string rendering.
@@ -498,7 +507,7 @@ def _needs_xsd_type_inference(
             or type(value) in _ALWAYS_CHECK
             or attr in [PROV_TYPE, PROV_LOCATION, PROV_VALUE]
         )
-        and _ns_xsi("type") not in subelem.attrib
+        and not has_xsi_type
         and not str(value).startswith("prov:")
         and not (attr in PROV_ATTRIBUTE_QNAMES and v)
         and attr not in [PROV_ATTR_TIME, PROV_LABEL]
@@ -551,7 +560,7 @@ def _infer_xsd_type(
 
 def _extract_attributes(
     element: etree._Element,
-) -> list[tuple[prov.identifier.QualifiedName, Any]]:
+) -> list[NameValuePair]:
     """Extract a record's attributes from its PROV-XML etree element.
 
     Each child of ``element`` becomes one ``(QualifiedName, value)`` pair:
@@ -578,7 +587,7 @@ def _extract_attributes(
             none of them is ``prov:ref``, ``xsi:type``, or ``xml:lang``, so
             no attribute value can be determined.
     """
-    attributes = []  # type: list[tuple[prov.identifier.QualifiedName, Any]]
+    attributes = []  # type: list[NameValuePair]
     _unassigned = object()
     for subel in element:
         sqname = etree.QName(subel)


### PR DESCRIPTION
## Summary
A scoped, behaviour-preserving quality pass over the serializers, matching the same style adopted for `src/prov/model/` in #346.

- `provxml.py` adopts the shared `NameValuePair` type alias in `_derive_record_label`, `_extract_attributes` and its `attributes = []` comment-annotation, in place of spelling out `list[tuple[QualifiedName, Any]]` three times.
- `provrdf.py` gets five new local type aliases for shapes that recur across its signatures: `RelationMapper`, `PredicateMapper`, `RecordTypeLabels` (each used on 5 signatures) and `RdfTerm`/`RdfSubject` for its RDF-term unions, including unquoting the three `cast("URIRef | BNode", ...)` call sites now that the union has a name (the file has no `from __future__ import annotations`, so the quoting was never required).
- `provxml.py`'s `_ALWAYS_CHECK` becomes a `frozenset`, matching the convention `provrdf.py` already uses for its own membership-test-only module constants.
- `provxml.py`'s `_needs_xsd_type_inference` takes a plain `bool` (`has_xsi_type`) instead of an XML element; its only call site now computes the flag once and passes it in. Parameter count is unchanged (a swap, not an addition).
- `provrdf.py`/`provjson.py` adopt the shared `AttributePair` alias for `_DecodeState.other_attributes`, `_repeated_formal_attribute`'s `attrs` parameter, and `_decode_record_instance`'s comment-annotation.

All six items are annotation-only or internal-only; nothing here changes serialized output or the public API.

## Verification
- `uv run pytest -q` → 1391 passed, 24 skipped, 0 xfailed (matches the pre-change baseline)
- `uv run pytest -q src/prov/tests/test_xml.py src/prov/tests/test_rdf.py src/prov/tests/test_json.py src/prov/tests/test_xml_schema.py` → 165 passed, 3 skipped
- `uv run ruff check src/`, `uv run ruff format --check src/`, `uv run mypy src` → all clean
- Byte-parity harness (`PYTHONHASHSEED=0` pinned on both runs, per the harness's own note on issue #337): `diff -ru` between a pre-change and post-change capture of every canonical example document across json/xml/rdf/provn/dot is empty
- `uv run --group docs ... sphinx-build -b html docs docs/_build/html` → 0 warnings
- `uvx lizard -C 15 src/prov/` → exactly 2 warnings, both test-only (`_populate`, `find_diff`, tracked as #336)

## Test plan
- [x] Full suite green at the exact pre-change tally
- [x] Named format-specific test modules green
- [x] Lint/format/type-check clean
- [x] Parity harness diff-clean
- [x] Docs build warning-free
- [x] Complexity report unchanged