### PR TITLE
Release 2.5.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 2.5.3 (unreleased)
+## 2.5.3 (2026-08-08)
 
 - Escaped PROV-N metacharacters (`= ' ( ) , : ; [ ]`) in the local parts of
   qualified names, so identifiers containing them serialise to valid PROV-N

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 
 __all__ = ["Error", "model", "read"]
 


### PR DESCRIPTION
Ships the eight Stage 2 back-port fixes accumulated on `2.x` since 2.5.2, stamping `__version__` and dating the `HISTORY.md` heading.

- Escaped PROV-N metacharacters in qualified-name local parts and string literals so identifiers containing them serialise to valid PROV-N (#223).
- Anonymous `prov:qualified*` nodes for communication, attribution, delegation and influence now carry their own influencer property per the PROV-O qualification tables, and decoding uses it to disambiguate same-kind qualification nodes (#250/#226).
- PROV-XML now round-trips empty-string attribute values and escapes attribute-name local parts that are not legal XML NCNames using the `_xHHHH_` convention (#224/#289).
- The PROV-JSON deserializer now raises `ProvJSONException` naming the offending construct on malformed input instead of letting `KeyError`/`AttributeError`/`TypeError` escape (#228).
- `prov:startedAtTime`/`prov:endedAtTime` asserted directly on a qualified `prov:Start`/`prov:End` node now decode into the relation's formal `prov:time` attribute instead of being stripped into extra attributes (#299).
- Anonymous attribution, communication and influence relations carrying extra attributes now reconcile onto their `prov:qualified*` node when decoded from RDF, instead of producing a duplicate record (#303).
- Qualified names whose local part ends in a PROV-N metacharacter now round-trip through PROV-O instead of raising `ValueError: Can't split` during RDF deserialization (#294).
- `prov.read()` now populates the serializer registry only when it is empty, instead of discarding and rebuilding it on every call (#353).
