### PR TITLE
Release 2.5.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 2.5.2 (unreleased)
+## 2.5.2 (2026-08-08)
 
 - Security: PROV-XML parsing no longer resolves DTD entities and never
   touches the network (`resolve_entities=False`, `no_network=True`),

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 __all__ = ["Error", "model", "read"]
 


### PR DESCRIPTION
Stamps the version and dates the changelog for 2.5.2, the security-only release closing Stage 1 of the 2.x back-port programme: PROV-XML XXE hardening (#273), CI supply-chain hardening (pinned Actions, restricted token scope), the find_diff test-helper fix, and the support-policy documentation update.