### PR TITLE
Escape PROV-N metacharacters in qualified-name local parts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 2.5.3 (unreleased)
+
+- Escaped PROV-N metacharacters (`= ' ( ) , : ; [ ]`) in the local parts of
+  qualified names, so identifiers containing them serialise to valid PROV-N
+  (#223). Backslashes in string literals are now escaped before quotes.
+
 ## 2.5.2 (2026-08-08)
 
 - Security: PROV-XML parsing no longer resolves DTD entities and never

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -5,6 +5,15 @@ from typing import Any
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
 
+# PROV-N metacharacters that must be backslash-escaped in the local part of a
+# qualified name (grammar production [55] PN_CHARS_ESC, #223). PN_CHARS_ESC
+# also lists '-' and '.' as escapable, but both are otherwise legal unescaped
+# there ('-' is a PN_CHARS character; '.' is legal unescaped except as the
+# final character of PN_LOCAL) so they are left untouched here -- only the
+# nine characters that are illegal unescaped anywhere in a local part are
+# escaped.
+_PROVN_LOCAL_ESCAPE = str.maketrans({c: f"\\{c}" for c in "='(),:;[]"})
+
 
 class Identifier:
     """Base class for all identifiers and also represents xsd:anyURI."""
@@ -91,9 +100,23 @@ class QualifiedName(Identifier):
     def __hash__(self) -> int:
         return hash(self.uri)
 
+    def provn_bare_representation(self) -> str:
+        """Return the ``prefix:local`` PROV-N form used at IDENTIFIER positions.
+
+        The local part's PROV-N metacharacters (``= ' ( ) , : ; [ ]``) are
+        backslash-escaped per grammar production [55] ``PN_CHARS_ESC`` (#223);
+        the prefix is never escaped, as it cannot contain these characters.
+        """
+        escaped_localpart = self._localpart.translate(_PROVN_LOCAL_ESCAPE)
+        return (
+            ":".join([self._namespace.prefix, escaped_localpart])
+            if self._namespace.prefix
+            else escaped_localpart
+        )
+
     def provn_representation(self) -> str:
         """Return the PROV-N representation of this qualified name as a quoted string."""
-        return f"'{self._str}'"
+        return f"'{self.provn_bare_representation()}'"
 
 
 class Namespace:

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -318,7 +318,11 @@ class ProvBundle:
 
         #  if this is the document, start the document;
         # otherwise, start the bundle
-        lines = ["document"] if self.is_document() else [f"bundle {self._identifier}"]
+        # #223: escape PN_CHARS_ESC metacharacters in the local part
+        bundle_id = (
+            self._identifier.provn_bare_representation() if self._identifier else ""
+        )
+        lines = ["document"] if self.is_document() else [f"bundle {bundle_id}"]
 
         default_namespace = self._namespaces.get_default_namespace()
         if default_namespace:

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -194,6 +194,9 @@ def first(a_set: set[Any]) -> Any | None:
 def _ensure_multiline_string_triple_quoted(value: str) -> str:
     # converting the value to a string
     s = str(value)
+    # Escape backslashes first, so quote-escaping below doesn't re-escape
+    # the backslashes it just introduced.
+    s = s.replace("\\", "\\\\")
     # Escaping any double quote
     s = s.replace('"', '\\"')
     if "\n" in s:
@@ -667,7 +670,8 @@ class ProvRecord:
         # Generating identifier
         relation_id = ""  # default blank
         if self._identifier:
-            identifier = str(self._identifier)  # TODO: QName export
+            # #223: escape PN_CHARS_ESC metacharacters in the local part
+            identifier = self._identifier.provn_bare_representation()
             if self.is_element():
                 items.append(identifier)
             else:
@@ -680,12 +684,13 @@ class ProvRecord:
             if values:
                 # Formal attributes always have single values
                 value = first(values)
-                # TODO: QName export
-                items.append(
-                    value.isoformat()
-                    if isinstance(value, datetime.datetime)
-                    else str(value)
-                )
+                if isinstance(value, datetime.datetime):
+                    items.append(value.isoformat())
+                elif isinstance(value, QualifiedName):
+                    # #223: escape PN_CHARS_ESC metacharacters in the local part
+                    items.append(value.provn_bare_representation())
+                else:
+                    items.append(str(value))
             else:
                 items.append("-")
 
@@ -699,8 +704,9 @@ class ProvRecord:
                         provn_represenation = value.provn_representation()
                     except AttributeError:
                         provn_represenation = encoding_provn_value(value)
-                    # TODO: QName export
-                    extra.append(f"{attr!s}={provn_represenation}")
+                    # #223: escape PN_CHARS_ESC metacharacters in the local part
+                    attr_name = attr.provn_bare_representation()
+                    extra.append(f"{attr_name}={provn_represenation}")
 
         if extra:
             # .format(), not an f-string: the nested string literals reuse the

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -1,0 +1,67 @@
+"""PROV-N local-part metacharacter escaping (#223, PROV-N [53]/[55])."""
+
+import pytest
+
+from prov.model import ProvDocument
+
+METACHARS = "='(),:;[]"
+
+
+def _doc():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    return document
+
+
+@pytest.mark.parametrize("ch", list(METACHARS))
+def test_metachar_local_parts_are_escaped(ch):
+    document = _doc()
+    document.entity(f"ex:na{ch}me")
+    provn = document.get_provn()
+    assert f"ex:na\\{ch}me" in provn
+
+
+def test_issue_repro_escaped_end_to_end():
+    document = _doc()
+    document.entity("ex:weird'name)x,y")
+    assert "entity(ex:weird\\'name\\)x\\,y)" in document.get_provn()
+
+
+def test_plain_local_parts_unchanged():
+    document = _doc()
+    document.entity("ex:plain-name_1.x")
+    assert "entity(ex:plain-name_1.x)" in document.get_provn()
+
+
+def test_string_literal_backslash_escaped_before_quotes():
+    document = _doc()
+    document.entity("ex:e1", {"ex:note": 'back\\slash and "quote"'})
+    provn = document.get_provn()
+    # backslash must be escaped first, giving an unambiguous \\ followed by \"
+    assert '\\\\slash and \\"quote\\"' in provn
+
+
+def test_bundle_identifier_metachar_is_escaped():
+    document = _doc()
+    bundle = document.bundle("ex:weird'bundle")
+    bundle.entity("ex:e1")
+    assert "bundle ex:weird\\'bundle" in document.get_provn()
+
+
+def test_bundle_identifier_plain_unchanged():
+    document = _doc()
+    bundle = document.bundle("ex:plain-bundle")
+    bundle.entity("ex:e1")
+    assert "bundle ex:plain-bundle" in document.get_provn()
+
+
+def test_attribute_name_metachar_is_escaped():
+    document = _doc()
+    document.entity("ex:e1", {"ex:weird'key": "value"})
+    assert '[ex:weird\\\'key="value"]' in document.get_provn()
+
+
+def test_attribute_name_plain_unchanged():
+    document = _doc()
+    document.entity("ex:e1", {"ex:plain_key": "value"})
+    assert '[ex:plain_key="value"]' in document.get_provn()


### PR DESCRIPTION
Back-port of #287 (#223) to 2.x, Stage 2 item 2.2 of the back-port programme.

PROV-N has no parser in this package, so escaping the local part converts previously invalid output into valid output without affecting any input path. Ported verbatim from master; the three source files applied cleanly with no adaptation.

Regression tests ported from #287 as `src/prov/tests/test_provn_escaping.py`. Verified failing before the fix.

Test counts: 1180 passed / 22 skipped / 14 xfailed (baseline 1164/22/14 plus the 16 tests added here).