### PR TITLE
Fix the vacuous test_read_lazily_populates_registry

### DIFF
--- a/src/prov/tests/test_extras.py
+++ b/src/prov/tests/test_extras.py
@@ -355,6 +355,11 @@ def test_read_lazily_populates_registry():
             "jsonld",
         }
         assert document is not None
+        # the guard's actual effect — a populated registry is not rebuilt
+        Registry.load_serializers()
+        existing = Registry.serializers
+        prov.read(json_content)
+        assert Registry.serializers is existing
     finally:
         Registry.serializers = original
 


### PR DESCRIPTION
`test_read_lazily_populates_registry` (added by #353) gave zero regression protection for the lazy-registry guard in `prov.read()`: with the guard reverted to a bare `Registry.load_serializers()`, the test still passed. The test sets `Registry.serializers = None` before calling `read()`, and `load_serializers()` unconditionally rebuilds and reassigns the dict, so the guarded and unguarded paths were indistinguishable from its assertions. No other test on master covered the guard — `test_get_serializer_lazily_populates_registry` exercises the different `get()` call site.

The test now also asserts the guard's actual effect: an already-populated registry is not rebuilt, checked by dict identity across a second `read()`. With the guard reverted, the test fails on that identity assertion and passes with it restored.

This ports the 2.x fix (#385) to master. The key-set assertion keeps master's `jsonld` entry, which 2.x does not have.

Test-only, no behaviour change: 1643 passed / 26 skipped before and after, with an identical skip list; ruff and `mypy src` clean.