### PR TITLE
Convert type aliases to the PEP 613 annotated form

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -207,6 +207,10 @@ History
   ``_ALWAYS_CHECK`` a ``frozenset``, and changed
   ``_needs_xsd_type_inference`` to take a plain ``bool`` computed by its
   caller instead of an XML element; behaviour is unchanged
+* Internal: the module-level type aliases in ``src/prov/model/records.py``
+  and ``src/prov/serializers/provrdf.py`` are now declared with the PEP 613
+  ``X: TypeAlias = ...`` form instead of the trailing ``# type:
+  typing.TypeAlias`` comment; behaviour is unchanged
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -7,7 +7,7 @@ import decimal
 import logging
 import os
 import re
-import typing  # noqa: F401 -- used by `# type: typing.TypeAlias` comments below
+import typing
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, MutableSet
 from typing import TYPE_CHECKING, Any, Union
@@ -86,19 +86,23 @@ logger = logging.getLogger(__name__)
 
 
 # Type aliases for convenience
-QualifiedNameCandidate = QualifiedName | str | Identifier  # type: typing.TypeAlias
-OptionalID = QualifiedNameCandidate | None  # type: typing.TypeAlias
-EntityRef = Union["ProvEntity", QualifiedNameCandidate]  # type: typing.TypeAlias
-ActivityRef = Union["ProvActivity", QualifiedNameCandidate]  # type: typing.TypeAlias
-AgentRef = Union["ProvAgent", "ProvEntity", "ProvActivity", QualifiedNameCandidate]  # type: typing.TypeAlias
-GenerationRef = Union["ProvGeneration", QualifiedNameCandidate]  # type: typing.TypeAlias
-UsageRef = Union["ProvUsage", QualifiedNameCandidate]  # type: typing.TypeAlias
-NameValuePair = tuple[QualifiedName, Any]  # type: typing.TypeAlias
-AttributePair = tuple[QualifiedNameCandidate, Any]  # type: typing.TypeAlias
-RecordAttributesArg = dict[QualifiedNameCandidate, Any] | Iterable[AttributePair]  # type: typing.TypeAlias
-DatetimeOrStr = datetime.datetime | str  # type: typing.TypeAlias
-NSCollection = dict[str, str] | Iterable[Namespace]  # type: typing.TypeAlias
-PathLike = str | bytes | os.PathLike[str]  # type: typing.TypeAlias
+QualifiedNameCandidate: typing.TypeAlias = QualifiedName | str | Identifier
+OptionalID: typing.TypeAlias = QualifiedNameCandidate | None
+EntityRef: typing.TypeAlias = Union["ProvEntity", QualifiedNameCandidate]
+ActivityRef: typing.TypeAlias = Union["ProvActivity", QualifiedNameCandidate]
+AgentRef: typing.TypeAlias = Union[
+    "ProvAgent", "ProvEntity", "ProvActivity", QualifiedNameCandidate
+]
+GenerationRef: typing.TypeAlias = Union["ProvGeneration", QualifiedNameCandidate]
+UsageRef: typing.TypeAlias = Union["ProvUsage", QualifiedNameCandidate]
+NameValuePair: typing.TypeAlias = tuple[QualifiedName, Any]
+AttributePair: typing.TypeAlias = tuple[QualifiedNameCandidate, Any]
+RecordAttributesArg: typing.TypeAlias = (
+    dict[QualifiedNameCandidate, Any] | Iterable[AttributePair]
+)
+DatetimeOrStr: typing.TypeAlias = datetime.datetime | str
+NSCollection: typing.TypeAlias = dict[str, str] | Iterable[Namespace]
+PathLike: typing.TypeAlias = str | bytes | os.PathLike[str]
 
 
 # Data Types
@@ -189,9 +193,9 @@ DATATYPE_PARSERS = {
 
 
 # Mappings for XSD datatypes to Python standard types
-SupportedXSDParsedTypes = (
+SupportedXSDParsedTypes: typing.TypeAlias = (
     str | datetime.datetime | float | int | bool | Identifier | None
-)  # type: typing.TypeAlias
+)
 XSD_DATATYPE_PARSERS: dict[QualifiedName, Callable[[str], SupportedXSDParsedTypes]] = {
     XSD_STRING: str,
     XSD_DOUBLE: float,
@@ -505,9 +509,9 @@ class Literal:
 
 # Depends on `Literal` and `SupportedXSDParsedTypes` above, so it cannot join
 # the "Type aliases for convenience" block near the top of the module.
-CoercedAttributeValue = (
+CoercedAttributeValue: typing.TypeAlias = (
     QualifiedName | datetime.datetime | Literal | SupportedXSDParsedTypes
-)  # type: typing.TypeAlias
+)
 
 
 # Exceptions and warnings

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -11,7 +11,7 @@ from prov import Error
 from prov.constants import *
 from prov.identifier import Identifier, Namespace, QualifiedName
 from prov.model import (
-    AttributePair,  # noqa: F401 -- used by a `# type:` comment-annotation below
+    AttributePair,
     Literal,
     ProvBundle,
     ProvDocument,
@@ -466,7 +466,7 @@ def _decode_record_instance(
             documented multi-entity ``hadMember`` (membership) hack.
     """
     attributes = {}  # type: dict[QualifiedNameCandidate, Any]
-    other_attributes = []  # type: list[AttributePair]
+    other_attributes: list[AttributePair] = []
     # this is for the multiple-entity membership hack to come
     membership_extra_members = None
     for attr_name, values in element.items():

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -4,7 +4,7 @@ import base64
 import datetime
 import io
 import re
-import typing  # noqa: F401 -- used by `# type: typing.TypeAlias` comments below
+import typing
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Generator
@@ -59,11 +59,11 @@ __email__ = "satra@mit.edu"
 # Type aliases for convenience. Deliberately local to this module: records.py
 # carries no runtime dependency on rdflib, which is what makes the
 # minimal-install story work (see CLAUDE.md).
-RelationMapper = dict[URIRef, str]  # type: typing.TypeAlias
-PredicateMapper = dict[URIRef, pm.QualifiedName]  # type: typing.TypeAlias
-RecordTypeLabels = dict[pm.QualifiedName, str]  # type: typing.TypeAlias
-RdfTerm = URIRef | RDFLiteral  # type: typing.TypeAlias
-RdfSubject = URIRef | BNode  # type: typing.TypeAlias
+RelationMapper: typing.TypeAlias = dict[URIRef, str]
+PredicateMapper: typing.TypeAlias = dict[URIRef, pm.QualifiedName]
+RecordTypeLabels: typing.TypeAlias = dict[pm.QualifiedName, str]
+RdfTerm: typing.TypeAlias = URIRef | RDFLiteral
+RdfSubject: typing.TypeAlias = URIRef | BNode
 
 
 class ProvRDFException(Error):


### PR DESCRIPTION
## Summary
- Under the project's pinned pythonVersion 3.10, pyright rejects the `X = <type>  # type: typing.TypeAlias` comment form at every call site that uses the alias (reportInvalidTypeForm), while the PEP 613 `X: typing.TypeAlias = <type>` form is accepted.
- Converts all 16 aliases in `src/prov/model/records.py` and all 6 in `src/prov/serializers/provrdf.py` to the annotated form; pure form change, no value or ordering changes.
- Drops the now-stale `# noqa: F401` on the `typing` imports in both files, since the annotation itself is a real use of `typing.TypeAlias`.
- Converts the one variable-level `# type: list[AttributePair]` comment in `provjson.py` to a real annotation and drops its matching noqa on the `AttributePair` import, since doing so was trivial and behaviour-neutral.
- pyright error count drops from 52 (41 `reportInvalidTypeForm`) to 11 (0 `reportInvalidTypeForm`); the remaining 11 are pre-existing and unrelated to this change.

## Test plan
- [x] `grep -rn "# type: typing.TypeAlias" src/` returns nothing
- [x] `uv run mypy src` clean
- [x] `uv run pytest -q` → 1391 passed, 24 skipped
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` clean
- [x] `uvx pyright --outputjson` at base and branch, broken down by rule
- [x] Byte-parity harness (`parity_capture.py`) diff-clean between base and branch with `PYTHONHASHSEED=0` pinned on both runs
- [x] `dir(prov.model)` length unchanged (175) and all public aliases importable
- [x] Sphinx build with `-W` (warnings-as-errors): 0 warnings
- [x] `uv run --python 3.10 ... pytest -q` → 1391 passed, 24 skipped