### PR TITLE
Support security fixes for the 2.x line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Introduction
 
 [![Latest Release](https://badge.fury.io/py/prov.svg)](http://badge.fury.io/py/prov)
+[![License](https://img.shields.io/pypi/l/prov.svg)](https://pypi.python.org/pypi/prov/)
 [![CI Status](https://github.com/trungdong/prov/workflows/CI/badge.svg)](https://github.com/trungdong/prov/actions?workflow=CI)
 [![Coverage Status](https://img.shields.io/coveralls/trungdong/prov.svg)](https://coveralls.io/r/trungdong/prov?branch=master)
-[![Wheel Status](https://img.shields.io/pypi/wheel/prov.svg)](https://pypi.python.org/pypi/prov/)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/73bdf6dda3884abf9f5e79352c07e66c)](https://app.codacy.com/gh/trungdong/prov/dashboard)
 [![Supported Python version](https://img.shields.io/pypi/pyversions/prov.svg)](https://pypi.python.org/pypi/prov/)
-[![License](https://img.shields.io/pypi/l/prov.svg)](https://pypi.python.org/pypi/prov/)
 
 A library for W3C Provenance Data Model supporting PROV-O (RDF), PROV-XML, PROV-JSON import/export
 
@@ -38,6 +38,7 @@ Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/iss
 
 ## Supported versions
 
-Only the latest 3.x release is supported; 2.x and earlier no longer receive
-fixes. See [SECURITY.md](https://github.com/trungdong/prov/blob/master/SECURITY.md)
+The latest 3.x release receives all fixes. The most recent 2.x release
+receives security fixes only; 1.x and earlier no longer receive fixes. See
+[SECURITY.md](https://github.com/trungdong/prov/blob/master/SECURITY.md)
 for the full support table and how to report a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,20 @@
 
 ## Supported Versions
 
-Only the latest `3.x` release is actively maintained. Security fixes are
-backported to the most recent `3.x` release; `2.x` and earlier are no
-longer supported.
+The latest `3.x` release is actively maintained and receives all fixes.
+The most recent `2.x` release receives security fixes only — no bug fixes,
+no new features. `1.x` and earlier are no longer supported.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 3.x     | :white_check_mark: |
-| 2.x     | :x:                |
-| < 2.0   | :x:                |
+| Version | Supported          | Fixes               |
+| ------- | ------------------ | ------------------- |
+| 3.x     | :white_check_mark: | All fixes           |
+| 2.x     | :white_check_mark: | Security fixes only |
+| < 2.0   | :x:                | None                |
 
-Starting with `2.3.0`, `prov` requires Python 3.10 or later. Earlier `2.x`
-releases support Python 3.9+; consult the `classifiers` in a given
-release's `pyproject.toml`/`setup.py` for its exact supported Python
-versions.
+Both supported lines require Python 3.10 or later: `3.x` from the outset,
+and `2.x` from `2.3.0` onwards. Earlier `2.x` releases support Python 3.9+;
+consult the `classifiers` in a given release's `pyproject.toml`/`setup.py`
+for its exact supported Python versions.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
3.0.0 shipped with SECURITY.md and the README stating that only the latest 3.x release is supported and that 2.x no longer receives fixes. That leaves projects still pinned to 2.x — of which there are many — with no security path at all, the day after 3.0.0 was published.

This changes the policy so the most recent 2.x release receives security fixes, while 3.x continues to receive all fixes. 1.x and earlier remain unsupported.

The support table gains a "Fixes" column so the distinction between "all fixes" and "security fixes only" is visible at a glance rather than only in the prose above it, and the Python-version note now covers both supported lines instead of just 2.x.

Also includes a README badge refresh: the Codacy grade badge replaces the wheel-status badge, and the license badge moves up.

Note for later consideration, deliberately not changed here: the roadmap's "API-stability promise for 2.x" says no behaviour-changing bug fixes land in 2.x. A security fix can be behaviour-changing, so that promise and this policy could collide in a specific case; the accepted convention is that security fixes are an exception to any stability promise, but the roadmap does not say so explicitly.