### PR TITLE
Quality pass: drop dead document_cls param, adopt PathLike, name dot counters, add DotContainer alias

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -211,6 +211,16 @@ History
   and ``src/prov/serializers/provrdf.py`` are now declared with the PEP 613
   ``X: TypeAlias = ...`` form instead of the trailing ``# type:
   typing.TypeAlias`` comment; behaviour is unchanged
+* Internal: ``src/prov/__init__.py`` and ``src/prov/dot.py`` quality pass —
+  ``_detect_and_parse`` no longer threads a ``document_cls`` parameter for a
+  target that can never vary, doing its own lazy ``ProvDocument`` import
+  instead; the ``prov.model``-re-exported ``PathLike`` alias replaces six
+  spelled-out ``str | bytes | os.PathLike[str]`` unions in ``prov/__init__.py``;
+  ``_DotRenderState``'s positionally-indexed ``count`` list is now four named
+  counters (``node_count``, ``bnode_count``, ``cluster_count``,
+  ``annotation_count``); and a local ``DotContainer`` alias replaces the
+  repeated ``pydot.Dot | pydot.Cluster`` union across nine ``dot.py``
+  signatures; behaviour is unchanged
 
 2.5.1 (2026-07-13)
 ^^^^^^^^^^^^^^^^^^

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from typing import IO, TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from prov.model import ProvDocument
+    from prov.model import PathLike, ProvDocument
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
@@ -22,17 +22,15 @@ class Error(Exception):
 
 
 def _resolve_source(
-    source: io.IOBase | IO[Any] | str | bytes | os.PathLike[str],
-) -> tuple[
-    io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None, str | bytes | None
-]:
+    source: io.IOBase | IO[Any] | PathLike,
+) -> tuple[io.IOBase | IO[Any] | PathLike | None, str | bytes | None]:
     """Split ``source`` into a ``(src, content)`` pair for deserialization.
 
     A ``str``/``bytes`` source naming an existing file stays as ``src`` (a
     path); any other ``str``/``bytes`` is returned as raw ``content``
     instead, with ``src`` set to ``None``.
     """
-    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None = source
+    src: io.IOBase | IO[Any] | PathLike | None = source
     content: str | bytes | None = None
     if isinstance(src, (str, bytes)) and not os.path.isfile(src):
         # Not a path to an existing file: treat the string itself as raw
@@ -42,7 +40,7 @@ def _resolve_source(
 
 
 def _prepare_stream(
-    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None,
+    src: io.IOBase | IO[Any] | PathLike | None,
 ) -> tuple[IO[Any] | None, int | None]:
     """Identify a seekable stream in ``src`` and capture its start position.
 
@@ -67,10 +65,9 @@ def _prepare_stream(
 
 
 def _detect_and_parse(
-    src: io.IOBase | IO[Any] | str | bytes | os.PathLike[str] | None,
+    src: io.IOBase | IO[Any] | PathLike | None,
     content: str | bytes | None,
     serializers: Iterable[str],
-    document_cls: type[ProvDocument],
 ) -> ProvDocument:
     """Try each registered format in turn, returning the first non-empty parse.
 
@@ -78,6 +75,9 @@ def _detect_and_parse(
         TypeError: If no registered serializer produced a non-empty
             document from ``src``/``content``.
     """
+    # Lazy import: prov and prov.model are circularly dependent.
+    from prov.model import ProvDocument
+
     stream, start_pos = _prepare_stream(src)
 
     # Failed-candidate diagnostics (e.g. rdflib's "does not look like a
@@ -106,7 +106,7 @@ def _detect_and_parse(
                     # the remaining attempts rather than aborting detection.
                     start_pos = None
             try:
-                document = document_cls.deserialize(
+                document = ProvDocument.deserialize(
                     source=src, content=content, format=format
                 )
             except Exception:
@@ -139,7 +139,7 @@ def _detect_and_parse(
 
 
 def read(
-    source: io.IOBase | IO[Any] | str | bytes | os.PathLike[str],
+    source: io.IOBase | IO[Any] | PathLike,
     format: str | None = None,
 ) -> ProvDocument | None:
     """Read a :class:`~prov.model.ProvDocument` from a file, path, or string.
@@ -204,4 +204,4 @@ def read(
                 )
             raise
 
-    return _detect_and_parse(src, content, serializers, ProvDocument)
+    return _detect_and_parse(src, content, serializers)

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -12,6 +12,7 @@ References:
 .. moduleauthor:: Trung Dong Huynh <trungdong@donggiang.com>
 """
 
+import typing
 from dataclasses import dataclass, field
 from datetime import datetime
 from html import escape
@@ -203,14 +204,17 @@ def htlm_link_if_uri(value: Any) -> str:
         return str(value)
 
 
+DotContainer: typing.TypeAlias = pydot.Dot | pydot.Cluster
+
+
 @dataclass
 class _DotRenderState:
     """Mutable state shared by the tree-walk helpers within one `prov_to_dot` call.
 
-    ``node_map`` and ``count`` are written and read across the whole,
-    possibly-nested bundle walk (they must stay shared across sub-bundles);
-    the four ``show_*``/``use_labels``/``show_nary`` flags are the
-    caller-supplied rendering options, constant for the call.
+    ``node_map`` and the ``*_count`` counters are written and read across
+    the whole, possibly-nested bundle walk (they must stay shared across
+    sub-bundles); the four ``show_*``/``use_labels``/``show_nary`` flags are
+    the caller-supplied rendering options, constant for the call.
     """
 
     use_labels: bool
@@ -218,14 +222,15 @@ class _DotRenderState:
     show_relation_attributes: bool
     show_nary: bool
     node_map: dict[str, pydot.Node] = field(default_factory=dict)
-    count: list[int] = field(
-        default_factory=lambda: [0, 0, 0, 0]
-    )  # counters for node ids
+    node_count: int = 0
+    bnode_count: int = 0
+    cluster_count: int = 0
+    annotation_count: int = 0
 
 
 def _attach_attribute_annotation(
     state: _DotRenderState,
-    dot: pydot.Dot | pydot.Cluster,
+    dot: DotContainer,
     node: pydot.Node,
     record: ProvRecord,
 ) -> None:
@@ -258,20 +263,20 @@ def _attach_attribute_annotation(
         for attr, value in attributes
     )
     ann_rows.append(ANNOTATION_END_ROW)
-    state.count[3] += 1
+    state.annotation_count += 1
     annotations = pydot.Node(
-        f"ann{state.count[3]}", label="\n".join(ann_rows), **ANNOTATION_STYLE
+        f"ann{state.annotation_count}", label="\n".join(ann_rows), **ANNOTATION_STYLE
     )
     dot.add_node(annotations)
     dot.add_edge(pydot.Edge(annotations, node, **ANNOTATION_LINK_STYLE))
 
 
 def _add_bundle(
-    state: _DotRenderState, dot: pydot.Dot | pydot.Cluster, bundle: ProvBundle
+    state: _DotRenderState, dot: DotContainer, bundle: ProvBundle
 ) -> pydot.Cluster:
-    state.count[2] += 1
+    state.cluster_count += 1
     subdot = pydot.Cluster(
-        graph_name=f"c{state.count[2]}",
+        graph_name=f"c{state.cluster_count}",
         URL=f'"{bundle.identifier.uri}"',  # type: ignore[union-attr]
     )
     # set_label is generated at runtime by pydot via setattr() for
@@ -287,10 +292,10 @@ def _add_bundle(
 
 
 def _add_node(
-    state: _DotRenderState, dot: pydot.Dot | pydot.Cluster, record: ProvRecord
+    state: _DotRenderState, dot: DotContainer, record: ProvRecord
 ) -> pydot.Node:
-    state.count[0] += 1
-    node_id = f"n{state.count[0]}"
+    state.node_count += 1
+    node_id = f"n{state.node_count}"
     if state.use_labels:
         if record.label == record.identifier:
             node_label = f'"{record.label}"'
@@ -319,12 +324,12 @@ def _add_node(
 
 def _add_generic_node(
     state: _DotRenderState,
-    dot: pydot.Dot | pydot.Cluster,
+    dot: DotContainer,
     qname: QualifiedName,
     prov_type: type[ProvElement] | None = None,
 ) -> pydot.Node:
-    state.count[0] += 1
-    node_id = f"n{state.count[0]}"
+    state.node_count += 1
+    node_id = f"n{state.node_count}"
     node_label = f'"{qname}"'
 
     uri = qname.uri
@@ -335,9 +340,9 @@ def _add_generic_node(
     return node
 
 
-def _get_bnode(state: _DotRenderState, dot: pydot.Dot | pydot.Cluster) -> pydot.Node:
-    state.count[1] += 1
-    bnode_id = f"b{state.count[1]}"
+def _get_bnode(state: _DotRenderState, dot: DotContainer) -> pydot.Node:
+    state.bnode_count += 1
+    bnode_id = f"b{state.bnode_count}"
     bnode = pydot.Node(bnode_id, label='""', shape="point", color="gray")
     dot.add_node(bnode)
     return bnode
@@ -345,7 +350,7 @@ def _get_bnode(state: _DotRenderState, dot: pydot.Dot | pydot.Cluster) -> pydot.
 
 def _get_node(
     state: _DotRenderState,
-    dot: pydot.Dot | pydot.Cluster,
+    dot: DotContainer,
     qname: QualifiedName | None,
     prov_type: type[ProvElement] | None = None,
 ) -> pydot.Node:
@@ -359,7 +364,7 @@ def _get_node(
 
 def _draw_nary_or_annotated_relation(
     state: _DotRenderState,
-    dot: pydot.Dot | pydot.Cluster,
+    dot: DotContainer,
     rec: ProvRecord,
     formal: list[tuple[Any, Any, Any]],
     style: dict[str, Any],
@@ -404,9 +409,7 @@ def _draw_nary_or_annotated_relation(
         _attach_attribute_annotation(state, dot, bnode, rec)
 
 
-def _add_relation(
-    state: _DotRenderState, dot: pydot.Dot | pydot.Cluster, rec: ProvRecord
-) -> None:
+def _add_relation(state: _DotRenderState, dot: DotContainer, rec: ProvRecord) -> None:
     args = rec.args
     # skipping empty records
     if not args:
@@ -455,7 +458,7 @@ def _add_relation(
 
 
 def _bundle_to_dot(
-    state: _DotRenderState, dot: pydot.Dot | pydot.Cluster, bundle: ProvBundle
+    state: _DotRenderState, dot: DotContainer, bundle: ProvBundle
 ) -> None:
     records = bundle.get_records()
     relations = []


### PR DESCRIPTION
## Summary

A scoped quality pass over `src/prov/__init__.py` and `src/prov/dot.py`, immediately before the 3.0.0 release.

- `_detect_and_parse()`'s `document_cls` parameter is removed; the function does its own lazy `from prov.model import ProvDocument` instead, since it has exactly one call site and the target can never vary. `prov` and `prov.model` are circularly dependent, which is why this was threaded as a parameter in the first place; the lazy import preserves that.
- The `prov.model`-re-exported `PathLike` alias (`str | bytes | os.PathLike[str]`) replaces six spelled-out copies of that union across `_resolve_source`, `_prepare_stream`, `_detect_and_parse` and `read()`.
- `_DotRenderState`'s positionally-indexed `count: list[int]` becomes four named `int` fields — `node_count`, `bnode_count`, `cluster_count`, `annotation_count` — each read/increment site updated accordingly.
- A local `DotContainer: typing.TypeAlias = pydot.Dot | pydot.Cluster` alias replaces the same union spelled out across nine `dot.py` signatures. It stays local to `dot.py` since it's a pydot type behind the optional `dot` extra, not a shared PROV-model reference type, and uses the PEP 613 form (`X: TypeAlias = ...`), matching the rest of the codebase's alias-spelling convention.

All four changes are internal with no behavioural or public-API effect.

## Test plan

- [x] `uv run pytest -q` — 1391 passed, 24 skipped, 0 xfailed (unchanged from baseline)
- [x] `uv run pytest -q src/prov/tests/test_dot.py src/prov/tests/test_public_api.py src/prov/tests/test_minimal_install.py` — all pass, confirming `dot.py`/`graph.py` still raise `ModuleNotFoundError` naming the `dot`/`graph` extras when absent
- [x] `uv run ruff check src/` / `uv run ruff format --check src/` / `uv run mypy src` — all clean
- [x] Cold-start proof for the lazy import: a fresh interpreter importing `prov` first, confirming `prov.model` is not yet in `sys.modules`, then exercising both the explicit-format and auto-detecting `read()` paths successfully
- [x] Byte-parity harness (`parity_capture.py`, `PYTHONHASHSEED=0` pinned both sides) — `diff -ru` between base and branch captures is empty across all 40 artefacts, including the `dot` leg for all 8 canonical documents, confirming the counter rename doesn't renumber any node
- [x] `uv run --group docs ... sphinx-build -b html docs docs/_build/html` — builds with 0 warnings
- [x] `uvx lizard -C 15 src/prov/` — still exactly 2 warnings, both test-only (tracked as #336)
- [x] `uvx pyright` — 11 errors, 15 warnings (unchanged from the `alias-pep613` baseline); `grep -rn "# type: typing.TypeAlias" src/` returns nothing