### PR TITLE
Test: cover _resolve_iri's graph-namespace resolution step

### DIFF
--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -1107,3 +1107,86 @@ def test_trailing_metacharacter_encode_output_unchanged():
     for ch in _TRAILING_METACHARS:
         expected.add((URIRef(ns + "a" + ch), RDF.type, URIRef(prov + "Entity")))
     assert isomorphic(reparsed, expected)
+
+
+# _resolve_iri()'s step 1 (a namespace bound in the *graph* being decoded,
+# not the document) only matters when the document hasn't already resolved
+# the IRI some other way. decode_document() hoists every one of a Dataset's
+# namespaces onto the document before decoding any statement (so
+# valid_identifier() -- itself a first-match, not longest-match, namespace
+# scan -- already succeeds by the time a real subject/object is decoded, and
+# _resolve_iri() is never reached with a matching graph namespace). Driving
+# these cases through decode_container() directly -- the same method
+# decode_document() calls per (sub)graph, and the real caller of
+# _resolve_iri() via _decode_type_triples() -- keeps a document with no
+# pre-hoisted namespaces, so _resolve_iri()'s own graph-namespace scan is
+# actually exercised, honestly reaching the branch under test.
+def _decode_via_container(turtle: str) -> ProvDocument:
+    graph = Graph().parse(data=turtle, format="turtle")
+    doc = ProvDocument()
+    ProvRDFSerializer(document=doc).decode_container(graph, doc)
+    return doc
+
+
+def test_resolve_iri_reuses_namespace_bound_in_graph_for_metacharacter_local_part():
+    # Step 1 of _resolve_iri(): an IRI under a namespace bound in the graph
+    # (but not on the document) must resolve against that namespace and reuse
+    # its declared prefix, rather than falling through to compute_qname's
+    # ValueError (#294's motivating case: a local part ending in a PROV-N
+    # metacharacter) and then minting a throwaway "ns" prefix in step 3.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    <http://example.org/thing;> a prov:Entity .
+    """
+    doc = _decode_via_container(turtle)
+
+    (record,) = doc.get_records()
+    identifier = record.identifier
+    assert identifier.uri == "http://example.org/thing;"
+    assert identifier.namespace.uri == "http://example.org/"
+    assert identifier.namespace.prefix == "ex"
+    assert identifier.localpart == "thing;"
+
+
+def test_resolve_iri_picks_longest_matching_bound_namespace():
+    # Step 1 must pick the *longest* bound namespace that prefixes the IRI,
+    # not merely the first one found: with "http://example.org/" and
+    # "http://example.org/sub/" both bound, an IRI under the longer namespace
+    # must split there, not against the shorter one it also happens to match.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    @prefix exsub: <http://example.org/sub/> .
+    <http://example.org/sub/thing> a prov:Entity .
+    """
+    doc = _decode_via_container(turtle)
+
+    (record,) = doc.get_records()
+    identifier = record.identifier
+    assert identifier.uri == "http://example.org/sub/thing"
+    assert identifier.namespace.uri == "http://example.org/sub/"
+    assert identifier.namespace.prefix == "exsub"
+    assert identifier.localpart == "thing"
+
+
+def test_resolve_iri_skips_bound_namespace_equal_to_the_iri_itself():
+    # The `iri != uri` guard: an IRI that exactly equals a bound namespace
+    # URI must not match against *that* namespace (which would produce a
+    # degenerate empty local part) even though it is also bound in the
+    # graph. It must fall through to a shorter namespace that is a genuine
+    # (non-equal) prefix, giving a real, non-empty local part instead.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix top: <http://example.org/> .
+    @prefix full: <http://example.org/thing> .
+    <http://example.org/thing> a prov:Entity .
+    """
+    doc = _decode_via_container(turtle)
+
+    (record,) = doc.get_records()
+    identifier = record.identifier
+    assert identifier.uri == "http://example.org/thing"
+    assert identifier.namespace.uri == "http://example.org/"
+    assert identifier.namespace.prefix == "top"
+    assert identifier.localpart == "thing"


### PR DESCRIPTION
## Summary

`ProvRDFSerializer._resolve_iri` (added by #310 for #294) resolves an IRI to a `QualifiedName` in three ordered steps; step 1 (the longest namespace bound in the *graph* being decoded, preferring the longest match and skipping an IRI that equals a namespace URI exactly) had no test, noted as a deferred minor during the 2.5.3 back-port review.

Reaching the branch honestly turned out to be the interesting part: going through the public `ProvDocument.deserialize()`/`prov.read()` path never actually exercises it, because `decode_document()` hoists every one of the source graph's bound namespaces onto the document before decoding any statement — so `valid_identifier()` (a first-match, not longest-match, scan of the document's own namespaces) already resolves the IRI before `_resolve_iri()` is ever called. The new tests instead drive `ProvRDFSerializer.decode_container()` directly — the same method `decode_document()` calls per (sub)graph, and the real caller of `_resolve_iri()` via `_decode_type_triples()` — against a document with no pre-hoisted namespaces, so the branch is actually reached with a real match.

Three tests, each independently verified (locally) to fail against a targeted mutation of the code it pins, then restored:
- reuses a graph-bound namespace's declared prefix for an IRI with a PROV-N-metacharacter local part (the #294 motivating case), instead of falling through to `compute_qname`'s `ValueError` and minting a throwaway prefix
- picks the *longest* matching bound namespace, not merely the first one encountered, when two bound namespaces are nested prefixes of each other
- skips a bound namespace that equals the IRI exactly (the `iri != uri` guard), falling through to a shorter genuine-prefix namespace instead of producing a degenerate empty local part

## Test plan
- [x] `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q` — 1646 passed, 26 skipped (baseline 1643/26 plus the 3 added tests; skips unmoved)
- [x] `uv run ruff check` / `ruff format --check` on the changed file
- [x] `uv run mypy src` (test files are excluded from the strict-mypy gate)