### PR TITLE
Open the 2.x line to back-ported bug fixes through 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/iss
 ## Supported versions
 
 The latest 3.x release receives all fixes. The most recent 2.x release
-receives security fixes only; 1.x and earlier no longer receive fixes. See
+receives security fixes, plus bug fixes back-ported from 3.x up to and
+including 2.6.0, after which it reverts to security fixes only; 1.x and
+earlier no longer receive fixes. See
 [SECURITY.md](https://github.com/trungdong/prov/blob/master/SECURITY.md)
 for the full support table and how to report a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,20 @@
 ## Supported Versions
 
 The latest `3.x` release is actively maintained and receives all fixes.
-The most recent `2.x` release receives security fixes only — no bug fixes,
-no new features. `1.x` and earlier are no longer supported.
+The most recent `2.x` release receives security fixes and, for a bounded
+period, bug fixes back-ported from `3.x`. `1.x` and earlier are no longer
+supported.
 
-| Version | Supported          | Fixes               |
-| ------- | ------------------ | ------------------- |
-| 3.x     | :white_check_mark: | All fixes           |
-| 2.x     | :white_check_mark: | Security fixes only |
-| < 2.0   | :x:                | None                |
+| Version | Supported          | Fixes                                       |
+| ------- | ------------------ | ------------------------------------------- |
+| 3.x     | :white_check_mark: | All fixes                                   |
+| 2.x     | :white_check_mark: | Security fixes, plus back-ported bug fixes until `2.6.0` |
+| < 2.0   | :x:                | None                                        |
+
+The back-porting window is scope-bounded, not open-ended: `2.x` receives
+back-ported bug fixes up to and including the `2.6.0` release, after which
+it reverts to security fixes only. New features and behaviour-breaking
+corrections are never back-ported — they stay on `3.x`.
 
 Both supported lines require Python 3.10 or later: `3.x` from the outset,
 and `2.x` from `2.3.0` onwards. Earlier `2.x` releases support Python 3.9+;


### PR DESCRIPTION
Stage 0.1 of the back-port programme (#370).

Since 3.0.0 shipped, `SECURITY.md` has documented the 2.x maintenance line as receiving **security fixes only — no bug fixes, no new features**. A review of everything merged after the 2.5.1 tag found a substantial set of conformance and correctness fixes that port cleanly to 2.x, so the line is opened to back-ported bug fixes as well.

## The window is bounded by scope, not by date

2.x accepts back-ported fixes up to and including **2.6.0**, then reverts to security fixes only. New features and behaviour-breaking corrections are never back-ported and stay on 3.x. That keeps the commitment from reading as open-ended without pinning it to a date that would need revisiting.

## Note

This amends the *published* policy, which lives here on `master`. The 2.x branch carries its own copies of both files, still describing 2.x as the only maintained line — text predating 3.0.0 entirely. That is fixed separately on the 2.x branch, and needs to land before 2.5.2 ships, otherwise the two branches advertise contradictory support commitments.

Documentation only.