### PR TITLE
Reconcile anonymous Communication/Attribution/Influence relations on RDF decode

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,10 @@
   qualified `prov:Start`/`prov:End` node are now decoded into the relation's
   formal `prov:time` attribute, instead of being stripped into extra
   attributes (#299).
+- Anonymous attribution, communication and influence relations carrying
+  extra attributes now reconcile onto their `prov:qualified*` node when
+  decoded from RDF, as delegation and association already did, instead of
+  producing a duplicate record (#303).
 
 ## 2.5.2 (2026-08-08)
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -121,6 +121,22 @@ RELATION_MAP = {
 :meth:`~ProvRDFSerializer.decode_container`: maps each PROV-O relation
 predicate URIRef to the name of the :class:`~prov.model.ProvBundle` factory
 method used to recreate it (e.g. ``bundle.derivation(...)``)."""
+
+#: Relation families that emit both a binary triple and a prov:qualified*
+#: node for an anonymous relation with extra attributes; on decode the binary
+#: triple is reconciled onto that qualified node (its first two formal
+#: attributes) rather than creating a second record. Maps each family's
+#: factory name to the PROV-O predicate that carries its influencer on the
+#: qualified node (used to disambiguate when a subject points at several
+#: nodes of the same kind, #226/#250).
+_QUALIFIED_RELATION_INFLUENCER: dict[str, URIRef] = {
+    "delegation": URIRef(PROV["agent"].uri),
+    "association": URIRef(PROV["agent"].uri),
+    "attribution": URIRef(PROV["agent"].uri),
+    "communication": URIRef(PROV["activity"].uri),
+    "influence": URIRef(PROV["influencer"].uri),
+}
+
 PREDICATE_MAP = {
     RDFS.label: pm.PROV["label"],
     URIRef(PROV["atLocation"].uri): PROV_LOCATION,
@@ -870,14 +886,11 @@ class ProvRDFSerializer(Serializer):
                     getattr(bundle, relation_mapper[pred])(
                         subj, str(obj), mentionBundle
                     )
-                elif "actedOnBehalfOf" in pred or "wasAssociatedWith" in pred:
-                    qualifier = (
-                        "qualified"
-                        + relation_mapper[pred].upper()[0]
-                        + relation_mapper[pred][1:]
-                    )
+                elif relation_mapper[pred] in _QUALIFIED_RELATION_INFLUENCER:
+                    name = relation_mapper[pred]
+                    qualifier = "qualified" + name.upper()[0] + name[1:]
                     qualifier_bnode = None
-                    agent_pred = URIRef(pm.PROV["agent"].uri)
+                    influencer_pred = _QUALIFIED_RELATION_INFLUENCER[name]
                     for stmt in graph.triples(
                         (URIRef(subj), URIRef(pm.PROV[qualifier].uri), None)
                     ):
@@ -888,14 +901,14 @@ class ProvRDFSerializer(Serializer):
                         # activity, differing only in `responsible` -- which
                         # "last node seen" cannot tell apart. Since #250, a
                         # freshly-encoded node also carries its own
-                        # `prov:agent` triple, so prefer whichever
-                        # candidate's `prov:agent` matches this binary
-                        # triple's object; only fall back to "last node
-                        # seen" (the pre-#250 behaviour, which cannot do
-                        # better) when no candidate carries that triple at
-                        # all, i.e. legacy input.
+                        # influencer triple, so prefer whichever candidate's
+                        # influencer matches this binary triple's object;
+                        # only fall back to "last node seen" (the pre-#250
+                        # behaviour, which cannot do better) when no
+                        # candidate carries that triple at all, i.e. legacy
+                        # input.
                         qualifier_bnode = candidate
-                        if (candidate, agent_pred, obj) in graph:
+                        if (candidate, influencer_pred, obj) in graph:
                             break
                     if qualifier_bnode is None:
                         getattr(bundle, relation_mapper[pred])(subj, str(obj))

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -631,3 +631,92 @@ def test_decode_qualified_start_at_time_still_lands_in_formal_time():
     formal = dict(start.formal_attributes)
     time_values = {value for name, value in formal.items() if name.localpart == "time"}
     assert time_values == {datetime.datetime(2020, 1, 1, 0, 0, 0)}
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda d: d.communication("ex:a2", "ex:a1", other_attributes={"ex:k": "v"}),
+        lambda d: d.attribution("ex:e1", "ex:ag1", other_attributes={"ex:k": "v"}),
+        lambda d: d.influence("ex:e2", "ex:e1", other_attributes={"ex:k": "v"}),
+        lambda d: d.delegation(
+            "ex:ag2", "ex:ag1", "ex:a", other_attributes={"ex:k": "v"}
+        ),
+    ],
+    ids=["communication", "attribution", "influence", "delegation"],
+)
+def test_anonymous_qualified_relation_with_extra_attributes_round_trips(build):
+    # #303: an anonymous (unidentified) Communication/Attribution/Influence
+    # relation carrying extra attributes used to decode into TWO records --
+    # one from the shorthand binary triple, one reconstructed from the
+    # prov:qualified* node -- because only Delegation/Association reconciled
+    # the two back into a single record. Generalised via
+    # _QUALIFIED_RELATION_INFLUENCER (provrdf.py) so all four qualifiable
+    # families collapse back to one record, matching what was actually
+    # asserted.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    build(document)
+    assert len(list(document.get_records())) == 1
+    roundtripped = roundtrip_document(document, "rdf")
+    assert len(list(roundtripped.get_records())) == 1
+    assert roundtripped == document
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda d: d.communication(
+            "ex:a2", "ex:a1", identifier="ex:c1", other_attributes={"ex:k": "v"}
+        ),
+        lambda d: d.attribution(
+            "ex:e1", "ex:ag1", identifier="ex:att1", other_attributes={"ex:k": "v"}
+        ),
+        lambda d: d.influence(
+            "ex:e2", "ex:e1", identifier="ex:inf1", other_attributes={"ex:k": "v"}
+        ),
+        lambda d: d.delegation(
+            "ex:ag2",
+            "ex:ag1",
+            "ex:a",
+            identifier="ex:del1",
+            other_attributes={"ex:k": "v"},
+        ),
+    ],
+    ids=["communication", "attribution", "influence", "delegation"],
+)
+def test_identified_qualified_relation_with_extra_attributes_round_trips(build):
+    # Regression guard: identified relations were never affected by #303 --
+    # the identifier alone is enough to reconcile the binary triple and the
+    # qualified node onto one record -- and must keep round-tripping cleanly.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    build(document)
+    assert len(list(document.get_records())) == 1
+    roundtripped = roundtrip_document(document, "rdf")
+    assert len(list(roundtripped.get_records())) == 1
+    assert roundtripped == document
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda d: d.communication("ex:a2", "ex:a1"),
+        lambda d: d.attribution("ex:e1", "ex:ag1"),
+        lambda d: d.influence("ex:e2", "ex:e1"),
+        lambda d: d.delegation("ex:ag2", "ex:ag1", "ex:a"),
+    ],
+    ids=["communication", "attribution", "influence", "delegation"],
+)
+def test_anonymous_qualified_relation_without_extra_attributes_round_trips(build):
+    # Regression guard: without extra attributes, an anonymous relation of
+    # these families is only ever emitted as the plain binary triple (no
+    # prov:qualified* node at all), so #303 never applied to this shape --
+    # confirm it still round-trips to exactly one record.
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    build(document)
+    assert len(list(document.get_records())) == 1
+    roundtripped = roundtrip_document(document, "rdf")
+    assert len(list(roundtripped.get_records())) == 1
+    assert roundtripped == document


### PR DESCRIPTION
## Summary

Back-port of #309 to 2.x (part of the 2.5.3 back-port programme, task 6 of 8).

An anonymous (unidentified) Communication, Attribution or Influence relation, when it carries extra attributes, is encoded as both a binary triple and a `prov:qualified*` node. On decode the two must collapse back into a single record — 2.x already did this for delegation and association (#291), but attribution, communication and influence previously fell through to the generic `getattr(bundle, relation_mapper[pred])(subj, str(obj))` branch and produced a duplicate record alongside the one reconstructed from the qualified node.

**This is new code on 2.x, not an adaptation of master's diff.** Master had already refactored this decode path into a separate `_decode_relation` helper by the time #309 landed, so its patch doesn't apply directly onto 2.x's inline decode loop. The fix here generalises the delegation/association branch #291 introduced (previously keyed on predicate name via `"actedOnBehalfOf" in pred or "wasAssociatedWith" in pred`) into a lookup against a new `_QUALIFIED_RELATION_INFLUENCER` map keyed on the relation's factory name, covering all five qualifiable families: `delegation`, `association`, `attribution`, `communication`, `influence`.

## Changes

- `src/prov/serializers/provrdf.py`: new `_QUALIFIED_RELATION_INFLUENCER` map; the decode branch generalises from two special-cased predicate names to a name-keyed lookup against the map. Branch ordering preserved — the new `elif` sits after the `alternateOf`/`mentionOf` special cases (not in the map) and before the generic fallback.
- `src/prov/tests/test_rdf.py`: three tests ported from master's #309, each parametrized over the four relation families that can carry a qualified node (communication, attribution, influence, delegation) — anonymous-with-extra-attributes (the regression), identified-with-extra-attributes (unaffected control), and anonymous-without-extra-attributes (unaffected control).
- `HISTORY.md`: 2.5.3 (unreleased) entry.

Fixes #303.

## Test plan

- [x] Reverting only `provrdf.py` makes `test_anonymous_qualified_relation_with_extra_attributes_round_trips` fail for attribution/communication/influence (delegation already passed via #291) — captured before the fix.
- [x] `uv run --extra rdf --extra xml pytest src/prov/tests/test_rdf.py -q` — 35 passed, 1 xfailed after the fix.
- [x] `uv run --extra rdf --extra xml pytest -q` — full suite 1239 passed (1227 baseline + 12 new parametrized items), 22 skipped, 12 xfailed. No unexplained movement.
- [x] `ruff check`, `ruff format --check`, `mypy src` all clean.