### PR TITLE
Port #353: Lazy serializer registry population

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,9 @@
 - Qualified names whose local part ends in a PROV-N metacharacter now
   round-trip through PROV-O instead of raising `ValueError: Can't split` from
   rdflib during deserialization (#294). Encoded output is unchanged.
+- `prov.read()` now populates the serializer registry only when it is empty,
+  instead of discarding and rebuilding it on every call. No observable
+  behaviour change (#353).
 
 ## 2.5.2 (2026-08-08)
 

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -65,7 +65,8 @@ def read(
     from prov.model import ProvDocument
     from prov.serializers import Registry
 
-    Registry.load_serializers()
+    if Registry.serializers is None:
+        Registry.load_serializers()
     assert Registry.serializers is not None  # populated by load_serializers()
     serializers = Registry.serializers.keys()
 

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -101,13 +101,12 @@ class Registry:
         (see :func:`get`) rather than a bare ``ModuleNotFoundError``.
 
         The insertion order is kept as ``json, rdf, provn, xml`` (the
-        historic order when all extras are present) because
-        :func:`prov.read`'s format auto-detection iterates
-        ``Registry.serializers`` in order and several tests
-        (``test_read_auto_detects_rdf``,
-        ``test_read_auto_detect_of_xml_hits_uncaught_rdf_syntax_error``,
-        ``test_read_on_unparseable_content_raises_bad_syntax``) pin the
-        exact candidate tried second.
+        historic order when all extras are present) because :func:`prov.read`'s
+        format auto-detection iterates ``Registry.serializers`` in order and
+        ``test_read_auto_detect_with_broken_tell_degrades_to_no_rewind``
+        pins JSON as the first candidate tried — a non-seekable stream can
+        only attempt the first format, so JSON must remain first for JSON
+        content to be auto-detected on broken streams.
         """
         from prov.serializers.provjson import ProvJSONSerializer
         from prov.serializers.provn import ProvNSerializer

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -311,6 +311,26 @@ def test_get_serializer_lazily_populates_registry():
         Registry.serializers = original
 
 
+def test_read_lazily_populates_registry():
+    import prov
+
+    # Build the serialized content BEFORE resetting the registry, so the
+    # serialize() call doesn't populate it via prov.serializers.get()
+    json_content = primer_example().serialize(format="json")
+
+    original = Registry.serializers
+    Registry.serializers = None
+    try:
+        assert Registry.serializers is None
+        # Now call read() with pre-built content, with the registry uninitialized
+        document = prov.read(json_content)
+        assert Registry.serializers is not None
+        assert set(Registry.serializers.keys()) == {"json", "rdf", "provn", "xml"}
+        assert document is not None
+    finally:
+        Registry.serializers = original
+
+
 def test_plot_without_matplotlib_raises_helpful_error():
     # Deliberately exercises matplotlib's *absence*: builtins.__import__ is
     # patched to fail for matplotlib imports, so this import must stay local

--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -327,6 +327,11 @@ def test_read_lazily_populates_registry():
         assert Registry.serializers is not None
         assert set(Registry.serializers.keys()) == {"json", "rdf", "provn", "xml"}
         assert document is not None
+        # added: the guard's actual effect — a populated registry is not rebuilt
+        Registry.load_serializers()
+        existing = Registry.serializers
+        prov.read(json_content)
+        assert Registry.serializers is existing
     finally:
         Registry.serializers = original
 


### PR DESCRIPTION
Port #353: read() now populates the serializer registry only when it is empty, instead of discarding and rebuilding it on every call.

No observable behaviour change; adds test_read_lazily_populates_registry.