### PR TITLE
Make prov.read() load serializers conditionally

### DIFF
--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -180,7 +180,8 @@ def read(
     from prov.model import ProvDocument
     from prov.serializers import Registry
 
-    Registry.load_serializers()
+    if Registry.serializers is None:
+        Registry.load_serializers()
     if Registry.serializers is None:  # pragma: no cover -- populated above
         raise AssertionError("Registry.serializers is not populated")
     serializers = Registry.serializers.keys()

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -99,11 +99,11 @@ class Registry:
         The insertion order is kept as ``json, rdf, provn, xml`` (the
         historic order when all extras are present) because
         :func:`prov.read`'s format auto-detection iterates
-        ``Registry.serializers`` in order and several tests
-        (``test_read_auto_detects_rdf``,
-        ``test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error``,
-        ``test_read_on_unparseable_content_raises_bad_syntax``) pin the
-        exact candidate tried second.
+        ``Registry.serializers`` in order and
+        ``test_read_auto_detect_with_broken_tell_degrades_to_no_rewind``
+        pins JSON as the first candidate tried — a non-seekable stream can
+        only attempt the first format, so JSON must remain first for JSON
+        content to be auto-detected on broken streams.
         """
         from prov.serializers.provjson import ProvJSONSerializer
         from prov.serializers.provn import ProvNSerializer

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -325,6 +325,26 @@ def test_get_serializer_lazily_populates_registry():
         Registry.serializers = original
 
 
+def test_read_lazily_populates_registry():
+    import prov
+
+    # Build the serialized content BEFORE resetting the registry, so the
+    # serialize() call doesn't populate it via prov.serializers.get()
+    json_content = primer_example().serialize(format="json")
+
+    original = Registry.serializers
+    Registry.serializers = None
+    try:
+        assert Registry.serializers is None
+        # Now call read() with pre-built content, with the registry uninitialized
+        document = prov.read(json_content)
+        assert Registry.serializers is not None
+        assert set(Registry.serializers.keys()) == {"json", "rdf", "provn", "xml"}
+        assert document is not None
+    finally:
+        Registry.serializers = original
+
+
 def test_plot_without_matplotlib_raises_helpful_error():
     # plot()'s interactive path renders through prov.dot before it ever gets
     # to the matplotlib check, so this test's premise (pydot present,


### PR DESCRIPTION
Make prov.read() load serializers conditionally, adopting the same cheaper guard that prov.serializers.get() uses instead of always repopulating the Registry on every auto-detect path.

The conditional load pattern eliminates unnecessary re-execution of the optional-dependency import blocks on repeated read() calls. Registry.load_serializers() itself is unchanged and maintains the insertion order of json, rdf, provn, xml; JSON must remain first because test_read_auto_detect_with_broken_tell_degrades_to_no_rewind requires it for non-seekable streams to detect JSON content.

Adds test_read_lazily_populates_registry, which pre-builds its serialized payload before resetting Registry.serializers to None so that read() itself exercises the conditional-load branch, and restores the registry in a finally block.