### PR TITLE
Back-port #291: anonymous qualified nodes carry their influencer property

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,12 @@
 - Escaped PROV-N metacharacters (`= ' ( ) , : ; [ ]`) in the local parts of
   qualified names, so identifiers containing them serialise to valid PROV-N
   (#223). Backslashes in string literals are now escaped before quotes.
+- Anonymous `prov:qualified*` nodes for communication, attribution,
+  delegation and influence now carry their own influencer property, as the
+  PROV-O qualification tables require, so a qualification node is
+  interpretable without its shorthand binary triple (#250). Decoding uses
+  that property to tell several same-kind qualification nodes apart instead
+  of guessing (#226).
 
 ## 2.5.2 (2026-08-08)
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -31,6 +31,7 @@ from prov.constants import (
     PROV_ATTR_TIME,
     PROV_ATTR_TRIGGER,
     PROV_ATTR_USED_ENTITY,
+    PROV_ATTRIBUTION,
     PROV_BASE_CLS,
     PROV_COMMUNICATION,
     PROV_DELEGATION,
@@ -38,6 +39,7 @@ from prov.constants import (
     PROV_END,
     PROV_GENERATION,
     PROV_ID_ATTRIBUTES_MAP,
+    PROV_INFLUENCE,
     PROV_INVALIDATION,
     PROV_LOCATION,
     PROV_MENTION,
@@ -135,6 +137,20 @@ PREDICATE_MAP = {
 :meth:`~ProvRDFSerializer.decode_container`: maps PROV-O predicate URIRefs
 that don't already match a PROV formal-attribute QualifiedName to the
 QualifiedName of the formal attribute they represent."""
+
+#: Relation types whose plain binary triple is always emitted *and* whose
+#: second formal attribute is the relation's influencer per the PROV-O
+#: section 3.1 qualification tables (``prov:activity``/``prov:agent``/
+#: ``prov:agent``/``prov:influencer``). Whenever one of these relations gets
+#: a ``prov:qualified*`` node -- identified, or anonymous with extra
+#: qualifiers -- that influencer must also be asserted directly on the node,
+#: not only implied by the binary triple, so the node is interpretable in
+#: isolation (#250). ``prov:mentionOf`` and ``prov:alternateOf`` are
+#: deliberately excluded: they are already special-cased elsewhere in the
+#: binary-triple/qualification-node machinery.
+_BINARY_TRIPLE_INFLUENCER_RELATIONS = frozenset(
+    {PROV_COMMUNICATION, PROV_ATTRIBUTION, PROV_DELEGATION, PROV_INFLUENCE}
+)
 
 
 def attr2rdf(attr: QualifiedName) -> URIRef:
@@ -510,6 +526,20 @@ class ProvRDFSerializer(Serializer):
                                                 )
                                             )
                                         has_qualifiers = False
+                                    elif (
+                                        rec_type in _BINARY_TRIPLE_INFLUENCER_RELATIONS
+                                        and has_qualifiers
+                                    ):
+                                        # #250: a qualification node is about to be
+                                        # minted for this relation, so un-consume the
+                                        # influencer attribute here: the generic
+                                        # emission loop below will then also assert it
+                                        # directly on that node, instead of leaving the
+                                        # node interpretable only via the shorthand
+                                        # triple just added above.
+                                        used_objects.remove(
+                                            record.formal_attributes[1][0]
+                                        )
                             if rec_type in [PROV_ALTERNATE]:
                                 continue
                             if subj and (has_qualifiers or identifier):
@@ -847,10 +877,26 @@ class ProvRDFSerializer(Serializer):
                         + relation_mapper[pred][1:]
                     )
                     qualifier_bnode = None
+                    agent_pred = URIRef(pm.PROV["agent"].uri)
                     for stmt in graph.triples(
                         (URIRef(subj), URIRef(pm.PROV[qualifier].uri), None)
                     ):
-                        qualifier_bnode = stmt[2]
+                        candidate = stmt[2]
+                        # #226/#250: a subject may point at more than one
+                        # qualification node of the same kind -- e.g. two
+                        # delegations from the same delegate to the same
+                        # activity, differing only in `responsible` -- which
+                        # "last node seen" cannot tell apart. Since #250, a
+                        # freshly-encoded node also carries its own
+                        # `prov:agent` triple, so prefer whichever
+                        # candidate's `prov:agent` matches this binary
+                        # triple's object; only fall back to "last node
+                        # seen" (the pre-#250 behaviour, which cannot do
+                        # better) when no candidate carries that triple at
+                        # all, i.e. legacy input.
+                        qualifier_bnode = candidate
+                        if (candidate, agent_pred, obj) in graph:
+                            break
                     if qualifier_bnode is None:
                         getattr(bundle, relation_mapper[pred])(subj, str(obj))
                     else:

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -208,17 +208,13 @@ def _populate(draw, container: ProvBundle) -> list[str]:
     for _ in range(times()):
         g1, g2 = pick(agents), pick(agents)
         if fresh("deleg", g1, g2):
-            # No qualifying activity: #226. Qualified delegation is lost through
-            # RDF when two anonymous delegations share the same delegate AND
-            # qualifying activity but differ in responsible — the
-            # qualifiedDelegation blank nodes are keyed on (delegate, activity),
-            # which the endpoint-pair `fresh` guard cannot prevent (distinct from
-            # #217, which is about relations sharing an explicit identifier).
-            # Every other relation qualifier (relation prov:time,
-            # association plan, start/end starter/ender) round-trips fine and is
-            # kept. Omitting only delegation's activity keeps the relation type
-            # in the corpus without depending on that RDF-lossy construct.
-            container.delegation(g1, g2)
+            # Qualifying activity restored (#250 fix): each qualifiedDelegation
+            # blank node now carries its own prov:agent triple, so two anonymous
+            # delegations sharing the same delegate AND qualifying activity but
+            # differing in responsible no longer collapse on the RDF round trip
+            # (#226) — decoding matches the node by its own influencer instead
+            # of an ambiguous "last node seen" guess.
+            container.delegation(g1, g2, pick(activities))
     for _ in range(times()):
         x1, x2 = pick(all_ids), pick(all_ids)
         if fresh("infl", x1, x2):

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -16,7 +16,7 @@ import pytest
 import rdflib as rl
 from rdflib import RDF, URIRef
 from rdflib.compare import graph_diff
-from rdflib.graph import ConjunctiveGraph, Graph
+from rdflib.graph import ConjunctiveGraph, Dataset, Graph
 
 import prov.model as pm
 from prov.model import ProvDocument
@@ -344,16 +344,14 @@ def test_float_precision_survives_rdf_roundtrip():
     assert roundtrip_document(document, "rdf") == document
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="#226: two qualified delegations sharing the same delegate and "
-    "qualifying activity but differing in responsible collapse through RDF -- "
-    "one loses its responsible (the qualifiedDelegation blank nodes are keyed "
-    "on delegate+activity). Regression guard from the Hypothesis property "
-    "tests; remove when #226 is fixed in 3.0.",
-)
 def test_qualified_delegation_pair_survives_rdf_roundtrip():
+    # #226: two qualified delegations sharing the same delegate and
+    # qualifying activity but differing in responsible used to collapse
+    # through RDF -- one lost its responsible, because the qualifiedDelegation
+    # blank nodes were keyed on (delegate, activity) alone. Fixed by #250:
+    # each qualifiedDelegation node now carries its own prov:agent triple, so
+    # decoding can match the correct node by its actual influencer instead of
+    # an ambiguous "last node seen" guess.
     document = ProvDocument()
     document.add_namespace("ex", "http://example.org/")
     document.agent("ex:g0")
@@ -407,3 +405,110 @@ def test_find_diff_detects_single_triple_difference():
     )
     match, _, _, _ = find_diff(e, f)
     assert match, "Identical graphs should match"
+
+
+@pytest.mark.parametrize(
+    ("build", "influencer_uri"),
+    [
+        (
+            lambda d: d.communication("ex:a2", "ex:a1", other_attributes={"ex:k": "v"}),
+            "http://www.w3.org/ns/prov#activity",
+        ),
+        (
+            lambda d: d.attribution("ex:e1", "ex:ag1", other_attributes={"ex:k": "v"}),
+            "http://www.w3.org/ns/prov#agent",
+        ),
+        (
+            lambda d: d.delegation(
+                "ex:ag2", "ex:ag1", "ex:a", other_attributes={"ex:k": "v"}
+            ),
+            "http://www.w3.org/ns/prov#agent",
+        ),
+        (
+            lambda d: d.influence("ex:e2", "ex:e1", other_attributes={"ex:k": "v"}),
+            "http://www.w3.org/ns/prov#influencer",
+        ),
+    ],
+    ids=["communication", "attribution", "delegation", "influence"],
+)
+def test_anonymous_qualified_node_carries_influencer(build, influencer_uri):
+    # #250: an anonymous qualified Communication/Attribution/Delegation/
+    # Influence node must carry its influencer property directly (PROV-O
+    # section 3.1's qualification tables), not just imply it via the
+    # shorthand binary triple, so the node is interpretable in isolation.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    build(document)
+    buf = BytesIO()
+    document.serialize(destination=buf, format="rdf", rdf_format="nt11")
+    output = buf.getvalue()
+    assert influencer_uri.encode() in output
+
+
+def test_anonymous_attributions_to_different_agents_each_carry_their_own_agent():
+    # #250's ambiguity repro: two anonymous, qualified (extra-attributed)
+    # attributions of the same entity to *different* agents must yield two
+    # distinct prov:Attribution blank nodes, each carrying its own
+    # prov:agent -- not a single node whose agent is ambiguous or lost.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.attribution("ex:e1", "ex:ag1", other_attributes={"ex:k": "v1"})
+    document.attribution("ex:e1", "ex:ag2", other_attributes={"ex:k": "v2"})
+    buf = BytesIO()
+    document.serialize(destination=buf, format="rdf", rdf_format="trig")
+    buf.seek(0)
+    graph = Dataset(default_union=True)
+    graph.parse(buf, format="trig")
+
+    agent_pred = URIRef("http://www.w3.org/ns/prov#agent")
+    ag1 = URIRef("http://example.org/ag1")
+    ag2 = URIRef("http://example.org/ag2")
+    attribution_nodes = {
+        stmt[0]
+        for stmt in graph.triples(
+            (None, RDF.type, URIRef("http://www.w3.org/ns/prov#Attribution"))
+        )
+    }
+    assert len(attribution_nodes) == 2
+    nodes_with_ag1 = {
+        node for node in attribution_nodes if (node, agent_pred, ag1) in graph
+    }
+    nodes_with_ag2 = {
+        node for node in attribution_nodes if (node, agent_pred, ag2) in graph
+    }
+    assert len(nodes_with_ag1) == 1
+    assert len(nodes_with_ag2) == 1
+    assert nodes_with_ag1 != nodes_with_ag2
+
+
+def test_legacy_qualified_delegation_without_influencer_still_parses():
+    # Documents produced by prov <=2.x (pre-#250) never asserted an
+    # influencer property directly on an anonymous qualification node --
+    # only the binary triple and (for delegation) prov:hadActivity. Such
+    # legacy input must still deserialize without error. Where two legacy
+    # nodes are genuinely ambiguous (same subject, no distinguishing
+    # prov:agent on either), decoding falls back to the old "last node seen"
+    # behaviour and -- as before #250 -- may collapse the pair; that is the
+    # documented pre-existing #226 limitation for legacy input, not a crash.
+    legacy_trig = """
+    @prefix ex: <http://example.org/> .
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    {
+        ex:ag2 prov:actedOnBehalfOf ex:ag1 ;
+               prov:actedOnBehalfOf ex:ag2 ;
+               prov:qualifiedDelegation _:b1 , _:b2 .
+        _:b1 a prov:Delegation ;
+             prov:hadActivity ex:a .
+        _:b2 a prov:Delegation ;
+             prov:hadActivity ex:a .
+    }
+    """
+    document = ProvDocument.deserialize(
+        content=legacy_trig, format="rdf", rdf_format="trig"
+    )
+    delegations = [
+        record
+        for record in document.get_records()
+        if record.get_type().localpart == "Delegation"
+    ]
+    assert len(delegations) == 2


### PR DESCRIPTION
Back-ports #291 (fix for #250/#226) to `2.x` for the 2.5.3 maintenance release. This is task 2 of the 2.x stage-2 back-port programme; task 1 (#287, PROV-N escaping) already merged.

## What changed

An anonymous `prov:qualified*` node minted for communication, attribution, delegation, or influence now asserts its own influencer property directly (`prov:activity`/`prov:agent`/`prov:agent`/`prov:influencer` respectively), as PROV-O section 3.1's qualification tables require, instead of leaving it only implied by the relation's shorthand binary triple (#250).

Decoding now uses that property to disambiguate several same-kind qualification nodes attached to the same subject, replacing the previous "last node seen" guess that could silently collapse distinct relations into one (#226). Legacy input produced before this fix (no influencer triple on the node) still parses, falling back to the old "last node seen" behaviour.

## Divergence from master's implementation

Two structural differences from `master`'s #291, both because 2.x predates later refactors:

1. `master`'s encode side lives in a decomposed `_encode_relation_binary_triple` helper (added by #290); 2.x still has the pre-#290 monolithic `encode_document` loop, so the fix is a small `elif` branch inside that loop rather than a helper change.
2. `master`'s decode side already generalised the qualification-node disambiguation to five relation families (a later change, #309, not yet back-ported); 2.x's decode side only ever special-cased `actedOnBehalfOf`/`wasAssociatedWith` (delegation/association) in one `elif` branch, so that is the only branch this PR touches. The disambiguation loop is written so a later back-port of #309's generalisation from two families to five is a natural extension, not a rewrite.

The fix itself -- un-consume the influencer formal attribute on the encode side when a qualification node is being minted so the generic attribute-emission loop asserts it on the node, and prefer the candidate node whose `prov:agent` matches the binary triple's object on the decode side -- is equivalent to `master`'s.

## Conformance note

This adds triples to RDF output for anonymous qualified nodes that previously had none. That is admitted to this patch release because the previous output was **non-conformant** with the PROV-O section 3.1 qualification tables -- the added triples are required by the spec, not optional/cosmetic.

## Tests

- Three tests ported by hand from `master`'s `test_rdf.py` (which has diverged too far from 2.x's for `git apply` to work): `test_anonymous_qualified_node_carries_influencer` (parametrized x4: communication/attribution/delegation/influence), `test_anonymous_attributions_to_different_agents_each_carry_their_own_agent`, `test_legacy_qualified_delegation_without_influencer_still_parses`.
- `test_qualified_delegation_pair_survives_rdf_roundtrip`'s `strict=True` xfail (guarding #226) is removed, matching `master`'s diff -- the fix makes it pass, and a strict xfail that unexpectedly passes fails the suite.
- `strategies.py`'s Hypothesis corpus restores `container.delegation(g1, g2, pick(activities))` (previously omitted the qualifying activity to dodge #226), applied cleanly via `git apply --3way` from master's diff.
- Confirmed red: with only the test/strategies changes and `provrdf.py` reverted, the five new non-legacy test items fail, and `test_property_roundtrip.py::test_generated_document_roundtrips[rdf]` fails reproducing #226 (two anonymous delegations sharing delegate+qualifying-activity but differing in `responsible` collapse to one on RDF round-trip).
- Confirmed green: all of the above pass with `provrdf.py` fixed, full local matrix (ruff check, ruff format --check, mypy --strict) clean.

## Full suite

Branch point `origin/2.x` (385d667): 1180 passed / 22 skipped / 14 xfailed.
This branch: **1187 passed / 22 skipped / 13 xfailed** -- +6 new test items (4 parametrized + 2) plus +1 test converted from xfail to a normal pass (the #226 regression guard, now fixed), and the xfail count drops by exactly that 1. No other skip/xfail movement.