### PR TITLE
Back-port #300: PROV-XML round-trips empty-string values and non-NCName attribute names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,11 @@
   interpretable without its shorthand binary triple (#250). Decoding uses
   that property to tell several same-kind qualification nodes apart instead
   of guessing (#226).
+- PROV-XML now round-trips empty-string attribute values, which previously
+  vanished entirely because lxml reports an empty element's text as `None`
+  (#224), and escapes attribute-name local parts that are not legal XML
+  NCNames using the `_xHHHH_` convention instead of emitting invalid XML
+  (#289).
 
 ## 2.5.2 (2026-08-08)
 

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -5,6 +5,7 @@ from __future__ import annotations  # needed for | type annotations in Python < 
 import datetime
 import io
 import logging
+import re
 import warnings
 from typing import Any
 
@@ -188,7 +189,11 @@ class ProvXMLSerializer(Serializer):
 
             for attr, value in sorted_attributes(rec_type, attributes):
                 subelem = etree.SubElement(
-                    elem, _ns(attr.namespace.uri, attr.localpart)
+                    elem,
+                    _ns(
+                        attr.namespace.uri,
+                        _escape_ncname_localpart(attr.localpart),
+                    ),
                 )
                 if isinstance(value, prov.model.Literal):
                     if (
@@ -457,9 +462,8 @@ def _extract_attributes(
     _unassigned = object()
     for subel in element:
         sqname = etree.QName(subel)
-        qname_str = (
-            f"{subel.prefix}:{sqname.localname}" if subel.prefix else sqname.localname
-        )
+        localname = _unescape_ncname_localpart(sqname.localname)
+        qname_str = f"{subel.prefix}:{localname}" if subel.prefix else localname
         _t = xml_qname_to_QualifiedName(subel, qname_str)
 
         _v: Any = _unassigned
@@ -472,9 +476,18 @@ def _extract_attributes(
                 if datatype == XSD_QNAME:
                     _v = xml_qname_to_QualifiedName(subel, subel.text)  # type: ignore[arg-type]
                 else:
-                    _v = prov.model.Literal(subel.text, datatype)
+                    # An empty XSD-typed text value (e.g. prov:value="")
+                    # round-trips through lxml as .text is None rather than
+                    # "" (#224); coalesce back to the empty string.
+                    _v = prov.model.Literal(
+                        subel.text if subel.text is not None else "", datatype
+                    )
             elif key == _ns_xml("lang"):
-                _v = prov.model.Literal(subel.text, langtag=value_str)
+                # Same None/"" coalescing as above, for language-tagged
+                # literals (#224).
+                _v = prov.model.Literal(
+                    subel.text if subel.text is not None else "", langtag=value_str
+                )
             else:
                 warnings.warn(
                     f"The element '{_t}' contains an attribute {key!s}='{value!s}' "
@@ -485,7 +498,14 @@ def _extract_attributes(
                 )
 
         if not subel.attrib:
-            _v = subel.text
+            # A plain-text attribute value (no xsi:type/xml:lang/prov:ref):
+            # lxml reports an empty element's .text as None rather than ""
+            # (e.g. <ex:k0></ex:k0>), which would otherwise make the
+            # attribute vanish entirely once None reaches record
+            # construction. Coalesce back to the empty string (#224). This
+            # does not affect optional formal attributes that are absent
+            # from the XML altogether: those never enter this loop.
+            _v = subel.text if subel.text is not None else ""
 
         if _v is _unassigned:
             raise ProvXMLException(
@@ -566,3 +586,89 @@ def _ns_xsi(tag: str) -> str:
 def _ns_xml(tag: str) -> str:
     NS_XML = "http://www.w3.org/XML/1998/namespace"
     return _ns(NS_XML, tag)
+
+
+# Character classes for the XML 1.0 5th-edition Name productions, minus ':'
+# (NCName), used to detect/escape attribute-name local parts that are not
+# legal NCNames when used as PROV-XML element tags (#289).
+#
+# Every range boundary is spelled as a \xHH/\uHHHH/\UHHHHHHHH escape (never
+# a literal glyph) and annotated with the spec clause it implements, so a
+# mangled/look-alike codepoint (as happened once with the CJK-compatibility
+# range below, which briefly read U+8C48 instead of U+F900) is visible on
+# inspection rather than hiding in the source as an indistinguishable glyph.
+_NCNAME_START_CHARS = (
+    "\x41-\x5a"  # NameStartChar: [A-Z]
+    "\x5f"  # NameStartChar: "_"
+    "\x61-\x7a"  # NameStartChar: [a-z]
+    "\xc0-\xd6"  # NameStartChar: [#xC0-#xD6]
+    "\xd8-\xf6"  # NameStartChar: [#xD8-#xF6]
+    "\xf8-\u02ff"  # NameStartChar: [#xF8-#x2FF]
+    "\u0370-\u037d"  # NameStartChar: [#x370-#x37D]
+    "\u037f-\u1fff"  # NameStartChar: [#x37F-#x1FFF]
+    "\u200c-\u200d"  # NameStartChar: [#x200C-#x200D]
+    "\u2070-\u218f"  # NameStartChar: [#x2070-#x218F]
+    "\u2c00-\u2fef"  # NameStartChar: [#x2C00-#x2FEF]
+    "\u3001-\ud7ff"  # NameStartChar: [#x3001-#xD7FF]
+    "\uf900-\ufdcf"  # NameStartChar: [#xF900-#xFDCF]
+    "\ufdf0-\ufffd"  # NameStartChar: [#xFDF0-#xFFFD]
+    "\U00010000-\U000effff"  # NameStartChar: [#x10000-#xEFFFF]
+)
+_NCNAME_CHARS = _NCNAME_START_CHARS + (
+    "\\-"  # NameChar: "-" (escaped: literal, not a range operator)
+    "\x2e"  # NameChar: "."
+    "\x30-\x39"  # NameChar: [0-9]
+    "\xb7"  # NameChar: #xB7
+    "\u0300-\u036f"  # NameChar: [#x0300-#x036F]
+    "\u203f-\u2040"  # NameChar: [#x203F-#x2040]
+)
+_NCNAME_START_RE = re.compile(f"[{_NCNAME_START_CHARS}]")
+_NCNAME_CHAR_RE = re.compile(f"[{_NCNAME_CHARS}]")
+_NCNAME_RE = re.compile(f"[{_NCNAME_START_CHARS}][{_NCNAME_CHARS}]*")
+# One escaped char: _x + 4 (BMP) or 8 (astral) uppercase hex digits + _
+_XML_NAME_ESCAPE_RE = re.compile(r"_x[0-9A-F]{4}(?:[0-9A-F]{4})?_")
+
+
+def _escape_ncname_localpart(local: str) -> str:
+    """Escape NCName-illegal characters in an attribute-name local part.
+
+    PROV attribute names are written as PROV-XML element tags, but an
+    attribute's local part is not guaranteed to be a legal XML NCName (it
+    may start with a digit, contain ``'``, ``(``, ``,`` etc. — none of
+    which prov itself restricts, per #257's no-assertion-time-enforcement
+    stance). Rather than raising, illegal characters are escaped using the
+    ``_xHHHH_`` convention (as used by the OpenXML/SQL Server ecosystems
+    for the same problem), so the name round-trips losslessly instead of
+    being rejected or silently corrupted.
+
+    A literal run that itself looks like an escape sequence gets its
+    introducing underscore self-escaped as ``_x005F_`` so decoding via
+    :func:`_unescape_ncname_localpart` is always the exact inverse of this
+    function, including for names produced by this package itself (#289):
+    ``"_x0041_"`` (a literal name that happens to look like an escaped
+    ``"A"``) becomes ``"_x005F_x0041_"``, not ``"_x0041_"`` unchanged
+    (which would decode back to ``"A"``) or ``"A"`` (which would lose the
+    original name). The same applies when the look-alike run is embedded
+    inside an otherwise-legal name, e.g. ``"prefix_x0041_suffix"``.
+
+    Names that are already legal NCNames and contain no ``_xHHHH_``-shaped
+    run are returned unchanged, so existing output is byte-identical.
+    """
+    if not _XML_NAME_ESCAPE_RE.search(local) and _NCNAME_RE.fullmatch(local):
+        return local
+    out = []
+    for i, char in enumerate(local):
+        char_re = _NCNAME_START_RE if i == 0 else _NCNAME_CHAR_RE
+        if char == "_" and _XML_NAME_ESCAPE_RE.match(local, i):
+            out.append("_x005F_")
+        elif char_re.fullmatch(char):
+            out.append(char)
+        else:
+            code = ord(char)
+            out.append(f"_x{code:04X}_" if code <= 0xFFFF else f"_x{code:08X}_")
+    return "".join(out)
+
+
+def _unescape_ncname_localpart(local: str) -> str:
+    """Invert :func:`_escape_ncname_localpart`."""
+    return _XML_NAME_ESCAPE_RE.sub(lambda m: chr(int(m.group(0)[2:-1], 16)), local)

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -48,13 +48,9 @@ local_part = st.text(
 # not a serializer behaviour we could round-trip; RDF handles every Cc codepoint
 # unchanged). Excluding both is a generation-validity narrowing (not a serializer
 # behaviour change) — the values that remain still cover the full non-ASCII range.
-# min_size=1: an *empty*-string attribute value is dropped entirely by the XML
-# serializer (the attribute vanishes on round trip), while JSON and RDF preserve
-# it — #224, a genuine XML round-trip bug deferred to 3.0, excluded here rather
-# than fixed under the 2.x output freeze.
 text_values = st.text(
     alphabet=st.characters(exclude_categories=("Cs", "Cc")),
-    min_size=1,
+    min_size=0,
     max_size=30,
 )
 

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -14,6 +14,8 @@ from prov.identifier import Namespace, QualifiedName
 from prov.serializers.provxml import (
     ProvXMLException,
     ProvXMLSerializer,
+    _escape_ncname_localpart,
+    _unescape_ncname_localpart,
     xml_qname_to_QualifiedName,
 )
 from prov.tests.conftest import roundtrip_document
@@ -513,19 +515,146 @@ def test_xml_qname_to_qualifiedname_without_colon_or_default_ns_raises():
     assert "Could not create a valid QualifiedName" in str(ctx.value)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="#224: the XML serializer drops an attribute whose value is the "
-    "empty string; it vanishes on the round trip (JSON and RDF preserve it). "
-    "Regression guard from the Hypothesis property tests; remove when #224 is "
-    "fixed in 3.0.",
-)
 def test_empty_string_attribute_survives_xml_roundtrip():
     document = prov.ProvDocument()
     document.add_namespace("ex", "http://example.org/")
     document.agent("ex:g0", {"ex:k0": ""})
     assert roundtrip_document(document, "xml") == document
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        pytest.param({"ex:k0": ""}, id="plain-attribute"),
+        pytest.param({"prov:label": ""}, id="prov-label"),
+        pytest.param({"prov:value": ""}, id="prov-value"),
+        pytest.param({"ex:lit": prov.Literal("", langtag="en")}, id="literal-langtag"),
+    ],
+)
+def test_empty_string_value_shapes_survive_xml_roundtrip(attributes):
+    # #224: an empty-string value must not vanish on the round trip,
+    # regardless of which XML shape it takes (plain text, prov:label,
+    # prov:value with an inferred xsd:string type, or a language-tagged
+    # Literal). The fix must not special-case just one of these paths.
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.agent("ex:g0", attributes)
+    assert roundtrip_document(document, "xml") == document
+
+
+def test_absent_optional_formal_attribute_stays_none_after_xml_roundtrip():
+    # Regression guard for #224: a genuinely *absent* optional formal
+    # attribute (no XML element for it at all) must still deserialize as
+    # None, not be coalesced into the empty string.
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.wasGeneratedBy("ex:e1", "ex:a1")
+    roundtripped = roundtrip_document(document, "xml")
+    assert roundtripped == document
+    (generation,) = [
+        rec
+        for rec in roundtripped.get_records()
+        if rec.get_type() == PROV["Generation"]
+    ]
+    formal = dict(generation.formal_attributes)
+    assert formal[PROV["time"]] is None
+
+
+def test_attribute_name_with_ncname_illegal_characters_survives_xml_roundtrip():
+    # #289 repro: an attribute name containing characters illegal in an XML
+    # NCName must not raise, and must round-trip losslessly.
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1", {"ex:weird'key": "value"})
+    assert roundtrip_document(document, "xml") == document
+
+
+@pytest.mark.parametrize(
+    "local_part",
+    [
+        pytest.param("weird'key", id="apostrophe"),
+        pytest.param("has(parens)", id="parens"),
+        pytest.param("has,comma", id="comma"),
+        pytest.param("has:colon", id="colon"),
+        pytest.param("has;semi", id="semicolon"),
+        pytest.param("has[bracket]", id="brackets"),
+        pytest.param("has=equals", id="equals"),
+        pytest.param("0leadingdigit", id="leading-digit"),
+    ],
+)
+def test_ncname_illegal_attribute_names_roundtrip_xml(local_part):
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1", {f"ex:{local_part}": "value"})
+    assert roundtrip_document(document, "xml") == document
+
+
+def test_valid_ncname_attribute_name_serializes_byte_identically():
+    # Names that are already legal NCNames must not gain any _xHHHH_
+    # escaping -- existing output stays byte-identical (#289).
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1", {"ex:plainKey0": "value"})
+    with io.BytesIO() as stream:
+        document.serialize(destination=stream, format="xml")
+        xml_text = stream.getvalue().decode("utf-8")
+    assert "_x" not in xml_text
+    assert "<ex:plainKey0>" in xml_text
+
+
+def test_literal_ncname_escape_shaped_attribute_name_roundtrips_xml():
+    # A literal attribute name that itself already looks like an _xHHHH_
+    # escape sequence must still round-trip: the write side self-escapes
+    # its introducing underscore (as _x005F_) so the read side's inverse
+    # transform recovers the original name exactly (#289).
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1", {"ex:_x0041_": "value"})
+    assert roundtrip_document(document, "xml") == document
+
+
+@pytest.mark.parametrize(
+    "local",
+    [
+        pytest.param("plainKey0", id="plain"),
+        pytest.param("weird'key", id="apostrophe"),
+        pytest.param("0leadingdigit", id="leading-digit"),
+        pytest.param("a(b)c,d;e:f[g]h=i", id="metacharacters"),
+        pytest.param("_x0041_", id="escape-lookalike"),
+        pytest.param("_", id="bare-underscore"),
+        pytest.param("café", id="legal-non-ascii-letter"),
+        pytest.param("a_x005F_x0041_b", id="embedded-escape-lookalike"),
+        pytest.param("", id="empty"),
+        # Boundary cases from the XML 1.0 5th-edition NameStartChar
+        # productions (#289's PUA-vs-CJK-compatibility bug: the range
+        # meant to be #xF900-#xFDCF briefly started at U+8C48 instead,
+        # which wrongly treated U+D800-U+F8FF -- including the whole
+        # Private Use Area -- as legal).
+        pytest.param("attr\ue000", id="pua-start-illegal"),
+        pytest.param("attr\uf8ff", id="pua-end-illegal"),
+        pytest.param("attr\uf900", id="cjk-compat-start-legal"),
+        pytest.param("attr\U0001f600", id="astral-legal"),
+        pytest.param("attr\U0010ffff", id="astral-above-legal-range"),
+    ],
+)
+def test_escape_unescape_ncname_localpart_is_inverse(local):
+    escaped = _escape_ncname_localpart(local)
+    # The pair must be an exact inverse ...
+    assert _unescape_ncname_localpart(escaped) == local
+    # ... AND, for any non-empty input, the escaped form must actually be an
+    # XML name lxml accepts as an element tag. This second assertion is what
+    # would have caught the PUA bug above: the escape function trusted a
+    # wrong "legal" verdict from _NCNAME_START_RE/_NCNAME_CHAR_RE and left
+    # the PUA character unescaped, which the first assertion alone can't
+    # detect (unescaping unescaped text is a no-op, so it still looks like a
+    # valid inverse). An empty local part has nothing to escape and stays
+    # empty either way -- that it cannot form a tag name is a separate,
+    # pre-existing "no name at all" limitation, not an NCName-legality bug,
+    # so it is exempted from this assertion.
+    if local:
+        etree.Element(escaped)
 
 
 # Hardening against XXE / entity expansion (#273).
@@ -639,13 +768,12 @@ def test_external_entity_does_not_leak_file_contents(tmp_path):
     assert "TOPSECRET123" not in document.get_provn()
     entity = next(iter(document.get_records(prov.ProvEntity)))
     values = list(entity.get_attribute(PROV["type"]))
-    # The reference is left unresolved, so the element carries no text. On
-    # 2.x that surfaces as the string "None": the element's text is None and
-    # the pre-#224 attribute extraction stringifies it. Once the #224 fix
-    # lands (queued for 2.5.3) the same value becomes "". Both spellings are
-    # accepted here so this test survives that change; what it actually pins
-    # is that neither ever contains the referenced file's contents.
-    assert values in ([""], ["None"])
+    # The reference is left unresolved, so the element carries no text.
+    # #224's None->"" coalescing (2.5.3) means that now surfaces as the
+    # empty string rather than the literal "None" 2.x used to stringify it
+    # to; what this pins is that it never contains the referenced file's
+    # contents.
+    assert values == [""]
     assert "TOPSECRET123" not in str(values)
 
 


### PR DESCRIPTION
Back-ports master #300 to 2.x.

PROV-XML silently dropped any attribute whose value was the empty string, because lxml reports an empty element's `.text` as `None` rather than `""` (#224); JSON and RDF preserve the empty string, only XML lost it. Attribute-name local parts containing characters illegal in an XML NCName (an apostrophe, a leading digit, `(`, `,`, `:`, `;`, `[`, `]`, `=`) had no safe representation as an element tag (#289).

## What changed

- `src/prov/serializers/provxml.py`: `None` is coalesced to `""` only for attribute values that are actually present in the parsed XML — an optional formal attribute that is genuinely absent from the XML still decodes as `None`, not `""`. NCName-illegal local parts are escaped on serialize and unescaped on deserialize using the `_xHHHH_` convention (as used elsewhere for this exact problem); a literal name that already looks like an `_xHHHH_` escape self-escapes its introducing underscore so decoding is always the exact inverse of encoding.
- `src/prov/tests/test_xml.py`: seven tests ported verbatim from master's #300 (`test_empty_string_value_shapes_survive_xml_roundtrip`, `test_absent_optional_formal_attribute_stays_none_after_xml_roundtrip`, `test_attribute_name_with_ncname_illegal_characters_survives_xml_roundtrip`, `test_ncname_illegal_attribute_names_roundtrip_xml`, `test_valid_ncname_attribute_name_serializes_byte_identically`, `test_literal_ncname_escape_shaped_attribute_name_roundtrips_xml`, `test_escape_unescape_ncname_localpart_is_inverse`); the pre-existing `strict=True` xfail on `test_empty_string_attribute_survives_xml_roundtrip` is removed since the fix makes it pass.
- `test_external_entity_does_not_leak_file_contents` (the #273/2.5.2 XXE regression guard) is deliberately tightened from `assert values in ([""], ["None"])` to `assert values == [""]`: the `"None"` alternative existed only to tolerate 2.x's pre-fix behaviour of stringifying the unresolved entity reference's `None` text; this fix's `None`→`""` coalescing removes that case, so the loose assertion is no longer needed.
- `src/prov/tests/strategies.py`: `text_values`'s Hypothesis strategy drops its `min_size=1` floor (now `min_size=0`) and the accompanying `#224` comment, since the empty string now round-trips through XML. This retires only the #224 generation exclusion; master's companion `attr_key_part`→`local_part` change is intentionally **not** ported, since 2.x's attribute keys already draw from `local_part` (ASCII lowercase + digits), so there is no NCName-illegal-key exclusion to retire there, and widening `local_part` itself is out of scope for this back-port.
- `HISTORY.md`: entry appended to the `2.5.3 (unreleased)` section.

## Verification

- Confirmed the ported tests fail before the source fix (collection-time `ImportError` on the two new private helpers, plus the target subset failing against unfixed `provxml.py`).
- `uv run --extra rdf --extra xml pytest src/prov/tests/test_xml.py -q` → 51 passed after the fix.
- `uv run --extra rdf --extra xml pytest src/prov/tests/test_property_roundtrip.py -q` → 3 passed after the `strategies.py` change.
- Full suite: 1218 passed, 22 skipped, 12 xfailed (baseline at `origin/2.x` was 1187/22/13 — the +31 passed is 30 new test items plus the one pre-existing `test_empty_string_attribute_survives_xml_roundtrip` reclassified from xfail to pass now that the bug it guarded is fixed, which also explains the xfail count dropping from 13 to 12; skips unchanged).

## Test plan

- [x] Seven ported tests pass
- [x] Reverting only `provxml.py` reproduces the pre-fix failure (captured)
- [x] `test_external_entity_does_not_leak_file_contents` passes with the tightened `values == [""]` assertion
- [x] `test_property_roundtrip.py` passes with `text_values` `min_size=0`
- [x] Full suite green at baseline + this task's tests
- [ ] CI green on this PR