### PR TITLE
Bring the branch's support policy in line with the 3.x line

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 2.5.2 (unreleased)
+
+- Documentation: the support policy on this branch is brought in line with
+  the 3.x line's — the 2.x release receives security fixes plus bug fixes
+  back-ported from 3.x up to and including 2.6.0, after which it reverts to
+  security fixes only. The previous text still described 2.x as the only
+  maintained line, which predates the 3.0.0 release
+
 ## 2.5.1 (2026-07-13)
 
 - `prov.read()` polish following 2.5.0's #239: seekable streams are now

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/iss
 
 ## Supported versions
 
-Only the latest 2.x release is supported; 1.x and earlier no longer receive
+The latest 3.x release receives all fixes. This 2.x line receives security
+fixes, plus bug fixes back-ported from 3.x up to and including 2.6.0, after
+which it reverts to security fixes only; 1.x and earlier no longer receive
 fixes. See [SECURITY.md](https://github.com/trungdong/prov/blob/2.x/SECURITY.md)
 for the full support table and how to report a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,26 @@
 
 ## Supported Versions
 
-Only the latest `2.x` release is actively maintained. Security fixes are
-backported to the most recent `2.x` release; `1.x` and earlier are no
-longer supported.
+The latest `3.x` release is actively maintained and receives all fixes.
+The most recent `2.x` release — this branch — receives security fixes and,
+for a bounded period, bug fixes back-ported from `3.x`. `1.x` and earlier
+are no longer supported.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 2.x     | :white_check_mark: |
-| 1.x     | :x:                |
-| < 1.0   | :x:                |
+| Version | Supported          | Fixes                                       |
+| ------- | ------------------ | ------------------------------------------- |
+| 3.x     | :white_check_mark: | All fixes                                   |
+| 2.x     | :white_check_mark: | Security fixes, plus back-ported bug fixes until `2.6.0` |
+| < 2.0   | :x:                | None                                        |
 
-Starting with `2.3.0`, `prov` requires Python 3.10 or later. Earlier `2.x`
-releases support Python 3.9+; consult the `classifiers` in a given
-release's `pyproject.toml`/`setup.py` for its exact supported Python
-versions.
+The back-porting window is scope-bounded, not open-ended: `2.x` receives
+back-ported bug fixes up to and including the `2.6.0` release, after which
+it reverts to security fixes only. New features and behaviour-breaking
+corrections are never back-ported — they stay on `3.x`.
+
+Both supported lines require Python 3.10 or later: `3.x` from the outset,
+and `2.x` from `2.3.0` onwards. Earlier `2.x` releases support Python 3.9+;
+consult the `classifiers` in a given release's `pyproject.toml`/`setup.py`
+for its exact supported Python versions.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Stage 0.4 of the back-port programme (#370). Stacked on #372; merge after it.

`SECURITY.md` and `README.md` on this branch still described 2.x as the only actively maintained line, with 1.x and earlier unsupported. **That text predates the 3.0.0 release**: 3.x is now the maintained line, and the 2.x line has just been opened to back-ported bug fixes through 2.6.0 (#371).

Without this, 2.5.2 would ship advertising a support policy that contradicts master's — worse than either statement alone.

Restates both files to match what #371 publishes, and extends the Python-version note to cover both supported lines rather than 2.x alone.

Also opens the `2.5.2 (unreleased)` section in `HISTORY.md`, which the rest of the stack adds to.

Documentation only.