### PR TITLE
Convert legacy # type: variable comments to PEP 526 annotations

### DIFF
--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -66,7 +66,7 @@ __email__ = "trungdong@donggiang.com"
 
 # Visual styles for various elements (nodes) and relations (edges)
 # see http://graphviz.org/content/attrs
-GENERIC_NODE_STYLE = {
+GENERIC_NODE_STYLE: dict[type[ProvElement | ProvBundle] | None, dict[str, Any]] = {
     None: {
         "shape": "oval",
         "style": "filled",
@@ -97,7 +97,7 @@ GENERIC_NODE_STYLE = {
         "fillcolor": "lightgray",
         "color": "dimgray",
     },
-}  # type: dict[type[ProvElement | ProvBundle] | None, dict[str, Any]]
+}
 # Value type is widened to Any (rather than str) because mypy treats a
 # dict[str, str] unpacked via `**style` as needing to satisfy *every*
 # named parameter pydot.Node/Edge/Cluster declare (e.g. `obj_dict`), not

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -327,12 +327,12 @@ class ProvBundle:
         """
         #  Initializing bundle-specific attributes
         self._identifier = identifier
-        self._records = []  # type: list[ProvRecord]
-        self._id_map = defaultdict(list)  # type: dict[QualifiedName, list[ProvRecord]]
+        self._records: list[ProvRecord] = []
+        self._id_map: dict[QualifiedName, list[ProvRecord]] = defaultdict(list)
         self._document = document
-        self._namespaces = NamespaceManager(
+        self._namespaces: NamespaceManager = NamespaceManager(
             namespaces, parent=(document._namespaces if document is not None else None)
-        )  # type: NamespaceManager
+        )
         if records:
             for record in records:
                 self.add_record(record)
@@ -773,10 +773,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvActivity`.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_STARTTIME: _ensure_datetime(startTime),
             PROV_ATTR_ENDTIME: _ensure_datetime(endTime),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_ACTIVITY,
             identifier,
@@ -809,11 +809,11 @@ class ProvBundle:
         Returns:
             The new generation record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ENTITY: entity,
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_TIME: _ensure_datetime(time),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_GENERATION,
             identifier,
@@ -847,11 +847,11 @@ class ProvBundle:
         Returns:
             The new :class:`ProvUsage` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_ENTITY: entity,
             PROV_ATTR_TIME: _ensure_datetime(time),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_USAGE,
             identifier,
@@ -888,12 +888,12 @@ class ProvBundle:
         Returns:
             The new :class:`ProvStart` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_TRIGGER: trigger,
             PROV_ATTR_STARTER: starter,
             PROV_ATTR_TIME: _ensure_datetime(time),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_START,
             identifier,
@@ -929,12 +929,12 @@ class ProvBundle:
         Returns:
             The new :class:`ProvEnd` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_TRIGGER: trigger,
             PROV_ATTR_ENDER: ender,
             PROV_ATTR_TIME: _ensure_datetime(time),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_END,
             identifier,
@@ -967,11 +967,11 @@ class ProvBundle:
         Returns:
             The new :class:`ProvInvalidation` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ENTITY: entity,
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_TIME: _ensure_datetime(time),
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_INVALIDATION,
             identifier,
@@ -999,10 +999,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvCommunication` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_INFORMED: informed,
             PROV_ATTR_INFORMANT: informant,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_COMMUNICATION,
             identifier,
@@ -1049,10 +1049,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvAttribution` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ENTITY: entity,
             PROV_ATTR_AGENT: agent,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_ATTRIBUTION,
             identifier,
@@ -1084,11 +1084,11 @@ class ProvBundle:
         Returns:
             The new :class:`ProvAssociation` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_AGENT: agent,
             PROV_ATTR_PLAN: plan,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_ASSOCIATION,
             identifier,
@@ -1121,11 +1121,11 @@ class ProvBundle:
         Returns:
             The new :class:`ProvDelegation` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_DELEGATE: delegate,
             PROV_ATTR_RESPONSIBLE: responsible,
             PROV_ATTR_ACTIVITY: activity,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_DELEGATION,
             identifier,
@@ -1155,10 +1155,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvInfluence` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_INFLUENCEE: influencee,
             PROV_ATTR_INFLUENCER: influencer,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_INFLUENCE,
             identifier,
@@ -1198,13 +1198,13 @@ class ProvBundle:
         Returns:
             The new :class:`ProvDerivation` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_GENERATED_ENTITY: generatedEntity,
             PROV_ATTR_USED_ENTITY: usedEntity,
             PROV_ATTR_ACTIVITY: activity,
             PROV_ATTR_GENERATION: generation,
             PROV_ATTR_USAGE: usage,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_DERIVATION, identifier, attributes, other_attributes
         )  # type: ignore
@@ -1360,10 +1360,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvSpecialization` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_SPECIFIC_ENTITY: specificEntity,
             PROV_ATTR_GENERAL_ENTITY: generalEntity,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_SPECIALIZATION,
             None,
@@ -1382,10 +1382,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvAlternate` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_ALTERNATE1: alternate1,
             PROV_ATTR_ALTERNATE2: alternate2,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_ALTERNATE,
             None,
@@ -1408,11 +1408,11 @@ class ProvBundle:
         Returns:
             The new :class:`ProvMention` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_SPECIFIC_ENTITY: specificEntity,
             PROV_ATTR_GENERAL_ENTITY: generalEntity,
             PROV_ATTR_BUNDLE: bundle,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_MENTION,
             None,
@@ -1452,10 +1452,10 @@ class ProvBundle:
         Returns:
             The new :class:`ProvMembership` record.
         """
-        attributes = {
+        attributes: dict[QualifiedNameCandidate, Any] = {
             PROV_ATTR_COLLECTION: collection,
             PROV_ATTR_ENTITY: entity,
-        }  # type: dict[QualifiedNameCandidate, Any]
+        }
         return self.new_record(
             PROV_MEMBERSHIP,
             None,
@@ -1588,7 +1588,7 @@ class ProvDocument(ProvBundle):
         ProvBundle.__init__(
             self, records=records, identifier=None, namespaces=namespaces
         )
-        self._bundles = {}  # type: dict[QualifiedName, ProvBundle]
+        self._bundles: dict[QualifiedName, ProvBundle] = {}
 
     def __repr__(self) -> str:
         return "<ProvDocument>"

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -14,7 +14,7 @@ DEFAULT_NAMESPACES = {"prov": PROV, "xsd": XSD, "xsi": XSI}
 class NamespaceManager(dict[str, Namespace]):
     """Manages namespaces for PROV documents and bundles."""
 
-    parent = None  # type: NamespaceManager | None
+    parent: NamespaceManager | None = None
     """Parent :class:`NamespaceManager` this manager is a child of, if any."""
 
     def __init__(
@@ -36,18 +36,18 @@ class NamespaceManager(dict[str, Namespace]):
         dict.__init__(self)
         self._default_namespaces = DEFAULT_NAMESPACES
         self.update(self._default_namespaces)
-        self._namespaces = {}  # type: dict[str, Namespace]
+        self._namespaces: dict[str, Namespace] = {}
 
         if default is not None:
             self.set_default_namespace(default)
         else:
-            self._default = None  # type: Namespace | None
+            self._default: Namespace | None = None
         self.parent = parent
         #  TODO check if default is in the default namespaces
         self._anon_id_count = 0
-        self._uri_map = {}  # type: dict[str, Namespace]
-        self._rename_map = {}  # type: dict[Namespace, Namespace]
-        self._prefix_renamed_map = {}  # type: dict[str, Namespace]
+        self._uri_map: dict[str, Namespace] = {}
+        self._rename_map: dict[Namespace, Namespace] = {}
+        self._prefix_renamed_map: dict[str, Namespace] = {}
         if namespaces is not None:
             self.add_namespaces(namespaces)
 

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -560,7 +560,7 @@ class ProvElementIdentifierRequired(ProvException):
 class ProvRecord:
     """Base class for PROV records."""
 
-    FORMAL_ATTRIBUTES = ()  # type: tuple[QualifiedName, ...]
+    FORMAL_ATTRIBUTES: tuple[QualifiedName, ...] = ()
     """Formal attributes names of this record type, in the expected order."""
 
     _prov_type: QualifiedName | None = None
@@ -1637,10 +1637,10 @@ class ProvInfluence(ProvRelation):
 class ProvSpecialization(ProvRelation):
     """Provenance Specialization relationship."""
 
-    FORMAL_ATTRIBUTES = (
+    FORMAL_ATTRIBUTES: tuple[QualifiedName, ...] = (
         PROV_ATTR_SPECIFIC_ENTITY,
         PROV_ATTR_GENERAL_ENTITY,
-    )  # type: tuple[QualifiedName, ...]
+    )
 
     _prov_type = PROV_SPECIALIZATION
 

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -40,8 +40,8 @@ class AnonymousIDGenerator:
     """Assigns and caches stable blank-node identifiers for unidentified records."""
 
     def __init__(self) -> None:
-        self._cache = {}  # type: dict[ProvRecord, Identifier]
-        self._count = 0  # type: int
+        self._cache: dict[ProvRecord, Identifier] = {}
+        self._count: int = 0
 
     def get_anon_id(self, obj: ProvRecord, local_prefix: str = "id") -> Identifier:
         """Return a blank-node :class:`~prov.identifier.Identifier` for a record.
@@ -206,8 +206,8 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
         and one entry per PROV-N record-type keyword, each mapping record
         identifiers (real or anonymous) to their encoded attributes.
     """
-    container = defaultdict(dict)  # type: dict[str, dict[str, Any]]
-    prefixes = {}  # type: dict[str, str]
+    container: dict[str, dict[str, Any]] = defaultdict(dict)
+    prefixes: dict[str, str] = {}
     for namespace in bundle._namespaces.get_registered_namespaces():
         prefixes[namespace.prefix] = namespace.uri
     if bundle._namespaces._default:
@@ -225,7 +225,7 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
         rec_label = PROV_N_MAP[rec_type]
         identifier = str(real_or_anon_id(record))
 
-        record_json = {}  # type: dict[str, Any]
+        record_json: dict[str, Any] = {}
         if record._attributes:
             for attr, values in record._attributes.items():
                 if not values:
@@ -465,16 +465,16 @@ def _decode_record_instance(
             formal attribute has more than one value, other than the
             documented multi-entity ``hadMember`` (membership) hack.
     """
-    attributes = {}  # type: dict[QualifiedNameCandidate, Any]
+    attributes: dict[QualifiedNameCandidate, Any] = {}
     other_attributes: list[AttributePair] = []
     # this is for the multiple-entity membership hack to come
     membership_extra_members = None
     for attr_name, values in element.items():
-        attr = (
+        attr: QualifiedName = (
             PROV_ATTRIBUTES_ID_MAP[attr_name]
             if attr_name in PROV_ATTRIBUTES_ID_MAP
             else bundle.mandatory_valid_qname(attr_name)
-        )  # type: QualifiedName
+        )
         if attr in PROV_ATTRIBUTES:
             value, extra_members = _decode_formal_attribute(
                 rec_type, attr, values, bundle
@@ -636,7 +636,7 @@ def decode_json_representation(
                 f"The typed-literal representation for {where} is missing "
                 f'its required "$" (value) key; found {literal!r}'
             ) from exc
-        datatype_str = literal.get("type", None)  # type: str | None
+        datatype_str: str | None = literal.get("type", None)
         datatype = valid_qualified_name(bundle, datatype_str)
         langtag = literal.get("lang", None)
         if datatype == XSD_ANYURI:

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -74,8 +74,8 @@ class AnonymousIDGenerator:
     """Assigns and caches stable blank-node identifier strings for unidentified records."""
 
     def __init__(self) -> None:
-        self._cache = {}  # type: dict[Any, str]
-        self._count = 0  # type: int
+        self._cache: dict[Any, str] = {}
+        self._count: int = 0
 
     def get_anon_id(self, obj: pm.ProvRecord, local_prefix: str = "id") -> str:
         """Return a blank-node identifier string (``"_:<local_prefix><n>"``) for a record.

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -177,10 +177,10 @@ class ProvXMLSerializer(Serializer):
         Returns:
             A prefix-to-URI mapping suitable for lxml's ``nsmap`` argument.
         """
-        nsmap = {
+        nsmap: dict[str, str] = {
             ns.prefix: ns.uri
             for ns in self.document._namespaces.get_registered_namespaces()  # type: ignore[union-attr]
-        }  # type: dict[str, str]
+        }
         if self.document._namespaces._default:  # type: ignore[union-attr]
             # TODO: Check if the below works as expected.
             nsmap[None] = self.document._namespaces._default.uri  # type: ignore[union-attr, index]
@@ -246,7 +246,7 @@ class ProvXMLSerializer(Serializer):
             with io.BytesIO() as buf:
                 buf.write(stream.read().encode("utf-8"))
                 buf.seek(0, 0)
-                xml_doc = etree.parse(buf, parser=_XML_PARSER).getroot()  # type: etree._Element
+                xml_doc: etree._Element = etree.parse(buf, parser=_XML_PARSER).getroot()
         else:
             xml_doc = etree.parse(stream, parser=_XML_PARSER).getroot()  # type: ignore[arg-type]
 
@@ -587,7 +587,7 @@ def _extract_attributes(
             none of them is ``prov:ref``, ``xsi:type``, or ``xml:lang``, so
             no attribute value can be determined.
     """
-    attributes = []  # type: list[NameValuePair]
+    attributes: list[NameValuePair] = []
     _unassigned = object()
     for subel in element:
         sqname = etree.QName(subel)


### PR DESCRIPTION
## Summary
Every legacy `x = value  # type: T` variable comment in `src/prov/` becomes a real `x: T = value` PEP 526 annotation, completing the modernisation that #348 deliberately left out (that PR covered only type alias definitions).
Two sites are class-level attribute declarations (`records.py`'s `FORMAL_ATTRIBUTES`, `namespaces.py`'s `parent`) rather than locals; these become class-level annotations and keep their assigned defaults.
Annotation-form only: no behaviour, signature, or public-surface change of any kind.

## Test plan
- [x] `uv run pytest -q` — 1391 passed, 24 skipped, 0 xfailed (unchanged)
- [x] `uv run mypy src` — clean before and after (0 errors)
- [x] `uvx pyright` — 11 errors / 15 warnings before and after (unchanged)
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` — clean
- [x] `uv run python -c "import prov.model; print(len(dir(prov.model)))"` — 175 before and after (unchanged)
- [x] Parity harness (40 artefacts across 8 documents × json/xml/rdf/provn/dot) diff-clean with `PYTHONHASHSEED=0` pinned on both runs