### PR TITLE
Fix find_diff blindness to single-triple differences (#304)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,8 @@
 - Security: CI workflows now pin every third-party action to a commit SHA
   rather than a mutable tag, and the CI workflow's `GITHUB_TOKEN` is
   restricted to `contents: read`
+- Test infrastructure: the RDF fixture-comparison helper `find_diff()` now
+  detects single-triple differences, which it previously missed (#304)
 - Documentation: the support policy on this branch is brought in line with
   the 3.x line's — the 2.x release receives security fixes plus bug fixes
   back-ported from 3.x up to and including 2.6.0, after which it reverts to

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -33,8 +33,16 @@ logger = logging.getLogger(__name__)
 def find_diff(g_rdf, g0_rdf):
     graphs_equal = True
     in_both, in_first, in_second = graph_diff(g_rdf, g0_rdf)
-    g1 = sorted(in_first.serialize(format="nt", encoding="utf-8").splitlines())[1:]
-    g2 = sorted(in_second.serialize(format="nt", encoding="utf-8").splitlines())[1:]
+    g1 = sorted(
+        line
+        for line in in_first.serialize(format="nt", encoding="utf-8").splitlines()
+        if line.strip()
+    )
+    g2 = sorted(
+        line
+        for line in in_second.serialize(format="nt", encoding="utf-8").splitlines()
+        if line.strip()
+    )
     # Compare literals
     if len(g1) != len(g2):
         graphs_equal = False
@@ -354,3 +362,48 @@ def test_qualified_delegation_pair_survives_rdf_roundtrip():
     document.delegation("ex:g0", "ex:g1", "ex:a")
     document.delegation("ex:g0", "ex:g0", "ex:a")
     assert roundtrip_document(document, "rdf") == document
+
+
+def test_find_diff_detects_single_triple_difference():
+    # #304: find_diff must report a mismatch for graphs differing by a single
+    # triple. The [1:] slices that removed a leading blank line from nt
+    # serialization were too aggressive: after sorted(), when the difference
+    # was a single triple, the slice discarded the only real line, leaving both
+    # g1 and g2 empty, and the function returned the initial graphs_equal=True.
+    # Regression test for the fix: replace [1:] slices with explicit
+    # blank-line filtering.
+
+    # Case 1: Single-triple graphs with transposed subject/object
+    # (genuinely differ, not just formatting)
+    a = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    b = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:b ex:p ex:a .", format="turtle"
+    )
+    match, _, _, _ = find_diff(a, b)
+    assert not match, (
+        "Single-triple graphs with transposed subject/object should differ"
+    )
+
+    # Case 2: Two-triple graphs differing in exactly one triple
+    c = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b . ex:c ex:p ex:d .",
+        format="turtle",
+    )
+    d = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:b ex:p ex:a . ex:c ex:p ex:d .",
+        format="turtle",
+    )
+    match, _, _, _ = find_diff(c, d)
+    assert not match, "Two-triple graphs differing in exactly one triple should differ"
+
+    # Case 3: Identical graphs should still match (ensure fix doesn't over-correct)
+    e = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    f = Graph().parse(
+        data="@prefix ex: <http://e/> . ex:a ex:p ex:b .", format="turtle"
+    )
+    match, _, _, _ = find_diff(e, f)
+    assert match, "Identical graphs should match"


### PR DESCRIPTION
Stage 0.3 of the back-port programme (#370). Stacked on #375, last in the 2.x stack.

Back-port of #307 from the 3.x line. **Test infrastructure only — no library code changes.**

## The bug

`find_diff()` sliced the first element off both sorted line lists to drop the blank line that rdflib's `nt` serialization emits. After `sorted()` that blank line is not reliably first, and when two graphs differ by **exactly one triple** the slice discarded the only real line instead, leaving both lists empty. The length comparison then matched, the per-statement loop had nothing to iterate, and the function returned its initial `graphs_equal=True` — reporting equal graphs that genuinely differ.

Filters blank lines explicitly instead of slicing by position.

## Why this lands before the Stage 2 RDF fixes

Those fixes are verified *through* `find_diff`. Porting them while the comparison helper is blind would produce green runs that prove nothing. This is why the spec lists it as a Stage 0 precondition despite being test-only.

## Verification

The added test was confirmed to **fail against the unfixed helper** before the fix was applied, so it genuinely catches #304 rather than passing vacuously.

Suite goes 1163 → **1164 passed, 22 skipped, 14 xfailed** (one added test); `ruff check` and `ruff format --check` clean.