### PR TITLE
Back-port #308: decode startedAtTime/endedAtTime on qualified Start/End into formal prov:time

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,10 @@
 - The PROV-JSON deserializer now raises `ProvJSONException` with a message
   naming the offending construct when given malformed input, instead of
   letting `KeyError`, `AttributeError` or `TypeError` escape (#228).
+- `prov:startedAtTime` and `prov:endedAtTime` asserted directly on a
+  qualified `prov:Start`/`prov:End` node are now decoded into the relation's
+  formal `prov:time` attribute, instead of being stripped into extra
+  attributes (#299).
 
 ## 2.5.2 (2026-08-08)
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -926,6 +926,15 @@ class ProvRDFSerializer(Serializer):
                     pred_new = PROV_ATTR_ENDER
                 if record_types[subj] in [PROV_START] and "activity" in str(pred_new):
                     pred_new = PROV_ATTR_STARTER
+                # #299: some producers put the binary-triple predicates
+                # prov:startedAtTime/prov:endedAtTime directly on the
+                # qualified Start/End node rather than prov:atTime. Rewrite
+                # them onto the generic prov:time formal attribute, so they
+                # are decoded like every other timed relation's time.
+                if record_types[subj] in [PROV_END] and "endTime" in str(pred_new):
+                    pred_new = PROV_ATTR_TIME
+                if record_types[subj] in [PROV_START] and "startTime" in str(pred_new):
+                    pred_new = PROV_ATTR_TIME
                 if record_types[subj] == PROV_DERIVATION and "entity" in str(pred_new):
                     pred_new = PROV_ATTR_USED_ENTITY
                 if str(pred_new) in [val.uri for val in formal_attributes[subj]]:

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -6,6 +6,7 @@ pytest-native ``fmt`` matrix (see ``conftest.py`` and the ``test_statements``/
 only the genuinely RDF-specific cases.
 """
 
+import datetime
 import logging
 import os
 import struct
@@ -19,7 +20,7 @@ from rdflib.compare import graph_diff
 from rdflib.graph import ConjunctiveGraph, Dataset, Graph
 
 import prov.model as pm
-from prov.model import ProvDocument
+from prov.model import ProvDocument, ProvException
 from prov.serializers.provrdf import (
     ProvRDFException,
     ProvRDFSerializer,
@@ -512,3 +513,121 @@ def test_legacy_qualified_delegation_without_influencer_still_parses():
         if record.get_type().localpart == "Delegation"
     ]
     assert len(delegations) == 2
+
+
+def test_decode_qualified_start_started_at_time_lands_in_formal_time():
+    # #299: some PROV-O producers put the time on a qualified prov:Start
+    # node using the binary prov:startedAtTime predicate (which prov's own
+    # encoder never emits for a qualified node -- it always uses
+    # prov:atTime there) rather than the generic prov:atTime spelling.
+    # Document equality would pass even with the bug (that is exactly why
+    # it stayed invisible), so this asserts formal_attributes/extra_attributes
+    # directly instead.
+    turtle = """
+    @prefix ex: <http://example.org/> .
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:a1 a prov:Activity ;
+        prov:qualifiedStart ex:n1 .
+
+    ex:n1 a prov:Start ;
+        prov:startedAtTime "2020-01-01T00:00:00"^^xsd:dateTime ;
+        prov:entity ex:trig .
+    """
+    doc = ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    (start,) = [r for r in doc.get_records() if type(r).__name__ == "ProvStart"]
+    formal = dict(start.formal_attributes)
+    time_values = {value for name, value in formal.items() if name.localpart == "time"}
+    assert time_values == {datetime.datetime(2020, 1, 1, 0, 0, 0)}
+    extra_names = {str(name) for name, _value in start.extra_attributes}
+    assert "prov:startTime" not in extra_names
+
+
+def test_decode_qualified_end_ended_at_time_lands_in_formal_time():
+    # #299, End's half of the fix above.
+    turtle = """
+    @prefix ex: <http://example.org/> .
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:a1 a prov:Activity ;
+        prov:qualifiedEnd ex:n1 .
+
+    ex:n1 a prov:End ;
+        prov:endedAtTime "2020-01-01T00:00:00"^^xsd:dateTime ;
+        prov:entity ex:trig .
+    """
+    doc = ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    (end,) = [r for r in doc.get_records() if type(r).__name__ == "ProvEnd"]
+    formal = dict(end.formal_attributes)
+    time_values = {value for name, value in formal.items() if name.localpart == "time"}
+    assert time_values == {datetime.datetime(2020, 1, 1, 0, 0, 0)}
+    extra_names = {str(name) for name, _value in end.extra_attributes}
+    assert "prov:endTime" not in extra_names
+
+
+def test_decode_duplicated_started_at_time_on_qualified_start_raises_documented_limitation():
+    # #217 guard: the #299 rewrite must not resurrect the rejected
+    # permutation-decode option. Two prov:startedAtTime values on the same
+    # identified qualified prov:Start node are just as irreconcilable as two
+    # prov:atTime values, and must fail rather than silently fabricating two
+    # same-identifier records.
+    #
+    # On `master`, this failure is relabelled with a friendly
+    # "documented PROV-O representational limitation" message pointing at
+    # conformance.md (see `_repeated_formal_attribute`/`_emit_decoded_records`
+    # in `provrdf.py`). That relabelling was introduced by a separate,
+    # 3.0-only commit ("Document #217 as a permanent PROV-O representational
+    # limitation") that Stage 2 does not back-port, so on 2.x the same
+    # duplicate-value case still raises the raw
+    # `ProvRecord.add_attributes()` message. This test is adapted to assert
+    # that raw message instead, while still guarding the behaviour that
+    # matters here: a ProvException, not a second fabricated record.
+    turtle = """
+    @prefix ex: <http://example.org/> .
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    ex:a1 a prov:Activity ;
+        prov:qualifiedStart ex:n1 .
+
+    ex:n1 a prov:Start ;
+        prov:entity ex:trig ;
+        prov:startedAtTime "2020-01-01T00:00:00"^^xsd:dateTime,
+            "2021-01-01T00:00:00"^^xsd:dateTime .
+    """
+    with pytest.raises(ProvException) as ctx:
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    message = str(ctx.value)
+    assert "Cannot have more than one value for attribute" in message
+    assert "prov:time" in message
+
+
+def test_decode_qualified_start_at_time_still_lands_in_formal_time():
+    # Regression: prov's own qualified-node spelling (prov:atTime, built via
+    # the model API's start(..., time=...)) must keep decoding onto the
+    # formal prov:time slot exactly as before the #299 rewrite.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.start(
+        "ex:a1", "ex:e1", identifier="ex:s1", time=datetime.datetime(2020, 1, 1)
+    )
+
+    rdf = document.serialize(format="rdf")
+
+    # Encode must be unaffected by this decode-only fix: the qualified node
+    # still uses prov:atTime, never the binary prov:startedAtTime spelling.
+    assert "prov:atTime" in rdf
+    assert "startedAtTime" not in rdf
+
+    decoded = ProvDocument.deserialize(content=rdf, format="rdf")
+    (start,) = [r for r in decoded.get_records() if type(r).__name__ == "ProvStart"]
+    formal = dict(start.formal_attributes)
+    time_values = {value for name, value in formal.items() if name.localpart == "time"}
+    assert time_values == {datetime.datetime(2020, 1, 1, 0, 0, 0)}


### PR DESCRIPTION
## Summary

Back-ports #308 (the 3.1.0-line fix) to `2.x` for 2.5.3: `prov:startedAtTime`/`prov:endedAtTime` asserted directly on a qualified `prov:Start`/`prov:End` node (rather than the generic `prov:atTime` prov's own encoder always uses there) now decode into the relation's formal `prov:time` attribute instead of being stripped into extra attributes (#299).

## Divergence from master

2.x has the pre-#290 flat `if`-chain in the decode loop, not master's `_DECODE_PREDICATE_REWRITES` dispatch table, so the two new rewrite branches are appended to that chain in `src/prov/serializers/provrdf.py` rather than added as dict entries.

Master's diff for #308 also updates a `_repeated_formal_attribute` docstring. That function does not exist on 2.x -- it arrived with #290's decode refactor, which this back-port programme does not port -- confirmed by `git grep -n "_repeated_formal_attribute\|currently-mishandled" -- src/prov/serializers/provrdf.py` returning no matches. That hunk is skipped.

## Test adaptation

Four tests were ported from master's `8870cad` diff of `test_rdf.py`. Three port unmodified. The fourth, `test_decode_duplicated_started_at_time_on_qualified_start_raises_documented_limitation`, is adapted: on master, a duplicate-value decode failure is relabelled with a friendly "documented PROV-O representational limitation" message pointing at `conformance.md`, but that relabelling was introduced by a separate, later, 3.0-only commit ("Document #217 as a permanent PROV-O representational limitation") that is out of scope for this back-port programme. On 2.x the same duplicate-value input still raises the raw `ProvRecord.add_attributes()` message ("Cannot have more than one value for attribute prov:time"), so the test now asserts that message instead, while still guarding the behaviour that matters: a `ProvException` is raised rather than the fix silently resurrecting the rejected permutation-decode option (two same-identifier records).

## Test plan

- [x] Reverting only `provrdf.py` makes all four ported tests fail (captured).
- [x] `uv run --extra rdf --extra xml pytest src/prov/tests/test_rdf.py -q` -- 23 passed, 1 xfailed.
- [x] `uv run --extra rdf --extra xml pytest -q` -- 1227 passed, 22 skipped, 12 xfailed (baseline 1223 + 4 new tests; skip/xfail counts unchanged).
- [ ] CI green on this PR.