### PR TITLE
Pin third-party actions to commit SHAs and restrict CI token scope

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
     branches: [main, master, dev, 2.x]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
@@ -18,8 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
-      - uses: astral-sh/setup-uv@v9.0.0
+        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
@@ -40,7 +43,7 @@ jobs:
         if: matrix.python-version == '3.12'
         run: uv run coverage report
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329  # v2
         # Advisory upload: a Coveralls outage must not fail the build (rule added
         # after the 2026-07-03 outage blocked PR #174; hotfixed on master in PR #176 —
         # keep continue-on-error on all coverage-upload steps in the rewrite)
@@ -64,7 +67,7 @@ jobs:
             label: "latest 7.x"
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: "3.12"
       - run: |
@@ -77,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - run: |
           uv sync --locked --group dev
           uv run ruff check src/
@@ -92,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - name: Sync without extras
         run: uv sync --locked --group dev
       - name: Degradation tests
@@ -102,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - run: |
           uv sync --locked --extra rdf --extra xml --group dev
           uv run mypy src
@@ -111,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - run: |
           uv build
           uvx twine check dist/*
@@ -122,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329  # v2
         continue-on-error: true
         with:
           parallel-finished: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - run: |
           uv build
           uvx twine check dist/*
@@ -43,7 +43,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -59,4 +59,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@
   `etree.set_default_parser()` — with a permissive parser installed that
   way, an external entity resolved and leaked the referenced file's
   contents through `ProvDocument.deserialize()` (#273)
+- Security: CI workflows now pin every third-party action to a commit SHA
+  rather than a mutable tag, and the CI workflow's `GITHUB_TOKEN` is
+  restricted to `contents: read`
 - Documentation: the support policy on this branch is brought in line with
   the 3.x line's — the 2.x release receives security fixes plus bug fixes
   back-ported from 3.x up to and including 2.6.0, after which it reverts to


### PR DESCRIPTION
Stage 1 of the back-port programme (#370), supply-chain half. Stacked on #374.

Back-port of the CI hardening from #271 on the 3.x line.

Workflow steps referenced third-party actions by **mutable tag**, so a compromised or force-moved tag would execute attacker-controlled code with the workflow's token. Pins the four third-party actions to the commit SHAs their current tags resolve to, keeping the human-readable version in a trailing comment so Dependabot can still see and bump them:

- `ts-graphviz/setup-graphviz`
- `astral-sh/setup-uv`
- `coverallsapp/github-action`
- `pypa/gh-action-pypi-publish`

The three GitHub-owned `actions/*` steps stay on tags, matching the 3.x line's choice.

The CI workflow also declared no top-level `permissions`, so its `GITHUB_TOKEN` got the repository default rather than least privilege. Adds the same `contents: read` block the release workflow already carries.

## Note on the SHAs

Taken from the 3.x line's *current* workflows, which pin the same action versions this branch already uses — **not** from #271 itself, whose SHAs were for older versions (setup-uv v8.2.0 against this branch's v9.0.0). So no action is upgraded or downgraded here.

Both files were checked to still parse as valid YAML with the expected permissions block, but the first CI run on this branch is the real verification.