### PR TITLE
Narrow Optional and dict/tuple ambiguity for pyright across model and PROV-XML

### DIFF
--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -698,13 +698,15 @@ class ProvBundle:
         attr_list: list[AttributePair] = []
         if attributes:
             if isinstance(attributes, dict):
-                attr_list.extend((attr, value) for attr, value in attributes.items())
+                attr_list.extend(
+                    cast("dict[QualifiedNameCandidate, Any]", attributes).items()
+                )
             else:
                 # expecting a list of attributes here
                 attr_list.extend(attributes)
         if other_attributes:
             attr_list.extend(
-                other_attributes.items()
+                cast("dict[QualifiedNameCandidate, Any]", other_attributes).items()
                 if isinstance(other_attributes, dict)
                 else other_attributes
             )
@@ -1705,8 +1707,8 @@ class ProvDocument(ProvBundle):
                         bundle_id is None
                     ):  # pragma: no cover -- bundles are always named
                         raise AssertionError("bundle has no identifier")
-                    if bundle.identifier in self._bundles:
-                        self._bundles[bundle.identifier].update(bundle)
+                    if bundle_id in self._bundles:
+                        self._bundles[bundle_id].update(bundle)
                     else:
                         new_bundle = self.bundle(bundle_id)
                         new_bundle.update(bundle)

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations  # defer eval: NamespaceManager self-refs in __init__
 
 from collections.abc import Iterable
+from typing import cast
 
 from prov.constants import PROV, XSD, XSI
 from prov.identifier import Identifier, Namespace, QualifiedName
@@ -148,7 +149,10 @@ class NamespaceManager(dict[str, Namespace]):
         if isinstance(namespaces, dict):
             # expecting a dictionary of {prefix: uri},
             # convert it to a list of Namespace
-            namespaces = [Namespace(prefix, uri) for prefix, uri in namespaces.items()]
+            namespaces = [
+                Namespace(prefix, uri)
+                for prefix, uri in cast("dict[str, str]", namespaces).items()
+            ]
         if namespaces:
             for ns in namespaces:
                 self.add_namespace(ns)
@@ -211,13 +215,13 @@ class NamespaceManager(dict[str, Namespace]):
         local_part = qname.localpart
         if not prefix:
             # the namespace is a default namespace
-            if self._default == namespace:
-                # the same default namespace is defined
-                new_qname = self._default[local_part]
-            elif self._default is None:
+            if self._default is None:
                 # no default namespace is defined, reused the one given
                 self._default = namespace
                 return qname  # no change, return the original
+            elif self._default == namespace:
+                # the same default namespace is defined
+                new_qname = self._default[local_part]
             else:
                 # different default namespace,
                 # use the 'dn' prefix for the new namespace

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -10,7 +10,7 @@ import re
 import typing
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, MutableSet
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from prov import Error
 from prov.constants import (
@@ -903,7 +903,9 @@ class ProvRecord:
             if isinstance(attributes, dict):
                 # Converting the dictionary into a list of tuples
                 # (i.e. attribute-value pairs)
-                attributes = attributes.items()
+                attributes = cast(
+                    "dict[QualifiedNameCandidate, Any]", attributes
+                ).items()
 
             # Check if one of the attributes specifies that the current type
             # is a collection. In that case multiple attributes of the same

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from lxml import etree
 
-import prov
 import prov.identifier
+import prov.model
 from prov.constants import *
 from prov.model import (
     DEFAULT_NAMESPACES,
@@ -374,6 +374,8 @@ class ProvXMLSerializer(Serializer):
                 continue
             if isinstance(value, prov.model.Literal):
                 value = value.value
+            if not isinstance(value, prov.identifier.QualifiedName):
+                continue
             if value in PROV_BASE_CLS and PROV_BASE_CLS[value] != value:
                 attributes.remove((key, value))
                 rec_label = FULL_NAMES_MAP[value]


### PR DESCRIPTION
## Summary

Pyright currently reports 11 errors and 15 warnings across the model package and the PROV-XML serializer; this brings that down to the two diagnostics that are deliberate survivors (an `open()` call after a `hasattr` duck-typing check, and `__all__` listing the lazily-imported `model` submodule). `uv run mypy src` stays clean throughout, and every change is a type-checker-visible clarification of existing logic, not a behaviour change.

- Reorders the default-namespace arms in `NamespaceManager._reconcile_qualified_name` so the `is None` check comes first; the previous order relied on `==` to narrow an `Optional`, which pyright (correctly) doesn't do. The equality arm that reuses the existing default namespace is preserved, just reordered.
- Adds explicit `cast`s on the dict-shaped branches of `add_namespaces`, `add_attributes`, and `new_record`, where a dict literal is structurally ambiguous between the mapping arm and the `(name, value)`-pairs iterable arm of its declared union parameter type.
- Uses the already-narrowed `bundle_id` local in `ProvDocument.update()` instead of re-reading `bundle.identifier`, which discarded the narrowing pyright had just proven.
- Imports `prov.model` directly in `provxml.py` instead of relying on it becoming available as a side effect of a later `from prov.model import (...)` line.
- Adds an `isinstance` guard before indexing `PROV_BASE_CLS` with a value that PROV-XML's `Literal`-unwrapping step may have turned into a plain `str`. `PROV_BASE_CLS` is keyed exclusively by `QualifiedName`, and `QualifiedName`/`Identifier.__eq__` explicitly returns `False` for non-`Identifier` operands, so this path was already unreachable for `str` values — the guard just makes that provable to a type checker instead of relying on it.

## Test plan

- [x] `uv run pytest -q` — 1391 passed, 24 skipped, 0 xfailed (unchanged)
- [x] `uv run mypy src` — clean, no new `type: ignore`, no `redundant-cast`
- [x] `uvx pyright` — 1 error, 1 warning (down from 11 errors, 15 warnings), both are the pre-existing deliberate survivors
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` — clean
- [x] Byte-for-byte serializer parity harness (PROV-JSON/XML/RDF, `PYTHONHASHSEED=0` pinned) — diff-clean across all 40 artefacts