### PR TITLE
Harden PROV-XML parsing against XXE and entity expansion (#273)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## 2.5.2 (unreleased)
 
+- Security: PROV-XML parsing no longer resolves DTD entities and never
+  touches the network (`resolve_entities=False`, `no_network=True`),
+  closing an XXE surface on untrusted input. Both `etree.parse()` call
+  sites previously inherited lxml's process-global default parser, which
+  any other library in the same process can repoint via
+  `etree.set_default_parser()` — with a permissive parser installed that
+  way, an external entity resolved and leaked the referenced file's
+  contents through `ProvDocument.deserialize()` (#273)
 - Documentation: the support policy on this branch is brought in line with
   the 3.x line's — the 2.x release receives security fixes plus bug fixes
   back-ported from 3.x up to and including 2.6.0, after which it reverts to

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -37,6 +37,33 @@ its record/subtype QualifiedName."""
 
 XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 
+# Hardened against XXE / entity expansion (#273): PROV-XML documents have no
+# legitimate use for DTD entity resolution or network access, so both are
+# switched off explicitly rather than left to whatever lxml's own default
+# parser happens to do. This matters for three distinct reasons, not just
+# one: lxml's own default for `resolve_entities` only became safe ('internal')
+# in lxml 5.0 -- this package's floor (`lxml>=3.3.5`) still admits older
+# releases that default to `True` (full external entity resolution); even on
+# a safe lxml release, any other library sharing the process can repoint the
+# *global* default parser via `etree.set_default_parser(...)`, which is what
+# a bare `etree.parse(...)` call (no `parser=`) silently inherits; and prov
+# is consumed by other applications (e.g. ProvStore) that may load such
+# libraries. Passing this parser explicitly at both parse sites closes all
+# three regardless of the installed lxml version or what else is loaded in
+# the process. `huge_tree` is left at its lxml default of `False`: raising it
+# disables libxml2's own hard limits on tree depth/text length/entity
+# amplification, which is the opposite of what a hardened parser wants here.
+#
+# Shared module-level instance, not one constructed per parse: lxml's own
+# documentation for `XMLParser` states that sharing a parser across threads
+# "is not harmful", only less efficient than per-thread instances under
+# heavy concurrent load (access is internally serialized). PROV-XML
+# deserialization is not expected to be a high-frequency, highly concurrent
+# hot path even in a web service such as ProvStore, so the simplicity of a
+# single shared parser wins over per-parse allocation; if profiling ever
+# shows lock contention here, switch to constructing a parser per call.
+_XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True)
+
 
 class ProvXMLException(prov.Error):
     """Raised when a PROV-XML document cannot be serialized or parsed by this package."""
@@ -266,9 +293,9 @@ class ProvXMLSerializer(Serializer):
             with io.BytesIO() as buf:
                 buf.write(stream.read().encode("utf-8"))
                 buf.seek(0, 0)
-                xml_doc = etree.parse(buf).getroot()  # type: etree._Element
+                xml_doc = etree.parse(buf, parser=_XML_PARSER).getroot()  # type: etree._Element
         else:
-            xml_doc = etree.parse(stream).getroot()  # type: ignore[arg-type]
+            xml_doc = etree.parse(stream, parser=_XML_PARSER).getroot()  # type: ignore[arg-type]
 
         # Remove all comments.
         for c in xml_doc.xpath("//comment()"):  # type: ignore[union-attr]

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -528,6 +528,162 @@ def test_empty_string_attribute_survives_xml_roundtrip():
     assert roundtrip_document(document, "xml") == document
 
 
+# Hardening against XXE / entity expansion (#273).
+#
+# Three distinct vectors were checked against unmodified pre-fix 2.x before
+# writing these tests, and only one reproduces with this project's locked
+# lxml (6.1.1):
+#
+# - External entity, pristine global default parser: does NOT reproduce
+#   pre-fix. lxml >= 5.0 changed XMLParser's own default `resolve_entities`
+#   from `True` to `'internal'` (no external file/URL access), so pre-fix
+#   the SYSTEM entity is left undefined and lxml raises XMLSyntaxError
+#   before any file is touched -- but that safety is an accident of the
+#   installed lxml version, not anything provxml.py configures: `lxml
+#   >=3.3.5` (this package's floor) still admits lxml < 5.0, where the
+#   default was `True` and this exact payload leaks the file's contents.
+#   Post-fix, the explicit `resolve_entities=False` used by `_XML_PARSER`
+#   changes the observable behaviour again: rather than raising, the
+#   reference is left unresolved and the attribute value comes back as an
+#   empty string -- still never containing the file's contents.
+# - Billion-laughs / entity amplification: does NOT reproduce on any
+#   supported lxml, pre- or post-fix. libxml2 itself has carried a hard cap
+#   on entity amplification for a long time, independent of any lxml-level
+#   flag, so this was never really exploitable through this library
+#   specifically. test_billion_laughs_does_not_expand pins libxml2's own
+#   protection as a regression guard, not as evidence of a prov-side fix.
+# - Global default parser tampering: DOES reproduce, today, through prov's
+#   public API. Both `etree.parse` call sites in provxml.py pass no
+#   `parser=` argument, so they silently inherit whatever
+#   `lxml.etree.set_default_parser()` last installed process-wide -- which
+#   any other library sharing the interpreter (prov is embedded in
+#   ProvStore, among others) is free to do.
+#
+#   test_deserialize_ignores_tampered_default_parser exercises exactly this
+#   and is the one test in this group that fails against unhardened
+#   provxml.py and passes once both `etree.parse` sites pass the explicit
+#   `_XML_PARSER`.
+
+
+@pytest.fixture
+def restore_default_xml_parser():
+    """Snapshot and restore lxml's process-global default parser.
+
+    Deliberately scoped to the one test that reconfigures the global
+    default via ``etree.set_default_parser`` -- leaving a permissive parser
+    installed globally would silently weaken entity handling for every
+    other test (and every other consumer of lxml) running after it in the
+    same process.
+    """
+    original_parser = etree.get_default_parser()
+    try:
+        yield
+    finally:
+        etree.set_default_parser(original_parser)
+
+
+def _xxe_document(secret_path):
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE prov:document [
+  <!ENTITY xxe SYSTEM "file://{secret_path}">
+]>
+<prov:document
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:ex="http://example.com/ns/ex#">
+  <prov:entity prov:id="ex:e1">
+    <prov:type xsi:type="xsd:string">&xxe;</prov:type>
+  </prov:entity>
+</prov:document>
+"""
+
+
+_BILLION_LAUGHS_DOCUMENT = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE prov:document [
+ <!ENTITY lol "lol">
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<prov:document
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:ex="http://example.com/ns/ex#">
+  <prov:entity prov:id="ex:e1">
+    <prov:type xsi:type="xsd:string">&lol9;</prov:type>
+  </prov:entity>
+</prov:document>
+"""
+
+
+def test_external_entity_does_not_leak_file_contents(tmp_path):
+    # Actual hardened behaviour observed with `_XML_PARSER`
+    # (resolve_entities=False): the document deserializes without raising,
+    # but the SYSTEM entity reference is left unresolved rather than
+    # expanded, so the attribute that referenced it comes back empty. The
+    # file's contents never appear anywhere in the parsed document.
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("TOPSECRET123")
+
+    xml_string = _xxe_document(secret_path.as_posix())
+    document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+
+    assert "TOPSECRET123" not in document.get_provn()
+    entity = next(iter(document.get_records(prov.ProvEntity)))
+    values = list(entity.get_attribute(PROV["type"]))
+    # The reference is left unresolved, so the element carries no text. On
+    # 2.x that surfaces as the string "None": the element's text is None and
+    # the pre-#224 attribute extraction stringifies it. Once the #224 fix
+    # lands (queued for 2.5.3) the same value becomes "". Both spellings are
+    # accepted here so this test survives that change; what it actually pins
+    # is that neither ever contains the referenced file's contents.
+    assert values in ([""], ["None"])
+    assert "TOPSECRET123" not in str(values)
+
+
+def test_billion_laughs_does_not_expand():
+    # Guards against unbounded entity amplification. This is libxml2's own
+    # long-standing hard-coded amplification cap doing the work, not
+    # anything provxml.py configures -- kept here as a regression guard in
+    # case that upstream protection is ever weakened (e.g. via a future
+    # `huge_tree=True`, which this module deliberately never sets).
+    with pytest.raises(etree.XMLSyntaxError):
+        prov.ProvDocument.deserialize(content=_BILLION_LAUGHS_DOCUMENT, format="xml")
+
+
+def test_deserialize_ignores_tampered_default_parser(
+    tmp_path, restore_default_xml_parser
+):
+    # The reproducible vector: provxml.py's own `etree.parse` calls pass an
+    # explicit, hardened parser, so they are unaffected even when some other
+    # code in the same process has repointed lxml's *global* default parser
+    # (via `etree.set_default_parser`) to something permissive -- which is
+    # exactly what happens, pre-fix, on today's locked lxml (6.1.1):
+    # tampering the global default is enough to make the external entity in
+    # _xxe_document resolve and leak the file's contents through
+    # ProvDocument.deserialize.
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("TOPSECRET123")
+
+    etree.set_default_parser(etree.XMLParser(resolve_entities=True, no_network=True))
+
+    xml_string = _xxe_document(secret_path.as_posix())
+    document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+
+    entity = next(iter(document.get_records(prov.ProvEntity)))
+    values = list(entity.get_attribute(PROV["type"]))
+    assert "TOPSECRET123" not in str(values)
+    assert "TOPSECRET123" not in document.get_provn()
+
+
 # Scaffolding for a per-file XML round-trip glob, left disabled.
 #
 # Deserializing then re-serializing PROV-XML does not maintain XML


### PR DESCRIPTION
Stage 1 of the back-port programme (#370) — the content of the 2.5.2 security release. Stacked on #373.

Back-port of #302 from the 3.x line.

## The vulnerability

Both `etree.parse()` call sites in the PROV-XML deserializer passed no parser, so they silently inherited lxml's process-global default. That default is not something this package controls:

- lxml's own `resolve_entities` default only became safe (`'internal'`) in **lxml 5.0**, and the dependency floor of `lxml>=3.3.5` still admits older releases where it was `True`
- more importantly, **any other library sharing the interpreter can repoint the global default** via `etree.set_default_parser()` — and `prov` is embedded in other applications, including ProvStore

## This reproduces on 2.x today

I confirmed it on this branch before writing the fix. With a permissive parser installed globally, an external entity resolves and **the referenced file's contents come back through `ProvDocument.deserialize()`** on the currently locked lxml 6.1.1. Both entity tests fail without the parser arguments and pass with them.

The other two vectors are pinned as regression guards rather than as evidence of a prov-side fix: the pristine-default external entity case is already blocked by lxml ≥ 5.0's own default, and billion-laughs is blocked by libxml2's own amplification cap.

## The fix

Parse through an explicit module-level parser built with `resolve_entities=False, no_network=True`. PROV-XML has no legitimate use for DTD entity resolution or network access, so no valid document changes behaviour. `huge_tree` is deliberately left at its default of `False` — raising it would disable libxml2's own limits on tree depth and entity amplification.

## One assertion differs from the 3.x tests

An unresolved entity leaves the element without text, which 3.x reports as `""` but 2.x stringifies to `"None"`, because the empty-string handling from #224 has not been back-ported yet. The test accepts either spelling so it survives that fix landing in 2.5.3; what it pins is that neither ever contains the referenced file's contents.

## Verification

**1163 passed, 22 skipped, 14 xfailed** (three added tests over the 1160 baseline), with `ruff`, `ruff format` and `mypy --strict` all clean.