### PR TITLE
Freeze prov.model's dir() surface with a checked-in snapshot test

### DIFF
--- a/src/prov/tests/test_public_api.py
+++ b/src/prov/tests/test_public_api.py
@@ -113,12 +113,19 @@ OPTIONAL_MODULE_REQUIREMENTS = {
 }
 
 
-# Exact snapshot of sorted(dir(prov.model)), generated at commit
-# dccff00217b745a8107379742a7157366703b5bd (177 names). Unlike PUBLIC_API
-# above, this is not curated -- it is every name the module exports,
-# including dunders, re-exported stdlib/typing imports, and internal
-# constants, because the freeze in prov/model/__init__.py applies to all
-# of them.
+# Exact snapshot of the non-dunder names in sorted(dir(prov.model)),
+# generated at commit dccff00217b745a8107379742a7157366703b5bd (166 names).
+# Unlike PUBLIC_API above, this is not curated -- it is every non-dunder
+# name the module exports, including re-exported stdlib/typing imports and
+# internal constants, because the freeze in prov/model/__init__.py applies
+# to all of them.
+#
+# Dunder names (__author__, __file__, __loader__, ...) are excluded: some
+# are CPython import-machinery details (__cached__, __file__, __loader__,
+# __path__, __spec__) that can legitimately vary or go missing under a
+# frozen build, zipapp, or non-standard loader, and asserting on them would
+# misdirect a future contributor toward "fix the code" when the real cause
+# is the install mechanism.
 #
 # If this test fails:
 # - an *added* name from an intentional change (new alias, new constant,
@@ -275,17 +282,6 @@ PROV_MODEL_DIR_SNAPSHOT = [
     "XSD_UNSIGNEDLONG",
     "XSD_UNSIGNEDSHORT",
     "XSI",
-    "__author__",
-    "__builtins__",
-    "__cached__",
-    "__doc__",
-    "__email__",
-    "__file__",
-    "__loader__",
-    "__name__",
-    "__package__",
-    "__path__",
-    "__spec__",
     "canonical_xsd_datatype",
     "datetime",
     "defaultdict",
@@ -309,7 +305,11 @@ PROV_MODEL_DIR_SNAPSHOT = [
 
 
 def test_prov_model_namespace_snapshot():
-    actual = sorted(dir(prov.model))
+    actual = sorted(
+        name
+        for name in dir(prov.model)
+        if not (name.startswith("__") and name.endswith("__"))
+    )
     expected = sorted(PROV_MODEL_DIR_SNAPSHOT)
     added = sorted(set(actual) - set(expected))
     removed = sorted(set(expected) - set(actual))

--- a/src/prov/tests/test_public_api.py
+++ b/src/prov/tests/test_public_api.py
@@ -1,13 +1,24 @@
 """Guards the public API surface for the 2.x line.
 
-Every name listed here must remain importable from its historic location.
-Additions are fine; removals or moves are a breaking change (3.0 only).
+Two different questions are answered here:
+
+- ``test_names_importable`` checks *intent*: a curated allowlist of the names
+  that are load-bearing public API and must stay importable from their
+  historic location. It is deliberately incomplete -- it does not enumerate
+  everything ``prov.model`` exports.
+- ``test_prov_model_namespace_snapshot`` checks *fact*: exactly what
+  ``dir(prov.model)`` exports today, compared against a checked-in list.
+  ``prov/model/__init__.py`` re-exports every public name at its historic
+  ``prov.model`` location and then deletes the submodule attributes,
+  deliberately freezing ``dir(prov.model)`` to the pre-split namespace; this
+  test is what actually holds that freeze in place.
 """
 
 import importlib
 import importlib.util
 import io
 
+import prov.model
 import prov.serializers
 from prov.model import ProvDocument
 from prov.tests.examples import primer_example
@@ -100,6 +111,212 @@ OPTIONAL_MODULE_REQUIREMENTS = {
     "prov.dot": "pydot",
     "prov.graph": "networkx",
 }
+
+
+# Exact snapshot of sorted(dir(prov.model)), generated at commit
+# dccff00217b745a8107379742a7157366703b5bd (177 names). Unlike PUBLIC_API
+# above, this is not curated -- it is every name the module exports,
+# including dunders, re-exported stdlib/typing imports, and internal
+# constants, because the freeze in prov/model/__init__.py applies to all
+# of them.
+#
+# If this test fails:
+# - an *added* name from an intentional change (new alias, new constant,
+#   ...) means updating this list in the same PR;
+# - a *removed* or *renamed* name is a breaking change to a namespace that
+#   is deliberately frozen -- do not "fix" the test to match, fix the code
+#   (or, if the removal is genuinely intended, that decision belongs in the
+#   PR description, not a silent test edit).
+PROV_MODEL_DIR_SNAPSHOT = [
+    "ADDITIONAL_N_MAP",
+    "ActivityRef",
+    "AgentRef",
+    "Any",
+    "AttributePair",
+    "Callable",
+    "DATATYPE_PARSERS",
+    "DEFAULT_NAMESPACES",
+    "DatetimeOrStr",
+    "EntityRef",
+    "Error",
+    "GenerationRef",
+    "IOBase",
+    "Identifier",
+    "InfluencerRef",
+    "Iterable",
+    "Literal",
+    "NSCollection",
+    "NameValuePair",
+    "Namespace",
+    "NamespaceManager",
+    "OptionalID",
+    "PROV",
+    "PROV_ACTIVITY",
+    "PROV_AGENT",
+    "PROV_ALTERNATE",
+    "PROV_ASSOCIATION",
+    "PROV_ATTRIBUTES",
+    "PROV_ATTRIBUTES_ID_MAP",
+    "PROV_ATTRIBUTE_LITERALS",
+    "PROV_ATTRIBUTE_QNAMES",
+    "PROV_ATTRIBUTION",
+    "PROV_ATTR_ACTIVITY",
+    "PROV_ATTR_AGENT",
+    "PROV_ATTR_ALTERNATE1",
+    "PROV_ATTR_ALTERNATE2",
+    "PROV_ATTR_BUNDLE",
+    "PROV_ATTR_COLLECTION",
+    "PROV_ATTR_DELEGATE",
+    "PROV_ATTR_ENDER",
+    "PROV_ATTR_ENDTIME",
+    "PROV_ATTR_ENTITY",
+    "PROV_ATTR_GENERAL_ENTITY",
+    "PROV_ATTR_GENERATED_ENTITY",
+    "PROV_ATTR_GENERATION",
+    "PROV_ATTR_INFLUENCEE",
+    "PROV_ATTR_INFLUENCER",
+    "PROV_ATTR_INFORMANT",
+    "PROV_ATTR_INFORMED",
+    "PROV_ATTR_PLAN",
+    "PROV_ATTR_RESPONSIBLE",
+    "PROV_ATTR_SPECIFIC_ENTITY",
+    "PROV_ATTR_STARTER",
+    "PROV_ATTR_STARTTIME",
+    "PROV_ATTR_TIME",
+    "PROV_ATTR_TRIGGER",
+    "PROV_ATTR_USAGE",
+    "PROV_ATTR_USED_ENTITY",
+    "PROV_BASE_CLS",
+    "PROV_BUNDLE",
+    "PROV_COMMUNICATION",
+    "PROV_DELEGATION",
+    "PROV_DERIVATION",
+    "PROV_END",
+    "PROV_ENTITY",
+    "PROV_GENERATION",
+    "PROV_ID_ATTRIBUTES_MAP",
+    "PROV_INFLUENCE",
+    "PROV_INTERNATIONALIZEDSTRING",
+    "PROV_INVALIDATION",
+    "PROV_LABEL",
+    "PROV_LOCATION",
+    "PROV_MEMBERSHIP",
+    "PROV_MENTION",
+    "PROV_N_MAP",
+    "PROV_QUALIFIEDNAME",
+    "PROV_RECORD_ATTRIBUTES",
+    "PROV_RECORD_IDS_MAP",
+    "PROV_REC_CLS",
+    "PROV_ROLE",
+    "PROV_SPECIALIZATION",
+    "PROV_START",
+    "PROV_TYPE",
+    "PROV_USAGE",
+    "PROV_VALUE",
+    "PathLike",
+    "ProvActivity",
+    "ProvAgent",
+    "ProvAlternate",
+    "ProvAssociation",
+    "ProvAttribution",
+    "ProvBundle",
+    "ProvCommunication",
+    "ProvDelegation",
+    "ProvDerivation",
+    "ProvDocument",
+    "ProvElement",
+    "ProvElementIdentifierRequired",
+    "ProvEnd",
+    "ProvEntity",
+    "ProvException",
+    "ProvExceptionInvalidQualifiedName",
+    "ProvGeneration",
+    "ProvInfluence",
+    "ProvInvalidation",
+    "ProvMembership",
+    "ProvMention",
+    "ProvRecord",
+    "ProvRelation",
+    "ProvSpecialization",
+    "ProvStart",
+    "ProvUnificationError",
+    "ProvUsage",
+    "ProvWarning",
+    "QualifiedName",
+    "QualifiedNameCandidate",
+    "RecordAttributesArg",
+    "StreamOrPath",
+    "SupportedXSDParsedTypes",
+    "Union",
+    "UsageRef",
+    "XSD",
+    "XSD_ANYURI",
+    "XSD_BOOLEAN",
+    "XSD_BYTE",
+    "XSD_DATATYPE_PARSERS",
+    "XSD_DATE",
+    "XSD_DATETIME",
+    "XSD_DECIMAL",
+    "XSD_DOUBLE",
+    "XSD_FLOAT",
+    "XSD_INT",
+    "XSD_INTEGER",
+    "XSD_LONG",
+    "XSD_NEGATIVEINTEGER",
+    "XSD_NONNEGATIVEINTEGER",
+    "XSD_NONPOSITIVEINTEGER",
+    "XSD_POSITIVEINTEGER",
+    "XSD_QNAME",
+    "XSD_SHORT",
+    "XSD_STRING",
+    "XSD_TIME",
+    "XSD_UNSIGNEDBYTE",
+    "XSD_UNSIGNEDINT",
+    "XSD_UNSIGNEDLONG",
+    "XSD_UNSIGNEDSHORT",
+    "XSI",
+    "__author__",
+    "__builtins__",
+    "__cached__",
+    "__doc__",
+    "__email__",
+    "__file__",
+    "__loader__",
+    "__name__",
+    "__package__",
+    "__path__",
+    "__spec__",
+    "canonical_xsd_datatype",
+    "datetime",
+    "defaultdict",
+    "encoding_provn_value",
+    "first",
+    "io",
+    "itertools",
+    "logger",
+    "logging",
+    "os",
+    "parse_boolean",
+    "parse_xsd_datetime",
+    "parse_xsd_types",
+    "serializers",
+    "shutil",
+    "sorted_attributes",
+    "tempfile",
+    "typing",
+    "urlparse",
+]
+
+
+def test_prov_model_namespace_snapshot():
+    actual = sorted(dir(prov.model))
+    expected = sorted(PROV_MODEL_DIR_SNAPSHOT)
+    added = sorted(set(actual) - set(expected))
+    removed = sorted(set(expected) - set(actual))
+    assert not added and not removed, (
+        f"prov.model namespace drifted from the checked-in snapshot: "
+        f"added={added!r} removed={removed!r}"
+    )
 
 
 def test_names_importable():


### PR DESCRIPTION
## Summary

prov/model/__init__.py re-exports every public name at its historic prov.model location and then deletes the submodule attributes, deliberately freezing dir(prov.model) to the pre-split namespace, but nothing asserted that.

test_names_importable only checks a curated allowlist of load-bearing names via hasattr, so it would not have caught a rename or the accidental removal of an alias absent from its list.

This adds test_prov_model_namespace_snapshot, which compares the non-dunder names in sorted(dir(prov.model)) against a checked-in list of the 166 names currently exported and reports added/removed names separately on mismatch, so a future diff is readable instead of an opaque list-equality failure.

Import-machinery dunders (__cached__, __file__, __loader__, __path__, __spec__, and friends) are excluded from the comparison: they are CPython implementation details that can legitimately vary or go missing under a frozen build, zipapp, or non-standard loader, and asserting on them would misdirect a future contributor toward "fix the code" when the real cause is the install mechanism. The frozen surface still legitimately includes incidental standard-library names visible on the module (shutil, tempfile, typing, urlparse, serializers, and similar) alongside the deliberate public API — those are deterministic facts about the source tree, unlike the loader dunders, so they stay in the snapshot.

The existing test_names_importable allowlist is unchanged; the module docstring explains that it documents intent (load-bearing public API) while the new snapshot documents fact (what is actually exported).

## Test plan

- [x] `uv run pytest -q` — 1393 passed, 24 skipped, 0 xfailed (was 1392 passed before this change; one new test)
- [x] `uv run pytest -q src/prov/tests/test_public_api.py -v` on the default interpreter and on `--python 3.10` — both 4 passed
- [x] New test passes in a minimal install (no rdf/xml/dot/graph extras); test module does not import prov.dot or prov.graph
- [x] Regression demonstrated: renaming an import alias in prov/model/__init__.py made the new test fail with a readable `added=[...] removed=[...]` message; reverted and confirmed the tree is clean
- [x] `uv run mypy src` clean
- [x] `uvx pyright` unchanged at 1 error, 1 warning (both pre-existing and deliberate)
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` clean
