### PR TITLE
Add release 3.1.1 point-release design spec

### DIFF
--- a/docs/superpowers/plans/2026-09-10-release-3.1.1.md
+++ b/docs/superpowers/plans/2026-09-10-release-3.1.1.md
@@ -1,0 +1,2295 @@
+# Release 3.1.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship prov 3.1.1, a point release of fixes, hardening, tests, documentation and repository scaffolding, to PyPI and conda-forge, with the project's first Zenodo DOI.
+
+**Architecture:** Every task is a fix, a test, a document or a repository file. No public API changes, no dependency changes, Python floor stays 3.10. Each task group is one focused PR off `main`, merged on green CI; the release itself follows `docs/releasing.md` unchanged. Tasks 13 and 14 move the planning files (including this plan and its spec) to a top-level `planning/` directory, so paths quoted below are the pre-move paths until Task 13 lands.
+
+**Tech Stack:** Python 3.10+, `uv`, pytest, mypy `--strict`, ruff, lxml, rdflib, pydot, networkx, Sphinx/MyST, GitHub Actions, `gh` CLI, Codacy CLI.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-release-3.1.1-design.md` (after Task 13: `planning/specs/2026-09-10-release-3.1.1-design.md`). Spec PR: <https://github.com/trungdong/prov/pull/408>.
+
+## Global Constraints
+
+- **Point release only.** No new public names, no signature changes, no dependency or Python-floor changes. Anything that changes decode semantics or adds a feature is out of scope (spec §5).
+- **Branching and PRs.** Every task group branches from up-to-date `origin/main`, opens one PR, and merges only on green CI (`gh pr checks <n> --watch`). Merge with `gh pr merge <n> --merge --delete-branch` (the repository uses merge commits). Codacy blocks on any markdownlint finding; query with `codacy pr gh trungdong prov <n>` and write bare URLs as `<https://…>`. Coveralls "decreased" is advisory as long as `uv run coverage run -m pytest && uv run coverage report` exits 0 against the 97% floor.
+- **Suite invariant.** Baseline on `main` @ d276e16: **1646 passed, 26 skipped, 0 xfailed** (`uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx`). Each task states how the pass count moves; the skip count must stay 26 and xfail 0. Any other movement is a regression.
+- **Every code task adds its `HISTORY.md` line** under the `## 3.1.1 (unreleased)` section that Task 1 creates, in the subsection the task names (Fixes / Security / Tests / Documentation / Project). Task 15 dates the heading.
+- **Fixture bytes.** DOT output of the eight canonical examples and every serializer fixture stay byte-identical except for the #337 cases (Task 3), which its tests cover.
+- **Quality gates per code PR:** `uv run mypy src`, `uv run ruff check src/`, `uv run ruff format --check src/`, full suite green.
+- **Commit and PR text.** No AI attribution lines. Paragraphs unwrapped (one line each). British English, no em dashes in commit/PR text or docs. Shipped docs never reference plan tasks or batches; describe changes by release.
+- **Maintainer-only actions** (Task 16): enabling the Zenodo GitHub integration before the tag, and enabling GitHub Discussions at release time. The coordinator verifies both with `gh` before Task 17 and does not proceed without them.
+
+**User decisions (already made):**
+- Inbound-equals-outbound licensing wording in `CONTRIBUTING.md`; no DCO sign-off, no CLA; the `cla/` directory is deleted.
+- `planning/` is the directory name for design specs and plans (`planning/specs/`, `planning/plans/`).
+- `prov.dot` link-scheme allowlist: `http`, `https`, `mailto`, `urn`, and scheme-less URIs.
+- The "What's new" page is `docs/whats-new-3.md`, placed under the Project toctree.
+- No `FUNDING.yml` (no GitHub Sponsors listing).
+- Spec and its four section-7 decisions are approved as written; do not re-open them.
+
+---
+
+## PR map
+
+| PR | Tasks | Branch | Closes |
+|---|---|---|---|
+| #408 (open) | 0 | `spec-3.1.1` | – |
+| A | 1, 2 | `perf/bundle-eq-namespace-lookup` | – |
+| B | 3 | `fix/bundle-namespace-order` | #337 |
+| C | 4 | `security/dot-link-label-hardening` | – |
+| D | 5 | `fix/graph-skip-warnings` | – |
+| E | 6 | `fix/provo-unconverted-warning` | – |
+| F | 7, 8 | `test/attribute-order-force-types` | #130, #338 |
+| G | 9 | `ci/own-warnings-guard` | #340 |
+| H | 10, 11 | `docs/support-policy-whats-new` | – |
+| I | 12 | `docs/architecture-overview` | – |
+| J | 13 | `chore/planning-directory` | – |
+| K | 14 | `chore/community-scaffolding` | – |
+| L | 15 | `release/3.1.1` | – |
+| – | 16, 17, 18 | (release operations on `main`) | – |
+
+---
+
+### Task 0: Land the spec and this plan
+
+**Goal:** PR #408 carries the approved spec plus this plan and its task file, and is merged so every later branch starts from a `main` that contains both.
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-09-10-release-3.1.1.md` (this file)
+- Create: `docs/superpowers/plans/2026-09-10-release-3.1.1.md.tasks.json` (local only; `docs/superpowers/plans/.gitignore` ignores `*.tasks.json`, as for every earlier plan)
+
+**Acceptance Criteria:**
+- [ ] The plan is committed on `spec-3.1.1` and pushed; the task file stays untracked.
+- [ ] PR #408 body says the plan is included; CI is green; PR is merged.
+- [ ] `git log origin/main -1` contains the merge commit.
+
+**Verify:** `gh pr view 408 --json state,mergedAt --jq '.state'` → `MERGED`
+
+**Steps:**
+
+- [ ] **Step 1: Commit the plan on the spec branch**
+
+```bash
+git checkout spec-3.1.1
+git add docs/superpowers/plans/2026-09-10-release-3.1.1.md
+git commit -m "Add release 3.1.1 implementation plan"
+git push
+```
+
+- [ ] **Step 2: Update the PR body and merge on green**
+
+```bash
+gh pr edit 408 --body "Design spec and implementation plan for the 3.1.1 point release. The four section-7 decisions are approved as written. The plan (docs/superpowers/plans/2026-09-10-release-3.1.1.md) maps the spec onto twelve PRs plus the release operations; Task 13 of the plan moves both files to planning/."
+gh pr checks 408 --watch
+gh pr merge 408 --merge --delete-branch
+git checkout main && git pull
+```
+
+---
+
+### Task 1: `ProvBundle.__eq__` fast path
+
+**Goal:** Equal bundles compare in O(n) via set equality; unequal or loosely-equal bundles still fall through to the existing O(n²) loop that honours `ProvRecord.__eq__`'s anonymous-versus-identified leniency.
+
+**Files:**
+- Modify: `src/prov/model/bundle.py:553-574` (`ProvBundle.__eq__`)
+- Modify: `src/prov/tests/test_model.py` (append after `test_not_equal_when_matching_bundle_content_differs`)
+- Modify: `HISTORY.md` (new `## 3.1.1 (unreleased)` section)
+
+**Acceptance Criteria:**
+- [ ] Two documents with the same records added in different orders compare equal.
+- [ ] A document whose relation is anonymous still compares equal to one whose matching relation carries an identifier (the slow path still runs).
+- [ ] `HISTORY.md` has a `## 3.1.1 (unreleased)` section with `### Fixes`, `### Security`, `### Tests`, `### Documentation`, `### Project` subsections, and a Fixes line for this change.
+- [ ] Suite: 1648 passed, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_model.py -q` → all pass; full suite 1648/26/0.
+
+**Steps:**
+
+- [ ] **Step 1: Write the tests**
+
+Append to `src/prov/tests/test_model.py`:
+
+```python
+# ProvBundle.__eq__: the set-equality fast path and the slow path it
+# falls back to when ProvRecord.__eq__ is looser than ProvRecord.__hash__.
+
+
+def test_equal_when_same_records_added_in_different_order():
+    d1 = ProvDocument()
+    d1.set_default_namespace("http://example.org/")
+    d1.entity("e1")
+    d1.activity("a1")
+    d1.wasGeneratedBy("e1", "a1")
+
+    d2 = ProvDocument()
+    d2.set_default_namespace("http://example.org/")
+    d2.wasGeneratedBy("e1", "a1")
+    d2.activity("a1")
+    d2.entity("e1")
+
+    assert d1 == d2
+    assert d2 == d1
+
+
+def test_anonymous_relation_still_equals_identified_relation():
+    # ProvRecord.__eq__ skips the identifier check when *this* record has no
+    # identifier, while __hash__ includes it; the two records hash
+    # differently, so set equality fails and __eq__ must fall through to the
+    # record-by-record loop to find the match.
+    d1 = ProvDocument()
+    d1.set_default_namespace("http://example.org/")
+    d1.wasGeneratedBy("e1", "a1")
+
+    d2 = ProvDocument()
+    d2.set_default_namespace("http://example.org/")
+    d2.wasGeneratedBy("e1", "a1", identifier="g1")
+
+    assert d1 == d2
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass on current code**
+
+Run: `uv run pytest src/prov/tests/test_model.py -q -k "different_order or anonymous_relation"`
+Expected: 2 passed. Both pass before the change (the change is a fast path, not a behaviour change); they pin the behaviour the fast path must preserve.
+
+- [ ] **Step 3: Add the fast path**
+
+Replace the body of `ProvBundle.__eq__` in `src/prov/model/bundle.py`:
+
+```python
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, ProvBundle):
+            return False
+        other_records = set(other.get_records())
+        this_records = set(self.get_records())
+        if len(this_records) != len(other_records):
+            return False
+        if this_records == other_records:
+            # The common case (e.g. after a round trip): every record has a
+            # hash-equal counterpart, settled in O(n).
+            return True
+        # ProvRecord.__eq__ is looser than ProvRecord.__hash__ (a record
+        # without an identifier equals one with, given the same type and
+        # attributes), so records that hash differently may still match.
+        for record_a in this_records:
+            #  Manually look for the record
+            found = False
+            for record_b in other_records:
+                if record_a == record_b:
+                    other_records.remove(record_b)
+                    found = True
+                    break
+            if not found:
+                logger.debug(
+                    "Equality (ProvBundle): Could not find this record: %s",
+                    str(record_a),
+                )
+                return False
+        return True
+```
+
+- [ ] **Step 4: Create the changelog section**
+
+Insert at the top of `HISTORY.md`, above `## 3.1.0 (2026-08-07)`:
+
+```markdown
+## 3.1.1 (unreleased)
+
+### Fixes
+
+- `ProvBundle.__eq__` (and therefore `ProvDocument.__eq__`) compares equal
+  bundles in linear time by testing record-set equality first, falling back
+  to the record-by-record search only when the sets differ
+
+### Security
+
+### Tests
+
+### Documentation
+
+### Project
+
+```
+
+Empty subsections are filled by later tasks; Task 15 deletes any that remain empty.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/model/bundle.py src/prov/tests/test_model.py HISTORY.md
+git commit -m "perf: compare bundle record sets before the record-by-record equality search"
+```
+
+---
+
+### Task 2: O(1) namespace lookup by URI
+
+**Goal:** `NamespaceManager.get_namespace(uri)` answers from indexes instead of scanning every registered namespace, with deterministic precedence.
+
+**Files:**
+- Modify: `src/prov/model/namespaces.py:12,55-67` (module constant + `get_namespace`)
+- Modify: `src/prov/tests/test_model.py` (after `test_get_namespace_miss_and_hit`)
+- Modify: `HISTORY.md` (Fixes)
+
+**Acceptance Criteria:**
+- [ ] `get_namespace` does not iterate `self.values()`.
+- [ ] Lookup after a prefix-conflict rename returns the renamed namespace; lookup after re-registering the same URI under another prefix returns the first-registered namespace; the built-in `prov`/`xsd`/`xsi` namespaces and the default namespace are found.
+- [ ] Suite: 1652 passed, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_model.py -q -k get_namespace` → 5 passed.
+
+**Steps:**
+
+- [ ] **Step 1: Write the tests**
+
+Insert after `test_get_namespace_miss_and_hit` in `src/prov/tests/test_model.py`:
+
+```python
+def test_get_namespace_finds_built_in_and_default_namespaces():
+    nm = NamespaceManager(default="http://default.example.org/")
+    assert nm.get_namespace(PROV.uri) == PROV
+    assert nm.get_namespace("http://default.example.org/") is nm.get_default_namespace()
+
+
+def test_get_namespace_after_prefix_rename_returns_renamed_namespace():
+    nm = NamespaceManager()
+    nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+    renamed = nm.add_namespace(Namespace("ex", "http://b.example.org/"))
+    assert renamed.prefix == "ex_1"
+    assert nm.get_namespace("http://b.example.org/") is renamed
+    assert nm.get_namespace("http://a.example.org/").prefix == "ex"
+
+
+def test_get_namespace_after_reregistering_uri_under_other_prefix():
+    nm = NamespaceManager()
+    first = nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+    again = nm.add_namespace(Namespace("other", "http://a.example.org/"))
+    assert again is first
+    assert "other" not in nm
+    assert nm.get_namespace("http://a.example.org/") is first
+
+
+def test_get_namespace_prefers_registered_over_default_for_same_uri():
+    nm = NamespaceManager(default="http://shared.example.org/")
+    registered = nm.add_namespace(Namespace("sh", "http://shared.example.org/"))
+    assert nm.get_namespace("http://shared.example.org/") is registered
+```
+
+`PROV` is importable from `prov.constants`; check the module's existing imports and add `from prov.constants import PROV` if it is not already there.
+
+- [ ] **Step 2: Run to see which fail**
+
+Run: `uv run pytest src/prov/tests/test_model.py -q -k get_namespace`
+Expected: the "prefers_registered_over_default" test fails (the current scan hits the default namespace first because `""` was inserted before `sh`); the others pass. That failing test pins the new precedence.
+
+- [ ] **Step 3: Implement the indexed lookup**
+
+In `src/prov/model/namespaces.py`, after `DEFAULT_NAMESPACES = {...}` add:
+
+```python
+_DEFAULT_NAMESPACES_BY_URI = {ns.uri: ns for ns in DEFAULT_NAMESPACES.values()}
+```
+
+Replace `get_namespace`:
+
+```python
+    def get_namespace(self, uri: str) -> Namespace | None:
+        """Return the known namespace with the given URI.
+
+        Lookup is by index, not by scan. When more than one known namespace
+        has the URI, the built-in ``prov``/``xsd``/``xsi`` namespaces win,
+        then the explicitly registered namespace, then the default namespace.
+
+        Args:
+            uri: The namespace URI to look up.
+
+        Returns:
+            The matching :class:`~prov.identifier.Namespace`, or ``None`` if no
+            known namespace has that URI.
+        """
+        namespace = _DEFAULT_NAMESPACES_BY_URI.get(uri) or self._uri_map.get(uri)
+        if namespace is not None:
+            return namespace
+        if self._default is not None and self._default.uri == uri:
+            return self._default
+        return None
+```
+
+`self._uri_map` already exists and is written by `add_namespace` at every registration, including renames (it stores the renamed object), and is never written again for a URI that is already present, which is what gives "first registration wins". Confirm with `grep -n "_uri_map" src/prov/model/namespaces.py` that `add_namespace` is its only writer.
+
+- [ ] **Step 4: Run, gates, changelog, commit**
+
+Run: `uv run pytest src/prov/tests/test_model.py -q -k get_namespace` → 5 passed. Full suite → 1652/26/0.
+
+Add under `### Fixes` in `HISTORY.md`:
+
+```markdown
+- `NamespaceManager.get_namespace()` looks a URI up by index instead of
+  scanning every known namespace; where a URI is both registered and the
+  default namespace, the registered one is now returned consistently
+```
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/model/namespaces.py src/prov/tests/test_model.py HISTORY.md
+git commit -m "perf: index namespace lookup by URI"
+```
+
+- [ ] **Step 5: Open PR A**
+
+```bash
+git push -u origin perf/bundle-eq-namespace-lookup
+gh pr create --base main --title "perf: linear bundle equality and indexed namespace lookup" --body "Two small performance fixes from the September 2026 audit, per the 3.1.1 design spec sections 2.1 and 2.6.
+
+ProvBundle.__eq__ tests record-set equality before its record-by-record search, so equal documents (the common case after a round trip) compare in linear time; the search still runs when the sets differ, preserving the anonymous-versus-identified leniency of ProvRecord.__eq__.
+
+NamespaceManager.get_namespace() reads the existing URI index instead of scanning every known namespace, with documented precedence (built-in, then registered, then default).
+
+No public signature changes. Suite: 1652 passed, 26 skipped."
+gh pr checks --watch
+```
+
+Merge per the Global Constraints once green and reviewed.
+
+---
+
+### Task 3: Deterministic bundle namespace declarations (#337)
+
+**Goal:** PROV-XML and PROV-O declare a bundle's namespaces in registration order, and a document added as a bundle keeps its registration order, independent of the hash seed.
+
+**Files:**
+- Modify: `src/prov/serializers/provxml.py:187` (`_build_nsmap`)
+- Modify: `src/prov/serializers/provrdf.py:870` (`encode_container`)
+- Modify: `src/prov/model/bundle.py:1754` (`ProvDocument.add_bundle`)
+- Modify: `src/prov/tests/test_xml.py`, `src/prov/tests/test_rdf.py`, `src/prov/tests/test_model.py`
+- Modify: `HISTORY.md` (Fixes)
+
+**Acceptance Criteria:**
+- [ ] No consumer iterates `ProvBundle.namespaces` (the `set`); its signature and return type are unchanged.
+- [ ] Five bundle-only namespaces are declared in registration order in PROV-XML output, bound in registration order on the PROV-O bundle graph, and registered in order on the bundle copy `add_bundle` makes from a document.
+- [ ] Each of the three new tests passes under `PYTHONHASHSEED=1`, `2`, `3`.
+- [ ] Suite: 1655 passed, 26 skipped.
+
+**Verify:** `for s in 1 2 3; do PYTHONHASHSEED=$s uv run pytest -q -k namespace_order src/prov/tests/test_xml.py src/prov/tests/test_rdf.py src/prov/tests/test_model.py || break; done` → 3 passed each run.
+
+**Steps:**
+
+- [ ] **Step 1: Write the three failing tests**
+
+Shared shape: a document whose bundle registers `ex1`..`ex5` (bundle-only, so the document-level element does not declare them) in that order, each used by one entity so PROV-O binds them.
+
+Append to `src/prov/tests/test_xml.py`:
+
+```python
+BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
+
+
+def _document_with_ordered_bundle_namespaces():
+    document = prov.ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    bundle = document.bundle("b1")
+    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
+        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
+        bundle.entity(f"{prefix}:e{i}")
+    return document
+
+
+def test_bundle_namespace_order_follows_registration_in_xml():
+    # #337: five namespaces give a one-in-120 chance of the old
+    # set-iteration order matching by accident.
+    xml_bytes = _document_with_ordered_bundle_namespaces().serialize(format="xml").encode()
+    declared = re.findall(rb'xmlns:(ex\d)=', xml_bytes)
+    assert [p.decode() for p in declared] == BUNDLE_NAMESPACE_ORDER
+```
+
+Add `import re` to the module's imports. Append to `src/prov/tests/test_rdf.py` (mirror the helper; per-format test files stay independent):
+
+```python
+BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
+
+
+def test_bundle_namespace_order_follows_registration_in_rdf():
+    # #337: bundle namespaces are bound on the bundle graph in registration
+    # order. rdflib sorts prefixes when it serializes, so the bound order on
+    # the graph is the observable.
+    document = ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    bundle = document.bundle("b1")
+    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
+        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
+        bundle.entity(f"{prefix}:e{i}")
+
+    serializer = ProvRDFSerializer(document)
+    graph = serializer.encode_container(bundle, identifier=URIRef("http://example.org/b1"))
+    bound = [prefix for prefix, _ in graph.namespace_manager.namespaces() if prefix in BUNDLE_NAMESPACE_ORDER]
+    assert bound == BUNDLE_NAMESPACE_ORDER
+```
+
+Check `test_rdf.py`'s imports for `ProvRDFSerializer`, `URIRef` and `ProvDocument`; add what is missing. Read `encode_container`'s signature (`provrdf.py` around line 840) and pass `container=None` explicitly if the identifier parameter is positional in a different slot.
+
+Append to `src/prov/tests/test_model.py`:
+
+```python
+def test_add_bundle_from_document_keeps_namespace_order():
+    # #337: ProvDocument.add_bundle() copies a document's namespaces into
+    # the new bundle in registration order.
+    source = ProvDocument()
+    prefixes = [f"ex{i}" for i in range(1, 6)]
+    for i, prefix in enumerate(prefixes, start=1):
+        source.add_namespace(prefix, f"http://example.org/ns{i}/")
+        source.entity(f"{prefix}:e{i}")
+
+    target = ProvDocument()
+    target.set_default_namespace("http://example.org/")
+    target.add_bundle(source, identifier="b1")
+
+    bundle = next(iter(target.bundles))
+    assert [ns.prefix for ns in bundle.get_registered_namespaces()] == prefixes
+```
+
+- [ ] **Step 2: Run the tests under several hash seeds to see failures**
+
+Run: `for s in 1 2 3 4 5 6; do PYTHONHASHSEED=$s uv run pytest -q -k namespace_order src/prov/tests/test_xml.py src/prov/tests/test_rdf.py src/prov/tests/test_model.py | tail -1; done`
+Expected: at least one seed fails each test (set iteration order varies with the seed).
+
+- [ ] **Step 3: Iterate registration order at the three sites**
+
+`src/prov/serializers/provxml.py` `_build_nsmap`: replace `for namespace in bundle.namespaces:` with `for namespace in bundle.get_registered_namespaces():`.
+
+`src/prov/serializers/provrdf.py` `encode_container`: replace `for namespace in bundle.namespaces:` with `for namespace in bundle.get_registered_namespaces():`. The `# #96:` comment two lines below says `bundle.namespaces` excludes the default namespace; reword its first clause to `get_registered_namespaces()` so it stays accurate.
+
+`src/prov/model/bundle.py` `add_bundle`: replace `new_bundle = ProvBundle(namespaces=bundle.namespaces)` with `new_bundle = ProvBundle(namespaces=list(bundle.get_registered_namespaces()))`.
+
+`ProvBundle.get_registered_namespaces()` is the existing public accessor over the ordered manager; `ProvBundle.namespaces` keeps returning a `set`.
+
+- [ ] **Step 4: Run under seeds, gates, fixture check, changelog, commit**
+
+Run the Verify loop above (all seeds green), then the full suite → 1655/26/0. Then confirm no other output moved: `uv run pytest -q src/prov/tests/test_statements.py src/prov/tests/test_examples.py` green.
+
+Add under `### Fixes` in `HISTORY.md`:
+
+```markdown
+- PROV-XML and PROV-O serializers declare a bundle's namespaces in
+  registration order instead of hash-seed-dependent set order, and
+  `ProvDocument.add_bundle()` registers a copied document's namespaces in the
+  same order; PROV-XML byte output changes for bundles carrying two or more
+  of their own namespaces
+  ([#337](https://github.com/trungdong/prov/issues/337))
+```
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/serializers/provxml.py src/prov/serializers/provrdf.py src/prov/model/bundle.py src/prov/tests/test_xml.py src/prov/tests/test_rdf.py src/prov/tests/test_model.py HISTORY.md
+git commit -m "fix: declare bundle namespaces in registration order (#337)"
+git push -u origin fix/bundle-namespace-order
+gh pr create --base main --title "fix: declare bundle namespaces in registration order" --body "Closes #337. Per the 3.1.1 design spec section 2.2.
+
+The three consumers of ProvBundle.namespaces (the PROV-XML namespace map, the PROV-O container binding, and the bundle copy ProvDocument.add_bundle() makes from a document) now iterate get_registered_namespaces() in registration order instead of the set, so declaration order no longer depends on PYTHONHASHSEED. ProvBundle.namespaces itself is unchanged.
+
+Byte output changes for PROV-XML bundles carrying two or more of their own namespaces, as the issue asks. Three new tests with five namespaces each, verified under PYTHONHASHSEED 1 to 6. Suite: 1655 passed, 26 skipped."
+gh pr checks --watch
+```
+
+---
+
+### Task 4: `prov.dot` link and label hardening
+
+**Goal:** Identifier URIs reach Graphviz link attributes only when their scheme is `http`, `https`, `mailto`, `urn` or absent; HTML-like labels are HTML-escaped and quoted labels escape backslash and double quote. Ordinary documents render byte-identically.
+
+**Files:**
+- Modify: `src/prov/dot.py` (imports; `ANNOTATION_ROW_TEMPLATE`; `_attach_attribute_annotation`; `_add_bundle`; `_add_node`; `_add_generic_node`)
+- Modify: `src/prov/tests/test_dot.py`
+- Modify: `HISTORY.md` (Security)
+
+**Acceptance Criteria:**
+- [ ] A node whose identifier URI is `javascript:` carries no `URL`; an annotation row whose value or attribute-name URI is `javascript:` carries no `href`; `http://` identifiers still carry both.
+- [ ] A label containing `<`, `&` and `"` renders escaped in the HTML-like label; an identifier containing `"` renders escaped in the quoted label; both documents still render to SVG.
+- [ ] DOT text for the eight canonical examples (`examples.tests`) is byte-identical to `main` before the change.
+- [ ] `htlm_link_if_uri` is unchanged (public helper not called by `prov_to_dot`; outside the spec's four sites).
+- [ ] Suite: +4 tests, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_dot.py -q` → all pass; the baseline diff in Step 1 is empty after the change.
+
+**Steps:**
+
+- [ ] **Step 1: Capture the DOT baseline from `main` before any edit**
+
+```bash
+git checkout main && git pull
+uv run --extra dot --extra graph python - <<'PY'
+from pathlib import Path
+from prov.dot import prov_to_dot
+from prov.tests import examples
+out = Path("/tmp/dot-baseline"); out.mkdir(exist_ok=True)
+for name, build in examples.tests:
+    (out / f"{name}.dot").write_text(prov_to_dot(build()).to_string())
+print("baseline written")
+PY
+git checkout -b security/dot-link-label-hardening
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `src/prov/tests/test_dot.py`:
+
+```python
+# Link and label hardening: identifier URIs and labels are document content
+# and rendered SVG makes link attributes live.
+
+
+def test_javascript_scheme_identifier_gets_no_url_or_href():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.add_namespace("js", "javascript:")
+    doc.entity("ex:safe", other_attributes={"ex:link": doc.valid_qualified_name("js:alert")})
+    doc.entity("js:payload", other_attributes={"js:attr": "value"})
+
+    dot_text = prov_to_dot(doc).to_string()
+
+    assert 'URL="http://example.org/safe"' in dot_text
+    assert 'href="http://example.org/link"' in dot_text
+    assert 'URL="javascript' not in dot_text
+    assert 'href="javascript' not in dot_text
+
+
+def test_bundle_with_javascript_identifier_gets_no_url():
+    doc = ProvDocument()
+    doc.add_namespace("js", "javascript:")
+    bundle = doc.bundle("js:bundle")
+    bundle.entity("js:e1")
+
+    dot_text = prov_to_dot(doc).to_string()
+
+    assert 'URL="javascript' not in dot_text
+
+
+def test_html_label_special_characters_are_escaped():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1", other_attributes={"prov:label": 'A<b> & "c"'})
+
+    dot = prov_to_dot(doc, use_labels=True)
+    dot_text = dot.to_string()
+
+    assert "A&lt;b&gt; &amp; &quot;c&quot;" in dot_text
+    assert 'A<b> & "c"' not in dot_text
+    assert len(dot.create(format="svg")) > 0
+
+
+def test_quoted_label_escapes_double_quote():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity('ex:e"1')
+
+    dot = prov_to_dot(doc)
+    dot_text = dot.to_string()
+
+    assert 'label="ex:e\\"1"' in dot_text
+    assert len(dot.create(format="svg")) > 0
+```
+
+- [ ] **Step 3: Run to confirm failures**
+
+Run: `uv run pytest src/prov/tests/test_dot.py -q -k "javascript or escaped or double_quote"`
+Expected: 4 failed (URLs and hrefs present; labels unescaped; the quoted-label document may fail to render).
+
+- [ ] **Step 4: Implement the helpers and route the sites through them**
+
+In `src/prov/dot.py`, add `from urllib.parse import urlsplit` to the imports, and after `ANNOTATION_END_ROW` add:
+
+```python
+_LINK_SCHEMES = frozenset({"http", "https", "mailto", "urn"})
+
+
+def _link_uri(uri: str) -> str | None:
+    """Return ``uri`` if it may be emitted as a Graphviz link, else ``None``.
+
+    Identifiers are document content and rendered SVG makes link attributes
+    live, so only ``http``, ``https``, ``mailto``, ``urn`` and scheme-less
+    URIs are linked.
+    """
+    scheme = urlsplit(uri).scheme.lower()
+    return uri if scheme == "" or scheme in _LINK_SCHEMES else None
+
+
+def _quoted(text: str) -> str:
+    """Render ``text`` as a double-quoted DOT string."""
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _url_attr(uri: str) -> dict[str, str]:
+    """Graphviz ``URL`` attribute for ``uri``, or no attribute if it is not linkable."""
+    link = _link_uri(uri)
+    return {"URL": _quoted(link)} if link is not None else {}
+
+
+def _href_attr(uri: str) -> str:
+    """HTML-like-label ``href`` attribute text for ``uri``, or ``""`` if it is not linkable."""
+    link = _link_uri(uri)
+    return f' href="{escape(link)}"' if link is not None else ""
+```
+
+Change `ANNOTATION_ROW_TEMPLATE` so the first cell's `href` is supplied like the second cell's:
+
+```python
+ANNOTATION_ROW_TEMPLATE = """    <TR>
+        <TD align=\"left\"%s>%s</TD>
+        <TD align=\"left\"%s>%s</TD>
+    </TR>"""
+```
+
+In `_attach_attribute_annotation`, the template arguments become:
+
+```python
+        ANNOTATION_ROW_TEMPLATE
+        % (
+            _href_attr(attr.uri),
+            escape(str(attr)),
+            _href_attr(value.uri) if isinstance(value, Identifier) else "",
+            escape(
+                str(value)
+                if not isinstance(value, datetime)
+                else str(value.isoformat())
+            ),
+        )
+```
+
+In `_add_bundle`:
+
+```python
+    subdot = pydot.Cluster(
+        graph_name=f"c{state.cluster_count}",
+        **_url_attr(bundle.identifier.uri),  # type: ignore[union-attr]
+    )
+    subdot.set_label(_quoted(str(bundle.identifier)))  # type: ignore[attr-defined]
+```
+
+Keep the existing comment about `set_label` above that line. In `_add_node`:
+
+```python
+    if state.use_labels:
+        if record.label == record.identifier:
+            node_label = _quoted(str(record.label))
+        else:
+            # Fancier label if both are different. The label will be
+            # the main node text, whereas the identifier will be a
+            # kind of subtitle.
+            node_label = (
+                f"<{escape(str(record.label))}<br />"
+                f'<font color="#333333" point-size="10">'
+                f"{escape(str(record.identifier))}</font>>"
+            )
+    else:
+        node_label = _quoted(str(record.identifier))
+
+    uri = record.identifier.uri  # type: ignore[union-attr]
+    style = DOT_PROV_STYLE[record.get_type()]
+    node = pydot.Node(node_id, label=node_label, **_url_attr(uri), **style)
+```
+
+In `_add_generic_node`:
+
+```python
+    node_label = _quoted(str(qname))
+
+    uri = qname.uri
+    style = GENERIC_NODE_STYLE[prov_type] if prov_type else DOT_PROV_STYLE[0]
+    node = pydot.Node(node_id, label=node_label, **_url_attr(uri), **style)
+```
+
+If mypy objects to the `**_url_attr(...)` unpack next to `**style` (`dict[str, str]` versus `dict[str, Any]`), type `_url_attr`'s return as `dict[str, Any]`, matching the comment above `DOT_PROV_STYLE`.
+
+- [ ] **Step 5: Run tests, compare the baseline, gates, changelog, commit**
+
+Run: `uv run pytest src/prov/tests/test_dot.py -q` → all pass.
+
+```bash
+uv run --extra dot --extra graph python - <<'PY'
+from pathlib import Path
+from prov.dot import prov_to_dot
+from prov.tests import examples
+changed = [name for name, build in examples.tests
+           if (Path("/tmp/dot-baseline") / f"{name}.dot").read_text() != prov_to_dot(build()).to_string()]
+print("changed:", changed)
+PY
+```
+
+Expected: `changed: []`. Any name listed means a site changed bytes for an ordinary document; diff that file and fix before continuing.
+
+Add under `### Security` in `HISTORY.md`:
+
+```markdown
+- `prov.dot` no longer writes identifier URIs into Graphviz `URL`/`href`
+  link attributes unless the scheme is `http`, `https`, `mailto`, `urn` or
+  absent, and escapes labels and identifiers in both HTML-like and quoted
+  node labels; a hostile document could previously plant `javascript:` links
+  or break out of a label in rendered SVG. Ordinary documents render
+  byte-identically
+```
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/dot.py src/prov/tests/test_dot.py HISTORY.md
+git commit -m "security: restrict prov.dot link schemes and escape labels"
+git push -u origin security/dot-link-label-hardening
+gh pr create --base main --title "security: restrict prov.dot link schemes and escape labels" --body "Per the 3.1.1 design spec section 2.3.
+
+A private _link_uri() allows http, https, mailto, urn and scheme-less URIs; the annotation-row hrefs, the bundle cluster URL and the two node URL sites omit the attribute for anything else. HTML-like labels pass label and identifier through html.escape; quoted labels escape backslash and double quote.
+
+DOT text for the eight canonical examples is byte-identical to main (checked against a captured baseline). htlm_link_if_uri() is a public helper not used by prov_to_dot() and is unchanged. Four new tests."
+gh pr checks --watch
+```
+
+---
+
+### Task 5: Observable drops in `prov.graph`
+
+**Goal:** `prov_to_graph` warns with `ProvWarning` instead of silently skipping a relation whose endpoint is unset or whose undeclared endpoint's type cannot be inferred.
+
+**Files:**
+- Modify: `src/prov/graph.py:1-14,75-125` (imports, docstring, loop)
+- Modify: `src/prov/tests/test_graphs.py:38-81` (two existing tests) and append one
+- Modify: `HISTORY.md` (Fixes)
+
+**Acceptance Criteria:**
+- [ ] A relation with an unset endpoint emits exactly one `ProvWarning` naming the relation and produces no edge.
+- [ ] A `wasInfluencedBy` with an undeclared endpoint emits exactly one `ProvWarning` and produces no edge; a following relation is still processed.
+- [ ] A document with neither emits no `ProvWarning`.
+- [ ] The docstring has a `Warns:` section and no longer says "silently skipped".
+- [ ] Suite: +1 test, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_graphs.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Rewrite the two skip tests and add the no-warning test**
+
+In `src/prov/tests/test_graphs.py`, add `import warnings` and `from prov.model import ProvWarning` (extend the existing `from prov.model import ...` line). Replace `test_relation_with_missing_end_is_skipped` and `test_relation_with_uninferrable_endpoint_type_is_skipped`:
+
+```python
+def test_relation_with_missing_end_is_skipped_with_warning(document):
+    # A generation record with no activity: one endpoint is None, so the
+    # relation cannot become an edge. The drop is reported, not silent.
+    document.generation(entity="ex:e1", activity=None)
+
+    with pytest.warns(ProvWarning, match="Generation") as record:
+        g = prov_to_graph(document)
+
+    assert list(g.edges()) == []
+    assert len(record) == 1
+
+
+def test_relation_with_uninferrable_endpoint_type_is_skipped_with_warning(document):
+    # prov:influencee/prov:influencer are the only first-two formal
+    # attributes with no INFERRED_ELEMENT_CLASS entry, so an influence
+    # between undeclared identifiers cannot get placeholder nodes. It is
+    # reported and dropped; later relations are still processed.
+    document.influence("ex:inf1", "ex:inf2")
+    document.wasGeneratedBy("ex:e2", "ex:a2")
+
+    with pytest.warns(ProvWarning, match="Influence") as record:
+        g = prov_to_graph(document)
+
+    assert len(record) == 1
+    assert len(g.nodes()) == 2
+    assert len(g.edges()) == 1
+    (_, _, edge_data) = next(iter(g.edges(data=True)))
+    assert edge_data["relation"].get_type().localpart == "Generation"
+
+
+def test_complete_document_emits_no_warning(document):
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.wasGeneratedBy("ex:e1", "ex:a1")
+    document.influence("ex:e1", "ex:a1")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ProvWarning)
+        g = prov_to_graph(document)
+
+    assert len(g.edges()) == 2
+```
+
+- [ ] **Step 2: Run to confirm the two warning tests fail**
+
+Run: `uv run pytest src/prov/tests/test_graphs.py -q`
+Expected: the two `_with_warning` tests fail with "DID NOT WARN"; the no-warning test passes.
+
+- [ ] **Step 3: Warn at both drop sites**
+
+In `src/prov/graph.py` add `import warnings` after `from typing import Any`, and `ProvWarning,` to the `from prov.model import (...)` block (alphabetical, after `ProvRelation`). Replace the relation loop:
+
+```python
+    for relation in unified.get_records(ProvRelation):
+        # taking the first two elements of a relation
+        attr_pair_1, attr_pair_2 = relation.formal_attributes[:2]
+        # only need the QualifiedName (i.e. the value of the attribute)
+        qn1, qn2 = attr_pair_1[1], attr_pair_2[1]
+        if not (qn1 and qn2):
+            warnings.warn(
+                f"Skipping {relation!r}: both of its first two formal "
+                "attributes must be set to add it as an edge",
+                ProvWarning,
+                stacklevel=2,
+            )
+            continue
+        try:
+            if qn1 not in node_map:
+                node_map[qn1] = INFERRED_ELEMENT_CLASS[attr_pair_1[0]](None, qn1)
+            if qn2 not in node_map:
+                node_map[qn2] = INFERRED_ELEMENT_CLASS[attr_pair_2[0]](None, qn2)
+        except KeyError as exc:
+            # No element class is inferred for this attribute (the
+            # influencee/influencer of a generic influence), so an undeclared
+            # endpoint has no known kind and the relation cannot be drawn.
+            warnings.warn(
+                f"Skipping {relation!r}: endpoint referenced by {exc.args[0]} "
+                "is not declared as an element and its type cannot be inferred",
+                ProvWarning,
+                stacklevel=2,
+            )
+            continue
+        g.add_edge(node_map[qn1], node_map[qn2], relation=relation)
+    return g
+```
+
+Update the docstring sentence "Relations whose first two formal attributes are not both populated, or whose attribute type is not in :data:`INFERRED_ELEMENT_CLASS`, are silently skipped." to "...are skipped with a :class:`~prov.model.ProvWarning`." and add after the `Raises:` block:
+
+```
+    Warns:
+        ProvWarning: For each relation skipped because one of its first two
+            formal attributes is unset, or because an undeclared endpoint's
+            element type cannot be inferred (its attribute has no
+            :data:`INFERRED_ELEMENT_CLASS` entry).
+```
+
+`ProvRelation.__repr__` includes the type and identifier, which is what the `match=` patterns rely on; run `uv run python -c "from prov.model import ProvDocument; d=ProvDocument(); d.add_namespace('ex','http://e/'); print(repr(d.generation('ex:e1', None)))"` and adjust the `match=` strings if the repr differs from `<ProvGeneration: ...>`.
+
+- [ ] **Step 4: Run, gates, changelog, commit**
+
+Run: `uv run pytest src/prov/tests/test_graphs.py src/prov/tests/test_dot.py -q` → all pass (`prov.dot` imports `INFERRED_ELEMENT_CLASS` and must be unaffected). Full suite: 26 skipped, 0 xfailed.
+
+Add under `### Fixes` in `HISTORY.md`:
+
+```markdown
+- `prov.graph.prov_to_graph()` warns with `prov.model.ProvWarning` when it
+  drops a relation (an unset endpoint, or an undeclared endpoint whose type
+  cannot be inferred, which only a `wasInfluencedBy` can trigger) instead of
+  skipping it silently
+```
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/graph.py src/prov/tests/test_graphs.py HISTORY.md
+git commit -m "fix: warn when prov_to_graph drops a relation"
+git push -u origin fix/graph-skip-warnings
+gh pr create --base main --title "fix: warn when prov_to_graph drops a relation" --body "Per the 3.1.1 design spec section 2.4.
+
+Both silent skip paths in prov_to_graph() now issue a ProvWarning naming the relation and the reason, so callers can filter by category. No type is inferred for an undeclared influence endpoint since its kind is unknown. The docstring gains a Warns section."
+gh pr checks --watch
+```
+
+---
+
+### Task 6: PROV-O decoder over-reports unconverted attributes
+
+**Goal:** `decode_container` warns only when at least one subject has a non-empty list of unconverted attributes, and reports only those entries.
+
+**Files:**
+- Modify: `src/prov/serializers/provrdf.py:1336-1342` (`decode_container`)
+- Modify: `src/prov/tests/test_rdf.py` (append two tests)
+- Modify: `HISTORY.md` (Fixes)
+
+**Acceptance Criteria:**
+- [ ] Decoding a document that round-trips cleanly emits no "not converted" warning.
+- [ ] Decoding a graph with a subject that has a non-PROV predicate and no PROV type still warns, and the message names that subject and nothing else.
+- [ ] The full suite's warning summary no longer shows any `The following attributes were not converted: {...: []}` entries.
+- [ ] Suite: +2 tests, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_rdf.py -q -k not_converted` → 2 passed; `uv run pytest -q 2>&1 | grep -c "were not converted: {[^}]*: \[\]}"` → 0.
+
+**Steps:**
+
+- [ ] **Step 1: Write the tests**
+
+Append to `src/prov/tests/test_rdf.py` (add `import warnings` if absent):
+
+```python
+NOT_CONVERTED = "The following attributes were not converted"
+
+
+def test_clean_round_trip_emits_no_not_converted_warning():
+    document = ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    document.entity("e1", other_attributes={"prov:label": "an entity"})
+    document.activity("a1")
+    document.wasGeneratedBy("e1", "a1")
+    document.wasAttributedTo("e1", "ag1")
+    rdf_text = document.serialize(format="rdf", rdf_format="trig")
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=NOT_CONVERTED)
+        reloaded = ProvDocument.deserialize(content=rdf_text, format="rdf", rdf_format="trig")
+
+    assert reloaded == document
+
+
+def test_unmapped_subject_still_warns_and_is_named():
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    ex:e1 a prov:Entity .
+    ex:orphan ex:note "no PROV type" .
+    """
+
+    with pytest.warns(UserWarning, match=NOT_CONVERTED) as record:
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    assert len(record) == 1
+    message = str(record[0].message)
+    assert "http://example.org/orphan" in message
+    assert "http://example.org/e1" not in message
+```
+
+Check how `test_rdf.py` already passes RDF syntax to `deserialize` (`rdf_format=` keyword) and match it.
+
+- [ ] **Step 2: Run to confirm the first fails and the second passes**
+
+Run: `uv run pytest src/prov/tests/test_rdf.py -q -k not_converted`
+Expected: the clean round-trip test fails (the warning is raised for `{'http://example.org/ag1': []}`); the unmapped-subject test may fail on the `e1 not in message` assertion because the current message includes every subject.
+
+- [ ] **Step 3: Warn on non-empty lists only**
+
+In `src/prov/serializers/provrdf.py` `decode_container`, replace:
+
+```python
+        if state.other_attributes:
+            warnings.warn(
+                "The following attributes were not converted: "
+                + str(state.other_attributes),
+                UserWarning,
+                stacklevel=2,
+            )
+```
+
+with:
+
+```python
+        # Every subject gets a (possibly empty) entry while decoding; only
+        # entries still holding attributes are unconverted.
+        unconverted = {
+            subj: attrs for subj, attrs in state.other_attributes.items() if attrs
+        }
+        if unconverted:
+            warnings.warn(
+                "The following attributes were not converted: " + str(unconverted),
+                UserWarning,
+                stacklevel=2,
+            )
+```
+
+- [ ] **Step 4: Run, gates, changelog, commit**
+
+Run: `uv run pytest src/prov/tests/test_rdf.py -q` → all pass; full suite → +2 passed, 26 skipped; the grep in Verify → 0.
+
+Add under `### Fixes` in `HISTORY.md`:
+
+```markdown
+- The PROV-O deserializer no longer warns "attributes were not converted"
+  for documents that decode cleanly; the warning fires only when a subject
+  is left with unconverted attributes and names only those subjects
+```
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/serializers/provrdf.py src/prov/tests/test_rdf.py HISTORY.md
+git commit -m "fix: warn about unconverted PROV-O attributes only when some remain"
+git push -u origin fix/provo-unconverted-warning
+gh pr create --base main --title "fix: warn about unconverted PROV-O attributes only when some remain" --body "Per the 3.1.1 design spec section 2.5.
+
+decode_container() keyed one entry per subject, so the dict was truthy even when every list was empty; every such warning in the test run reported empty lists. It now warns only when at least one list is non-empty and reports only those entries. The remaining test-run warnings are rdflib's own TriG deprecation notices, outside this project's control."
+gh pr checks --watch
+```
+
+---
+
+### Task 7: Close #130 with an attribute-order regression test
+
+**Goal:** A test pins that PROV-N and PROV-JSON emit multi-valued attributes in insertion order, and the PROV-N how-to states the guarantee.
+
+**Files:**
+- Modify: `src/prov/tests/test_model.py` (append)
+- Modify: `docs/howto/provn.md` (new section before "Deserializing raises")
+- Modify: `HISTORY.md` (Tests)
+
+**Acceptance Criteria:**
+- [ ] The test passes under `PYTHONHASHSEED=1`, `2` and `3` for both value orders.
+- [ ] `docs/howto/provn.md` has an "Attribute order is stable" section.
+- [ ] Suite: +2 tests (parametrised), 26 skipped.
+
+**Verify:** `for s in 1 2 3; do PYTHONHASHSEED=$s uv run pytest src/prov/tests/test_model.py -q -k insertion_order | tail -1; done` → 2 passed each.
+
+**Steps:**
+
+- [ ] **Step 1: Write the test**
+
+Append to `src/prov/tests/test_model.py` (add `import json` at the top if absent):
+
+```python
+# #130: multi-valued attributes are written in insertion order. Attribute
+# values have been insertion-ordered since 3.0, so this pins the guarantee.
+
+
+@pytest.mark.parametrize("values", [("foo", "bar", "baz"), ("baz", "bar", "foo")])
+def test_attribute_values_keep_insertion_order_in_provn_and_json(values):
+    document = ProvDocument()
+    document.set_default_namespace("https://example.com/")
+    document.entity("id", [(PROV_TYPE, value) for value in values])
+
+    expected_provn = ", ".join(f'prov:type="{value}"' for value in values)
+    assert expected_provn in document.get_provn()
+
+    encoded = json.loads(document.serialize(format="json"))
+    assert encoded["entity"]["id"]["prov:type"] == list(values)
+```
+
+`PROV_TYPE` is exported by `prov.model`; add it to the module's `from prov.model import (...)` block if missing. If the PROV-JSON encoder wraps plain strings in `{"$": ..., "type": ...}` objects, adjust the last assertion to compare `[v["$"] if isinstance(v, dict) else v for v in encoded[...]]`; confirm by printing `encoded` once.
+
+- [ ] **Step 2: Run under seeds**
+
+Run the Verify loop. Expected: 2 passed each seed (the behaviour already holds; the test guards it).
+
+- [ ] **Step 3: Document the guarantee**
+
+Insert into `docs/howto/provn.md` before `## Deserializing raises `NotImplementedError``:
+
+```markdown
+## Attribute order is stable
+
+Attribute values are written in the order they were added to a record, in PROV-N and in
+every other format. Since 3.0.0 a record stores its attribute values insertion-ordered, so
+two runs of the same program produce the same text and PROV-N output is safe to use in
+doctests and golden files:
+
+```python
+document.entity("e2", [(pm.PROV_TYPE, "foo"), (pm.PROV_TYPE, "bar")])
+print(document.get_provn())
+# entity(e2, [prov:type="foo", prov:type="bar"])
+```
+```
+
+- [ ] **Step 4: Changelog and commit**
+
+Add under `### Tests` in `HISTORY.md`:
+
+```markdown
+- Regression test pinning insertion-ordered attribute output in PROV-N and
+  PROV-JSON; the non-determinism reported in
+  [#130](https://github.com/trungdong/prov/issues/130) was removed by the
+  3.0.0 attribute-storage rework and the guarantee is now documented in the
+  PROV-N how-to
+```
+
+```bash
+uv run pytest src/prov/tests/test_model.py -q
+git add src/prov/tests/test_model.py docs/howto/provn.md HISTORY.md
+git commit -m "test: pin insertion-ordered attribute output (#130)"
+```
+
+Task 8 shares this branch (`test/attribute-order-force-types`); the PR is opened there.
+
+---
+
+### Task 8: `force_types` coverage (#338)
+
+**Goal:** `test_xml.py` exercises `force_types=True` and `False` independently of the disabled `_perform_round_trip` scaffold.
+
+**Files:**
+- Modify: `src/prov/tests/test_xml.py` (append)
+- Modify: `HISTORY.md` (Tests)
+
+**Acceptance Criteria:**
+- [ ] With `force_types=False`, a non-`prov:` string attribute has no `xsi:type`; with `True` it has `xsd:string`.
+- [ ] In both modes an `int` value carries `xsd:int`, a `datetime` carries `xsd:dateTime`, and a `prov:type` string carries `xsd:string`.
+- [ ] Suite: +2 tests (parametrised), 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_xml.py -q -k force_types` → 2 passed.
+
+**Steps:**
+
+- [ ] **Step 1: Write the test**
+
+Append to `src/prov/tests/test_xml.py` (`datetime` is imported as a module already; check):
+
+```python
+# #338: force_types coverage, independent of the disabled _perform_round_trip
+# scaffold above.
+
+XSI_TYPE = "{http://www.w3.org/2001/XMLSchema-instance}type"
+EX_NS = {"ex": "http://example.org/", "prov": "http://www.w3.org/ns/prov#"}
+
+
+@pytest.mark.parametrize("force_types", [True, False])
+def test_force_types_controls_xsi_type_on_non_prov_attributes(force_types):
+    document = prov.ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity(
+        "ex:e1",
+        {
+            "ex:text": "plain",
+            "ex:count": 7,
+            "ex:when": datetime.datetime(2026, 9, 10, 12, 0, 0),
+            "prov:type": "a type",
+        },
+    )
+
+    root = etree.fromstring(
+        document.serialize(format="xml", force_types=force_types).encode()
+    )
+
+    def xsi_type(path):
+        return root.find(path, EX_NS).get(XSI_TYPE)
+
+    assert xsi_type(".//ex:text") == ("xsd:string" if force_types else None)
+    assert xsi_type(".//ex:count") == "xsd:int"
+    assert xsi_type(".//ex:when") == "xsd:dateTime"
+    assert xsi_type(".//prov:type") == "xsd:string"
+```
+
+`_infer_xsd_type` types ints by magnitude via `canonical_xsd_datatype` (#244); `7` yields `xsd:int`. If the assertion reports `xsd:integer` or similar, read `canonical_xsd_datatype` in `src/prov/model/records.py` and pin whatever it returns for `7`, since that is the contract under test. Check `import datetime` exists at the top of `test_xml.py` and add it if not.
+
+- [ ] **Step 2: Run, changelog, commit, open PR F**
+
+Run: `uv run pytest src/prov/tests/test_xml.py -q -k force_types` → 2 passed. Full suite: +4 since PR E merged, 26 skipped.
+
+Add under `### Tests` in `HISTORY.md`:
+
+```markdown
+- The PROV-XML serializer's `force_types` parameter is now covered in both
+  states ([#338](https://github.com/trungdong/prov/issues/338))
+```
+
+```bash
+uv run ruff check src/ && uv run ruff format --check src/
+git add src/prov/tests/test_xml.py HISTORY.md
+git commit -m "test: cover PROV-XML force_types in both states (#338)"
+git push -u origin test/attribute-order-force-types
+gh pr create --base main --title "test: pin attribute order and cover force_types" --body "Closes #130. Closes #338. Per the 3.1.1 design spec sections 2.7 and 2.8.
+
+Attribute values have been insertion-ordered since 3.0.0, so the non-determinism #130 reported no longer occurs; a parametrised test pins PROV-N and PROV-JSON output order under several hash seeds and the PROV-N how-to states the guarantee.
+
+force_types gains direct coverage in test_xml.py for both states, independent of the disabled _perform_round_trip scaffold."
+gh pr checks --watch
+```
+
+---
+
+### Task 9: Own-warnings CI guard (#340)
+
+**Goal:** A non-blocking CI job fails when `prov` itself raises a `DeprecationWarning` or `FutureWarning`, using the ini-style `filterwarnings` form that matches submodules.
+
+**Files:**
+- Modify: `.github/workflows/CI.yml` (new job after `minimal-install`)
+- Modify: `CLAUDE.md` (Tests section, one bullet)
+- Modify: `HISTORY.md` (Project)
+
+**Acceptance Criteria:**
+- [ ] The job runs the ini-style filter, carries the comment on why `-W` is not used, and has `continue-on-error: true`.
+- [ ] `pyproject.toml`'s `[tool.pytest.ini_options]` is untouched.
+- [ ] Locally, the invocation is green on the current tree and red with a probe warning inserted in a `prov` submodule (then reverted).
+- [ ] On the PR, the job appears and passes.
+
+**Verify:** `uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov' | tail -1` → all passed.
+
+**Steps:**
+
+- [ ] **Step 1: Prove the filter discriminates**
+
+```bash
+uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov' | tail -1
+```
+
+Expected: green. Then insert a probe at the top of `ProvBundle.__init__` in `src/prov/model/bundle.py`: `warnings.warn("probe", DeprecationWarning, stacklevel=2)` (add `import warnings` if absent), re-run the same command, and expect hundreds of failures with `DeprecationWarning: probe`. Revert the probe with `git checkout src/prov/model/bundle.py`. Also confirm the `-W` form is the documented no-op: with the probe still in place, `uv run pytest -q -W error::DeprecationWarning:prov src/prov/tests/test_model.py | tail -1` stays green. Revert.
+
+- [ ] **Step 2: Add the job**
+
+Insert into `.github/workflows/CI.yml` after the `minimal-install` job:
+
+```yaml
+  own-warnings:
+    # Non-blocking guard (#340): prov must raise no DeprecationWarning or
+    # FutureWarning of its own. It runs apart from the matrix so a failure
+    # names exactly one cause, and rdflib's deprecation notices (attributed
+    # to rdflib's own modules) stay out of scope.
+    #
+    # The ini-style filterwarnings form is deliberate. pytest's command-line
+    # `-W error::DeprecationWarning:prov` escapes and anchors the module
+    # field, so it matches only warnings raised in prov/__init__.py and is a
+    # silent no-op for every submodule. The ini-style path treats the module
+    # field as a regular expression, so `prov` matches every submodule. It
+    # is not added to pyproject.toml because rdflib's warning surface is not
+    # a stability contract and must not redden every contributor's run.
+    name: own-warnings guard (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          python-version: "3.12"
+      - name: Run the suite with prov's own deprecation warnings as errors
+        env:
+          HYPOTHESIS_PROFILE: ci
+        run: |
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
+          uv run --no-sync pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+```
+
+- [ ] **Step 3: Note it in CLAUDE.md and the changelog**
+
+Add a bullet at the end of the `### Tests` list in `CLAUDE.md`:
+
+```markdown
+- CI's `own-warnings` job (non-blocking) fails if `prov` raises a `DeprecationWarning` or
+  `FutureWarning` of its own. It uses pytest's ini-style `filterwarnings` because the `-W`
+  command-line form anchors the module field and silently ignores submodules (#340).
+```
+
+Add under `### Project` in `HISTORY.md`:
+
+```markdown
+- A non-blocking CI job fails if `prov` raises a `DeprecationWarning` or
+  `FutureWarning` of its own
+  ([#340](https://github.com/trungdong/prov/issues/340))
+```
+
+- [ ] **Step 4: Commit, push, confirm the job ran**
+
+```bash
+uv run pre-commit run check-yaml --files .github/workflows/CI.yml
+git add .github/workflows/CI.yml CLAUDE.md HISTORY.md
+git commit -m "ci: add non-blocking own-warnings guard (#340)"
+git push -u origin ci/own-warnings-guard
+gh pr create --base main --title "ci: add non-blocking own-warnings guard" --body "Closes #340. Per the 3.1.1 design spec section 2.9.
+
+A separate, non-blocking job runs the suite with the ini-style filterwarnings that errors on DeprecationWarning and FutureWarning raised from any prov submodule. The job comment records why the -W command-line form is not used (it anchors the module field and is a silent no-op for submodules). Nothing is added to pyproject.toml. Verified locally: green on the current tree, red with a probe warning inserted in prov.model.bundle."
+gh pr checks --watch
+gh run list --branch ci/own-warnings-guard --limit 1
+```
+
+Confirm the `own-warnings guard (non-blocking)` job is listed and succeeded before merging.
+
+---
+
+### Task 10: Support-policy wording
+
+**Goal:** `README.md` and `SECURITY.md` say 2.x receives security fixes only and that 2.5.3 was the last back-port release.
+
+**Files:**
+- Modify: `README.md:41-46` ("Supported versions")
+- Modify: `SECURITY.md:5-19`
+- Modify: `HISTORY.md` (Documentation)
+
+**Acceptance Criteria:**
+- [ ] Neither file mentions `2.6.0`.
+- [ ] Both state "security fixes only" for 2.x and name `2.5.3` as the last back-port release.
+- [ ] `grep -n "2.6.0" README.md SECURITY.md` prints nothing.
+
+**Verify:** `grep -c "2.5.3" README.md SECURITY.md` → `README.md:1`, `SECURITY.md:2`.
+
+**Steps:**
+
+- [ ] **Step 1: README**
+
+Replace the "Supported versions" paragraph in `README.md` with:
+
+```markdown
+The latest 3.x release receives all fixes. The most recent 2.x release
+receives security fixes only; the last release to carry bug fixes
+back-ported from 3.x was 2.5.3. 1.x and earlier no longer receive fixes. See
+[SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md)
+for the full support table and how to report a vulnerability.
+```
+
+- [ ] **Step 2: SECURITY.md**
+
+Replace the opening paragraph, the table's 2.x row, and the "back-porting window" paragraph:
+
+```markdown
+The latest `3.x` release is actively maintained and receives all fixes.
+The most recent `2.x` release receives security fixes only. `1.x` and
+earlier are no longer supported.
+
+| Version | Supported          | Fixes                                       |
+| ------- | ------------------ | ------------------------------------------- |
+| 3.x     | :white_check_mark: | All fixes                                   |
+| 2.x     | :white_check_mark: | Security fixes only                         |
+| < 2.0   | :x:                | None                                        |
+
+Bug fixes are no longer back-ported to `2.x`: the back-port programme that
+followed the 3.0.0 release closed with `2.5.3`. New features and
+behaviour-breaking corrections were never back-ported and stay on `3.x`.
+```
+
+Keep the Python-version paragraph and the reporting section as they are.
+
+- [ ] **Step 3: Changelog and commit**
+
+Add under `### Documentation` in `HISTORY.md`:
+
+```markdown
+- `README.md` and `SECURITY.md` now state the 2.x support policy as it
+  stands: security fixes only, with 2.5.3 the last back-port release
+```
+
+```bash
+git add README.md SECURITY.md HISTORY.md
+git commit -m "docs: state the 2.x policy as security fixes only"
+```
+
+Task 11 shares this branch (`docs/support-policy-whats-new`).
+
+---
+
+### Task 11: "What's new in 3" page
+
+**Goal:** `docs/whats-new-3.md` summarises the 3.x line for someone still on 2.x, sits under the Project toctree, and is linked from the README roadmap paragraph.
+
+**Files:**
+- Create: `docs/whats-new-3.md`
+- Modify: `docs/index.rst` (Project toctree)
+- Modify: `README.md:32-37` (Roadmap paragraph)
+- Modify: `HISTORY.md` (Documentation)
+
+**Acceptance Criteria:**
+- [ ] The page covers: zero unconditional dependencies, the conformance audit and matrix, PROV-CONSTRAINTS unification, PROV-JSONLD, the upgrade guide, the 2.x policy, the roadmap, and the request to unpin 2.1.1 and 1.5.1.
+- [ ] Every `{doc}` target resolves and the Sphinx build succeeds with no new warnings.
+- [ ] README's Roadmap paragraph links to the page on Read the Docs.
+
+**Verify:** `uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html 2>&1 | grep -i "warning\|error" ; ls docs/_build/html/whats-new-3.html` → no warnings mentioning `whats-new-3`, file present.
+
+**Steps:**
+
+- [ ] **Step 1: Write the page**
+
+Create `docs/whats-new-3.md`:
+
+```markdown
+# What's new in 3
+
+This page is for projects still on `prov` 2.x, or pinned to an older release. It says what
+the 3.x line changed, what it costs to move, and why the pin can go.
+
+## Nothing to install that you do not use
+
+3.0.0 removed every unconditional runtime dependency. `pip install prov` installs the
+library alone; each format or capability that needs a third-party package is an extra:
+
+| Extra | Enables | Pulls in |
+|---|---|---|
+| `rdf` | PROV-O (RDF) serializer and deserializer | `rdflib` |
+| `xml` | PROV-XML serializer and deserializer | `lxml` |
+| `graph` | NetworkX conversion (`prov.graph`) | `networkx` |
+| `dot` | Graphviz export (`prov.dot`) | `pydot`, `networkx` |
+| `plot` | `ProvBundle.plot()` | `matplotlib`, `pydot`, `networkx` |
+
+PROV-JSON, PROV-N and PROV-JSONLD need no extra. See {doc}`installation`.
+
+## Standards conformance, audited
+
+Before 3.0.0 the library was audited against W3C PROV-DM, PROV-CONSTRAINTS, PROV-O,
+PROV-XML and PROV-JSON. The {doc}`reference/conformance` page records, concept by concept,
+how each serializer round-trips it and which gaps are permanent limitations of a format
+rather than defects. The audit's fixes shipped in 3.0.0, each with tests showing the old and
+new behaviour.
+
+## Unification follows PROV-CONSTRAINTS
+
+`unified()` implements the PROV-CONSTRAINTS key constraints: records sharing an identifier
+are merged by term unification of their formal attributes, and records that cannot be
+merged (different concrete values for the same formal attribute, or incompatible types)
+raise `ProvUnificationError` instead of being silently combined. Bundles unify
+independently. See {doc}`explanation/unification-flattening`.
+
+## PROV-JSONLD
+
+3.1.0 added a serializer and deserializer for
+[PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), selected with
+`format="jsonld"`, implemented with the standard library alone. It joins PROV-JSON,
+PROV-XML and PROV-O in the shared round-trip test matrix and in `prov.read()`'s format
+auto-detection. See {doc}`howto/provjsonld`.
+
+## Typed and documented
+
+Every public name carries type hints and the package ships `py.typed`, so type checkers see
+the API. The documentation is organised as tutorial, how-to guides, reference and
+explanation, and the API reference is generated from the docstrings.
+
+## Moving from 2.x
+
+For most code the upgrade needs no change. The two things that can need attention are the
+extras above (install the ones you use) and `unified()` raising on records it previously
+merged silently. {doc}`upgrading-3.0` lists every change, what triggers it, and what to do.
+
+## The 2.x line
+
+The most recent 2.x release receives security fixes only; 2.5.3 was the last release to
+carry bug fixes back-ported from 3.x. See
+[SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md).
+
+## If you pin `prov==2.1.1` or `prov==1.5.1`
+
+Those pins predate the 3.x work. Both versions are outside the support policy, and 1.5.1
+predates Python 3 support. Lift the pin to `prov>=3` and add the extras your code uses.
+Please open an issue if anything in the upgrade guide does not cover your case.
+
+## What comes next
+
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) has the ordered list
+of planned releases. Next is a PROV-N parser (3.2.0), making the notation readable as well
+as writable. Python 3.10 support ends in the first release after its end of life on
+2026-10-31.
+```
+
+Check `docs/installation.md` exists and lists the extras (it is in the Project toctree). Check the claims against the current tree before committing: `grep -n "dependencies = \[\]" pyproject.toml`, the extras table against `[project.optional-dependencies]`, and `1.5.1` against `docs/changelog-archive.md` (released 2017-07-18; "predates Python 3 support" must be confirmed there and softened to "predates the 2.x line" if the archive says otherwise).
+
+- [ ] **Step 2: Toctree and README link**
+
+In `docs/index.rst`, under the Project toctree, insert `whats-new-3` between `installation` and `upgrading-3.0`.
+
+Replace the README "Roadmap" paragraph body with:
+
+```markdown
+3.0.0 has been released, completing the staged modernisation (tooling, type hints,
+tests, documentation, standards conformance), and 3.1.0 added PROV-JSONLD. See
+[What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html) for a summary
+aimed at projects still on 2.x, and
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) for the plan
+and the 3.x API-stability promise.
+Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/issues).
+```
+
+- [ ] **Step 3: Build, changelog, commit, open PR H**
+
+Run the Verify command. Add under `### Documentation` in `HISTORY.md`:
+
+```markdown
+- New [What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html)
+  page summarising the 3.x line for projects still on 2.x, linked from the
+  README
+```
+
+```bash
+git add docs/whats-new-3.md docs/index.rst README.md HISTORY.md
+git commit -m "docs: add What's new in 3 page"
+git push -u origin docs/support-policy-whats-new
+gh pr create --base main --title "docs: 2.x policy wording and What's new in 3 page" --body "Per the 3.1.1 design spec sections 3.1 and 3.2.
+
+README.md and SECURITY.md drop the \"until 2.6.0\" wording (the back-port programme closed at 2.5.3, with no 2.6.0) in favour of security fixes only.
+
+docs/whats-new-3.md, under the Project toctree, summarises the 3.x line for someone still on 2.x and asks projects pinned to 2.1.1 or 1.5.1 to lift the pin; the README roadmap paragraph links to it. It is the page the 3.x announcement will point at. Sphinx builds clean."
+gh pr checks --watch
+```
+
+Codacy's markdownlint runs on both files; fix any finding it reports before merging.
+
+---
+
+### Task 12: Architecture overview
+
+**Goal:** `docs/explanation/architecture.md` describes the packages and their dependencies, the object model, the serializer registry and auto-detection, the extras, and where the tests live; `CLAUDE.md` points at it.
+
+**Files:**
+- Create: `docs/explanation/architecture.md`
+- Modify: `docs/index.rst` (Explanation toctree)
+- Modify: `CLAUDE.md` ("## Architecture" section)
+- Modify: `HISTORY.md` (Documentation)
+
+**Acceptance Criteria:**
+- [ ] Every module, class and function named on the page exists at the stated location (checked with `grep`/`python -c` before commit).
+- [ ] The dependency direction stated matches the imports in each module.
+- [ ] Sphinx builds with no new warnings; `{py:class}`/`{py:func}` roles resolve.
+- [ ] `CLAUDE.md`'s Architecture section opens with a pointer to the page and keeps its agent-specific rules.
+
+**Verify:** `uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html 2>&1 | grep -i "architecture"` → no warnings; `ls docs/_build/html/explanation/architecture.html`.
+
+**Steps:**
+
+- [ ] **Step 1: Write the page**
+
+Create `docs/explanation/architecture.md`:
+
+```markdown
+# Architecture
+
+`prov` is one package, `src/prov/`, in layers that depend in one direction. Reading it in
+that order gives the shape of the library.
+
+## Layers
+
+| Module | Responsibility | Depends on |
+|---|---|---|
+| `prov.identifier` | `Identifier`, `QualifiedName`, `Namespace`: the names records are made of | standard library |
+| `prov.constants` | The PROV vocabulary as `QualifiedName` constants (`PROV_ENTITY`, `PROV_ATTR_ACTIVITY`, ...), plus the tables that map record types to classes and to their PROV-N, PROV-JSON and PROV-XML spellings | `prov.identifier` |
+| `prov.model` | The in-memory data model: records, bundles, documents and namespace management | `prov.constants`, `prov.serializers` (for `serialize()`/`deserialize()` dispatch) |
+| `prov.serializers` | One module per format behind a registry; `ProvDocument.serialize()`, `ProvDocument.deserialize()` and `prov.read()` dispatch through it | `prov.model`, plus `rdflib` (`provrdf`) and `lxml` (`provxml`) behind extras |
+| `prov.graph` | `prov_to_graph()` / `graph_to_prov()`: conversion to and from a NetworkX `MultiDiGraph` | `prov.model`, `networkx` (extra `graph`) |
+| `prov.dot` | `prov_to_dot()`: Graphviz rendering via pydot | `prov.graph`, `prov.model`, `pydot` (extra `dot`) |
+| `prov.scripts` | The `prov-convert` and `prov-compare` command-line tools | `prov.model`, `prov.serializers` |
+
+`prov.model` is a package (`records.py`, `bundle.py`, `namespaces.py`) whose `__init__.py`
+re-exports every public name at its historic `prov.model` location, so user code imports
+from `prov.model` and never from the submodules.
+
+## The object model
+
+A {py:class}`~prov.model.ProvRecord` is a PROV type, an optional identifier, and an ordered
+multi-valued attribute map. Two subclasses split the PROV-DM world:
+{py:class}`~prov.model.ProvElement` (entity, activity, agent) and
+{py:class}`~prov.model.ProvRelation` (generation, usage, derivation and the rest). Each
+concrete class declares its formal attributes in order; everything else on the record is an
+"other" attribute.
+
+A {py:class}`~prov.model.ProvBundle` owns records and a namespace manager, and offers a
+factory method per record type (`entity()`, `wasGeneratedBy()`, ...). A
+{py:class}`~prov.model.ProvDocument` is a bundle that can also contain named bundles, and
+is the unit that serializes. Records are created through the bundle so that identifiers
+resolve against its namespaces; the bundle records every namespace a record mentions.
+
+Two transformations produce new documents rather than mutating:
+{py:meth}`~prov.model.ProvDocument.flattened` lifts bundle contents to the top level, and
+{py:meth}`~prov.model.ProvBundle.unified` merges records that share an identifier under the
+PROV-CONSTRAINTS rules. See {doc}`unification-flattening`.
+
+## Serializers and format detection
+
+Each serializer subclasses {py:class}`~prov.serializers.Serializer` and implements
+`serialize()` and `deserialize()`. `prov.serializers.Registry` holds them under their
+format names in insertion order, `json`, `rdf`, `provn`, `xml`, `jsonld`, and
+{py:func}`prov.serializers.get` resolves a name to a class. PROV-N is write-only: its
+deserializer raises `NotImplementedError`.
+
+{py:func}`prov.read` reads a file, path or string without a `format` by trying the
+registered formats in that order until one succeeds, rewinding the stream between attempts
+where it can. The order is part of the contract: `json` is tried first because it is the
+only attempt that can succeed on a non-seekable stream.
+
+Formats whose parser is an optional dependency (`rdf`, `xml`) register unconditionally and
+fail at use time with a `ModuleNotFoundError` naming the extra to install, so the registry's
+shape does not depend on what is installed.
+
+## Extras
+
+The core package has no runtime dependencies. `rdflib`, `lxml`, `networkx`, `pydot` and
+`matplotlib` sit behind the `rdf`, `xml`, `graph`, `dot` and `plot` extras respectively
+(see {doc}`../installation`). `prov.graph` and `prov.dot` raise `ModuleNotFoundError`
+naming the extra when imported without it.
+
+## Tests
+
+The test suite lives inside the package, at `src/prov/tests/`, and ships with it. Shared
+coverage runs once per serializer through a parametrised round-trip fixture, so a new
+record type or attribute shape is exercised against every format at once; per-format
+modules keep only what is specific to that format. `examples.py` holds the canonical example
+documents that several modules and the DOT smoke tests reuse, and a Hypothesis property test
+round-trips generated documents through every format.
+```
+
+- [ ] **Step 2: Verify every claim against the source**
+
+Before committing, run and reconcile:
+
+```bash
+uv run python -c "import prov.serializers as s; print(list(s.Registry.serializers))"   # or the attribute Registry actually uses; must print json, rdf, provn, xml, jsonld
+grep -n "^from\|^import" src/prov/model/bundle.py src/prov/serializers/__init__.py src/prov/graph.py src/prov/dot.py src/prov/scripts/*.py | grep "prov\."
+grep -n "def get\|class Serializer\|class Registry" src/prov/serializers/__init__.py
+grep -n "NotImplementedError" src/prov/serializers/provn.py
+sed -n 140,200p src/prov/__init__.py   # read() auto-detection and the rewind behaviour
+```
+
+Correct any sentence the source contradicts (for example if `prov.model` does not import `prov.serializers` at module level, say "imports lazily inside `serialize()`" instead). The page must describe the code as it is.
+
+- [ ] **Step 3: Toctree, CLAUDE.md pointer, build**
+
+In `docs/index.rst` add `explanation/architecture` as the first entry of the Explanation toctree.
+
+In `CLAUDE.md`, directly under `## Architecture`, insert:
+
+```markdown
+`docs/explanation/architecture.md` is the overview (layers, object model, registry and
+auto-detection, extras, tests). The notes below are the agent-specific rules on top of it.
+```
+
+Run the Verify command.
+
+- [ ] **Step 4: Changelog, commit, open PR I**
+
+Add under `### Documentation` in `HISTORY.md`:
+
+```markdown
+- New [architecture overview](https://prov.readthedocs.io/en/latest/explanation/architecture.html)
+  under Explanation
+```
+
+```bash
+git add docs/explanation/architecture.md docs/index.rst CLAUDE.md HISTORY.md
+git commit -m "docs: add architecture overview"
+git push -u origin docs/architecture-overview
+gh pr create --base main --title "docs: add architecture overview" --body "Per the 3.1.1 design spec section 3.3.
+
+docs/explanation/architecture.md describes the package layers and their dependency direction, the record and bundle object model, the serializer registry and prov.read() auto-detection, the extras, and where the tests live. Every named module, class and function was checked against the source. CLAUDE.md keeps its agent-specific rules and points at the page for the overview."
+gh pr checks --watch
+```
+
+---
+
+### Task 13: Planning files leave `docs/`
+
+**Goal:** `docs/superpowers/` and `docs/test-gap-checklist.md` move to a top-level `planning/` directory with `git mv`, every live reference is updated, and `CLAUDE.md` states that specs and plans live under `planning/`.
+
+**Files:**
+- Move: `docs/superpowers/{specs,plans,triage}` → `planning/{specs,plans,triage}`; `docs/test-gap-checklist.md` → `planning/test-gap-checklist.md`
+- Modify: `ROADMAP.md:9,81`; `CLAUDE.md:13,82` (+ new statement); `docs/upgrading-3.0.md:26`; `docs/conf.py:30-39`; `.codacy.yaml:10`; `.codacy/codacy.config.json:163`; `pyproject.toml:169` (comment); `src/prov/tests/schemas/README.md`; test-module comments in `src/prov/tests/` (13 files, comments only); `docs/dependencies.md`
+- Modify: `planning/plans/2026-09-10-release-3.1.1.md.tasks.json` (`planPath`)
+- Modify: `HISTORY.md` (Project)
+
+**Acceptance Criteria:**
+- [ ] `git status` shows renames, not delete-plus-add, for every moved file.
+- [ ] `grep -rn "docs/superpowers\|docs/test-gap-checklist" --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.claude --exclude-dir=planning .` prints nothing.
+- [ ] `docs/conf.py` `exclude_patterns` no longer lists `superpowers` or `test-gap-checklist.md`; Sphinx builds clean.
+- [ ] `CLAUDE.md` says design specs and plans live under `planning/specs/` and `planning/plans/`.
+- [ ] `docs/upgrading-3.0.md`'s roadmap-design link points at `main`, not `master`.
+- [ ] Suite unchanged (comment-only edits under `src/`).
+
+**Verify:** `grep -rn "docs/superpowers\|docs/test-gap-checklist" --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.claude --exclude-dir=planning . | wc -l` → `0`; `uv run pytest -q | tail -1` → unchanged counts.
+
+**Steps:**
+
+- [ ] **Step 1: Move**
+
+```bash
+git checkout main && git pull && git checkout -b chore/planning-directory
+git mv docs/superpowers planning
+git mv docs/test-gap-checklist.md planning/test-gap-checklist.md
+git status --short | head
+```
+
+- [ ] **Step 2: Rewrite live references**
+
+Historic plans and specs inside `planning/` keep their old paths (they are archival). Everything outside `planning/` and `.claude/` is rewritten:
+
+```bash
+grep -rl "docs/superpowers\|docs/test-gap-checklist" --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.claude --exclude-dir=planning . \
+  | xargs sed -i '' -e 's#docs/superpowers/#planning/#g' -e 's#docs/test-gap-checklist\.md#planning/test-gap-checklist.md#g'
+grep -rn "superpowers\|test-gap-checklist" --exclude-dir=.git --exclude-dir=.venv --exclude-dir=.claude --exclude-dir=planning .
+```
+
+The second grep must show only `docs/conf.py`, `.codacy.yaml` and `.codacy/codacy.config.json` (their patterns are `"superpowers"` and `"docs/superpowers/**"`, handled next), and `planning/test-gap-checklist.md` mentions in `pyproject.toml`/tests that the sed already rewrote.
+
+- [ ] **Step 3: Configuration files**
+
+`docs/conf.py`: remove the `"superpowers",` and `"test-gap-checklist.md",` entries and reword the comment:
+
+```python
+exclude_patterns = [
+    "_build",
+    # Internal working docs (dependency notes, the release runbook) live under
+    # docs/ for convenience but are not part of the published documentation.
+    # Design specs and plans live in the top-level planning/ directory.
+    "dependencies.md",
+    "releasing.md",
+]
+```
+
+`.codacy.yaml`: change `"docs/superpowers/**"` to `"planning/**"`. `.codacy/codacy.config.json` line 163: same change.
+
+`docs/upgrading-3.0.md` line 26: the link becomes `https://github.com/trungdong/prov/blob/main/planning/specs/2026-07-03-modernisation-roadmap-design.md` (the sed rewrote the path; change `master` to `main` by hand on that line and the `ROADMAP.md` link two lines above it).
+
+- [ ] **Step 4: CLAUDE.md**
+
+After the sed, `CLAUDE.md` lines 13 and 82 point at `planning/specs/...`. Add to the end of the "Modernisation roadmap" bullet list:
+
+```markdown
+- Design specs and implementation plans live under `planning/` (`planning/specs/`,
+  `planning/plans/`), not `docs/`. Write new ones there; `docs/` is the published site plus
+  the two internal runbooks it excludes.
+```
+
+- [ ] **Step 5: This plan's task file**
+
+In `planning/plans/2026-09-10-release-3.1.1.md.tasks.json`, set `"planPath": "planning/plans/2026-09-10-release-3.1.1.md"`. In this plan's header, the spec path line already names the post-move location.
+
+- [ ] **Step 6: Build, test, changelog, commit, open PR J**
+
+```bash
+uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html 2>&1 | grep -i "warning\|error"
+uv run pytest -q | tail -1
+```
+
+Add under `### Project` in `HISTORY.md`:
+
+```markdown
+- Design specs, implementation plans and the test-gap checklist moved from
+  `docs/` to a top-level `planning/` directory; the published documentation
+  is unaffected
+```
+
+```bash
+git add -A
+git commit -m "chore: move planning files to planning/"
+git push -u origin chore/planning-directory
+gh pr create --base main --title "chore: move planning files to planning/" --body "Per the 3.1.1 design spec section 3.4.
+
+docs/superpowers/ and docs/test-gap-checklist.md move to planning/ with git mv (specs, plans, triage, checklist). Live links in ROADMAP.md, CLAUDE.md, docs/upgrading-3.0.md (which also now points at main rather than master), docs/conf.py's exclusion list, the Codacy configs, and test-module comments are updated; historic plans keep their old paths. CLAUDE.md now states where new specs and plans go. docs/releasing.md and docs/dependencies.md stay in docs/."
+gh pr checks --watch
+```
+
+---
+
+### Task 14: Community scaffolding
+
+**Goal:** The repository gains a Code of Conduct, issue and pull-request templates, `CITATION.cff` with a version-agreement test, `.zenodo.json`, a licensing paragraph in `CONTRIBUTING.md`, the `good first issue` and `help wanted` labels, and loses the `cla/` directory.
+
+**Files:**
+- Create: `CODE_OF_CONDUCT.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`, `.github/ISSUE_TEMPLATE/config.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `CITATION.cff`, `.zenodo.json`, `src/prov/tests/test_citation.py`
+- Modify: `CONTRIBUTING.md` (new "Licensing" section), `docs/releasing.md` (§2 stamp table gains `CITATION.cff`), `HISTORY.md` (Project)
+- Delete: `cla/krischer.rst`, `cla/satra.rst`
+- Repository: labels `good first issue`, `help wanted`
+
+**Acceptance Criteria:**
+- [ ] `CODE_OF_CONDUCT.md` is Contributor Covenant 2.1 with `trungdong@donggiang.com` as the contact.
+- [ ] Both issue forms and `config.yml` pass `uv run pre-commit run check-yaml --files .github/ISSUE_TEMPLATE/*.yml`; `config.yml` links questions to Discussions and vulnerabilities to `SECURITY.md`.
+- [ ] `CITATION.cff` `version` equals `prov.__version__` and `test_citation.py` proves it; `.zenodo.json` parses.
+- [ ] `gh label list` shows both new labels.
+- [ ] `cla/` is gone and `CONTRIBUTING.md` has the inbound-equals-outbound paragraph.
+- [ ] Suite: +2 tests, 26 skipped.
+
+**Verify:** `uv run pytest src/prov/tests/test_citation.py -q` → 2 passed; `gh label list --repo trungdong/prov | grep -c "good first issue\|help wanted"` → 2.
+
+**Steps:**
+
+- [ ] **Step 1: Code of Conduct**
+
+```bash
+curl -sL https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md -o CODE_OF_CONDUCT.md
+sed -i '' 's/\[INSERT CONTACT METHOD\]/trungdong@donggiang.com/' CODE_OF_CONDUCT.md
+grep -n "INSERT\|donggiang" CODE_OF_CONDUCT.md
+```
+
+Expected: one `donggiang` line, no `INSERT`. If the download is not markdown (the site occasionally serves HTML), fetch <https://raw.githubusercontent.com/EthicalSource/contributor_covenant/release/content/version/2/1/code_of_conduct.md> instead. Codacy's markdownlint runs on it; if it flags long lines or bare URLs, wrap or angle-bracket them without changing the wording.
+
+- [ ] **Step 2: Issue forms and config**
+
+`.github/ISSUE_TEMPLATE/bug_report.yml`:
+
+```yaml
+name: Bug report
+description: Something behaves differently from the documentation or the PROV specifications
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: prov version
+      description: Output of `python -c "import prov; print(prov.__version__)"`
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version and implementation
+      placeholder: "3.12.4 (CPython) on macOS 15"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal script or document that shows the problem. Say which format and extras are involved.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include the full traceback if there is one.
+    validations:
+      required: true
+```
+
+`.github/ISSUE_TEMPLATE/feature_request.yml`:
+
+```yaml
+name: Feature request
+description: Propose an addition or a change to the library
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The use case, not the solution. Name the PROV concept or format involved.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: How it would work from the caller's side. Keep the scope as narrow as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+```
+
+`.github/ISSUE_TEMPLATE/config.yml`:
+
+```yaml
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and discussion
+    url: https://github.com/trungdong/prov/discussions
+    about: Ask how to do something, or discuss an idea before proposing it
+  - name: Report a security vulnerability
+    url: https://github.com/trungdong/prov/security/advisories/new
+    about: Please report vulnerabilities privately, as described in SECURITY.md
+```
+
+- [ ] **Step 3: Pull request template**
+
+`.github/PULL_REQUEST_TEMPLATE.md`:
+
+```markdown
+## Summary
+
+<!-- What changes and why. Link the issue it closes with "Closes #N". -->
+
+## Checklist
+
+- [ ] Tests cover the change (see "Pull Request Guidelines" in CONTRIBUTING.md).
+- [ ] Documentation is updated if the change adds or alters behaviour.
+- [ ] `uv run pytest`, `uv run mypy src`, `uv run ruff check src/` and `uv run ruff format --check src/` pass locally.
+- [ ] CI is green for every supported Python version, including PyPy.
+- [ ] `HISTORY.md` has an entry under the unreleased version.
+```
+
+- [ ] **Step 4: Citation metadata**
+
+`CITATION.cff` (`version` must equal the current `prov.__version__`, `3.1.0` at the time this task runs; Task 15 bumps it):
+
+```yaml
+cff-version: 1.2.0
+message: If you use this software, please cite it using the metadata below.
+type: software
+title: "prov: a Python library for the W3C PROV Data Model"
+abstract: >-
+  A library for the W3C Provenance Data Model with import and export in
+  PROV-JSON, PROV-XML, PROV-O (RDF), PROV-JSONLD and PROV-N, graph
+  conversion via NetworkX, and Graphviz rendering.
+authors:
+  - family-names: Huynh
+    given-names: Trung Dong
+    orcid: "https://orcid.org/0000-0003-4937-2473"
+repository-code: "https://github.com/trungdong/prov"
+url: "https://prov.readthedocs.io"
+license: MIT
+version: "3.1.0"
+keywords:
+  - provenance
+  - W3C PROV
+  - PROV-DM
+  - PROV-JSON
+  - PROV-XML
+  - PROV-O
+  - PROV-JSONLD
+```
+
+`.zenodo.json`:
+
+```json
+{
+  "title": "prov: a Python library for the W3C PROV Data Model",
+  "description": "A library for the W3C Provenance Data Model with import and export in PROV-JSON, PROV-XML, PROV-O (RDF), PROV-JSONLD and PROV-N, graph conversion via NetworkX, and Graphviz rendering.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "MIT",
+  "creators": [
+    {
+      "name": "Huynh, Trung Dong",
+      "orcid": "0000-0003-4937-2473"
+    }
+  ],
+  "keywords": ["provenance", "W3C PROV", "PROV-DM", "PROV-JSON", "PROV-XML", "PROV-O", "PROV-JSONLD"]
+}
+```
+
+`src/prov/tests/test_citation.py`:
+
+```python
+"""Repository metadata files must agree with the package.
+
+These files live at the repository root, not in the package, so the tests
+skip when run from an installed wheel.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import prov
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CITATION_FILE = REPO_ROOT / "CITATION.cff"
+ZENODO_FILE = REPO_ROOT / ".zenodo.json"
+
+pytestmark = pytest.mark.skipif(
+    not CITATION_FILE.is_file(), reason="CITATION.cff only exists in a source checkout"
+)
+
+
+def test_citation_version_matches_package_version():
+    match = re.search(r'^version:\s*"?([^"\n]+?)"?\s*$', CITATION_FILE.read_text(), re.MULTILINE)
+    assert match is not None, "CITATION.cff has no version line"
+    assert match.group(1) == prov.__version__
+
+
+def test_zenodo_metadata_names_the_maintainer():
+    metadata = json.loads(ZENODO_FILE.read_text())
+    assert metadata["license"] == "MIT"
+    assert metadata["creators"][0]["orcid"] == "0000-0003-4937-2473"
+```
+
+Run: `uv run pytest src/prov/tests/test_citation.py -q` → 2 passed. Then break it on purpose (`version: "9.9.9"`), confirm the first test fails, and restore.
+
+Add a row to the §2 table in `docs/releasing.md`:
+
+```markdown
+| `CITATION.cff` | `version: "X.Y.Z"` — `src/prov/tests/test_citation.py` fails the suite if it disagrees with `prov.__version__` |
+```
+
+and change "Four files, in one commit:" to "Five files, in one commit:".
+
+- [ ] **Step 5: Licensing paragraph and CLA removal**
+
+Append to `CONTRIBUTING.md`:
+
+```markdown
+## Licensing
+
+`prov` is released under the MIT licence (see `LICENSE`). By submitting a contribution you
+agree that it is licensed under the same terms, with no additional restrictions: the
+licence that applies to your contribution inbound is the licence the project applies
+outbound. There is no contributor licence agreement to sign.
+```
+
+```bash
+git rm -r cla
+```
+
+- [ ] **Step 6: Labels**
+
+```bash
+gh label create "good first issue" --repo trungdong/prov --color 7057ff --description "Good for newcomers"
+gh label create "help wanted" --repo trungdong/prov --color 008672 --description "Extra attention is needed"
+gh label list --repo trungdong/prov | grep -i "good first\|help wanted"
+```
+
+- [ ] **Step 7: Changelog, commit, open PR K**
+
+Add under `### Project` in `HISTORY.md`:
+
+```markdown
+- Contributor Covenant 2.1 code of conduct, issue forms, a pull-request
+  template, `CITATION.cff` (kept in step with `prov.__version__` by a test)
+  and `.zenodo.json`; contributions are accepted under the project's MIT
+  licence on an inbound-equals-outbound basis and the contributor licence
+  agreements in `cla/` are removed
+```
+
+```bash
+uv run pre-commit run --all-files
+uv run pytest -q | tail -1
+git add -A
+git commit -m "chore: add community scaffolding and citation metadata"
+git push -u origin chore/community-scaffolding
+gh pr create --base main --title "chore: add community scaffolding and citation metadata" --body "Per the 3.1.1 design spec section 3.5.
+
+Adds CODE_OF_CONDUCT.md (Contributor Covenant 2.1), issue forms and config (questions to Discussions, vulnerabilities to SECURITY.md), a pull-request template built from CONTRIBUTING's guidelines, CITATION.cff with a test that fails the suite if its version drifts from prov.__version__, and .zenodo.json. CONTRIBUTING.md gains an inbound-equals-outbound licensing section and cla/ is removed. The good first issue and help wanted labels are created on the repository. docs/releasing.md's stamp table gains the CITATION.cff row."
+gh pr checks --watch
+```
+
+---
+
+### Task 15: Stamp the release
+
+**Goal:** One PR stamps 3.1.1 in the five stamped files, finalises the changelog section and adds the ROADMAP row, per `docs/releasing.md` §1 to §3.
+
+**Files:**
+- Modify: `src/prov/__init__.py` (`__version__ = "3.1.1"`)
+- Modify: `CITATION.cff` (`version: "3.1.1"`)
+- Modify: `HISTORY.md` (`## 3.1.1 (YYYY-MM-DD)`; remove empty subsections)
+- Modify: `ROADMAP.md` (3.1.1 row after 3.1.0)
+- Modify: `docs/reference/conformance.md` ("last revised for" sentence)
+
+**Acceptance Criteria:**
+- [ ] Pre-flight from `docs/releasing.md` §1 passes on the stamp commit: full interpreter matrix, `mypy`, `ruff check`, `ruff format --check`, `uv build`, wheel contains `py.typed` and `prov-jsonld-context`.
+- [ ] Suite on the stamp commit: 1646 + 22 = **1668 passed, 26 skipped, 0 xfailed** (Tasks 1, 2, 3, 5, 6, 7, 8, 14 add 2, 4, 3, 1, 2, 2, 2, 2; Task 4 adds 4). Recount from the merged PRs if any task's count moved.
+- [ ] Coverage report exits 0 against the 97% floor.
+- [ ] `HISTORY.md` has no empty subsections and the heading is dated.
+- [ ] Release PR L is green and merged.
+
+**Verify:** `uv run pytest -q -rsx | tail -1` → `1668 passed, 26 skipped`; `uv run coverage run -m pytest -q && uv run coverage report | tail -1` → TOTAL ≥ 97%.
+
+**Steps:**
+
+- [ ] **Step 1: Branch and stamp**
+
+```bash
+git checkout main && git pull && git checkout -b release/3.1.1
+sed -i '' 's/^__version__ = "3.1.0"/__version__ = "3.1.1"/' src/prov/__init__.py
+sed -i '' 's/^version: "3.1.0"/version: "3.1.1"/' CITATION.cff
+DATE=$(date +%Y-%m-%d)
+sed -i '' "s/^## 3.1.1 (unreleased)/## 3.1.1 ($DATE)/" HISTORY.md
+```
+
+- [ ] **Step 2: Finalise the changelog**
+
+Read the `## 3.1.1` section of `HISTORY.md`. Delete any subsection heading with no bullets. Lead the section with one sentence before the first subsection:
+
+```markdown
+3.1.1 is a point release: bug fixes, hardening of the graphical export, test
+coverage for long-open issues, a "What's new in 3" page, and the community
+files the repository lacked. No API, dependency or Python-floor changes.
+```
+
+- [ ] **Step 3: ROADMAP row and conformance revisit**
+
+Insert after the 3.1.0 row in `ROADMAP.md`'s table:
+
+```markdown
+| **3.1.1** *(released YYYY-MM-DD)* | Point release | Bug fixes and hardening from the September 2026 audit: deterministic bundle namespace declarations ([#337](https://github.com/trungdong/prov/issues/337)), link and label hardening in `prov.dot`, `ProvWarning` on dropped `prov_to_graph()` relations, quieter PROV-O decoding, faster bundle equality and namespace lookup. Tests close [#130](https://github.com/trungdong/prov/issues/130) and [#338](https://github.com/trungdong/prov/issues/338); a non-blocking CI job answers [#340](https://github.com/trungdong/prov/issues/340). Documentation and repository scaffolding: "What's new in 3", an architecture overview, code of conduct, issue and PR templates, `CITATION.cff` and the first Zenodo DOI. |
+```
+
+with the real date. In `docs/reference/conformance.md`, re-read the page against the merged changes (none of 3.1.1's fixes alter round-trip results; #337 changes declaration order only) and update the opening sentence to:
+
+```markdown
+It's revisited at every release — last revised for the 3.1.1 release (YYYY-MM-DD), which
+changed no round-trip result; the JSON-LD column was added for 3.1.0's **PROV-JSONLD**
+serializer/deserializer (`format="jsonld"`, {doc}`../howto/provjsonld`).
+```
+
+- [ ] **Step 4: Pre-flight**
+
+```bash
+for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do
+    uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest -q || break
+done
+uv run --python 3.13 --extra rdf --extra xml --extra dot --extra graph mypy src
+uv run ruff check src/ && uv run ruff format --check src/
+uv run coverage run -m pytest -q && uv run coverage report | tail -1
+rm -rf dist && uv build && unzip -l dist/prov-*.whl | grep -E "py.typed|prov-jsonld-context"
+uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov' | tail -1
+```
+
+Every command must succeed. `docs/releasing.md` §1 says the suite "must match the invariant recorded in `CLAUDE.md`"; `CLAUDE.md` no longer records a fixed count, so the invariant is the count in this task's acceptance criteria, compared against the previous run.
+
+- [ ] **Step 5: Commit and open PR L**
+
+```bash
+git add src/prov/__init__.py CITATION.cff HISTORY.md ROADMAP.md docs/reference/conformance.md
+git commit -m "Release 3.1.1"
+git push -u origin release/3.1.1
+gh pr create --base main --title "Release 3.1.1" --body "Stamps 3.1.1 in src/prov/__init__.py, CITATION.cff, HISTORY.md, ROADMAP.md and docs/reference/conformance.md per docs/releasing.md section 2. Pre-flight (full interpreter matrix, mypy, ruff, build, coverage floor, own-warnings guard) passed locally on this commit. Suite: 1668 passed, 26 skipped, 0 xfailed."
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout main && git pull
+```
+
+---
+
+### Task 16: Maintainer pre-release gates
+
+**Goal:** Before anything irreversible, the Zenodo GitHub integration is confirmed active on `trungdong/prov` and GitHub Discussions is enabled, both verified with `gh`.
+
+**USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+**Files:** none (repository settings). Coordinator runs this task directly; do not delegate.
+
+**Acceptance Criteria:**
+- [ ] `gh api repos/trungdong/prov/hooks --jq '.[].config.url' | grep -c zenodo.org` prints `1` (the Zenodo webhook; do not print the hook URL itself, it embeds a token). Verified present on 2026-09-10 after the maintainer enabled the repository on Zenodo.
+- [ ] `gh repo view trungdong/prov --json hasDiscussionsEnabled --jq .hasDiscussionsEnabled` prints `true`.
+- [ ] Both outputs are captured in the task's close message.
+
+**Verify:** the two commands above → `1` and `true`.
+
+**Steps:**
+
+- [ ] **Step 1: Check both settings**
+
+```bash
+gh api repos/trungdong/prov/hooks --jq '.[].config.url' | grep -c zenodo.org
+gh repo view trungdong/prov --json hasDiscussionsEnabled --jq .hasDiscussionsEnabled
+```
+
+- [ ] **Step 2: If Discussions is `false`, stop and ask the maintainer**
+
+Discussions is a repository setting (Settings → General → Features → Discussions). `gh` cannot enable it. Ask the maintainer to enable it, then re-run Step 1. Do not start Task 17 until both checks pass.
+
+---
+
+### Task 17: Publish
+
+**Goal:** 3.1.1 is on TestPyPI (dry run), then PyPI via the GitHub release, and the installed wheel is verified, per `docs/releasing.md` §4 and §5.
+
+**Files:** none in the repository. Coordinator runs this task directly; publishing is irreversible and must not be delegated to a subagent.
+
+**Acceptance Criteria:**
+- [ ] The `workflow_dispatch` run publishes 3.1.1 to TestPyPI and skips `publish-pypi`.
+- [ ] `gh release create 3.1.1` succeeds with notes taken from the `## 3.1.1` section of `HISTORY.md`; the triggered run's `publish-pypi` job succeeds.
+- [ ] `curl https://pypi.org/pypi/prov/3.1.1/json` shows sdist and wheel and every `requires_dist` entry gated on an extra.
+- [ ] A fresh venv installs `prov==3.1.1`, prints the version, and round-trips a document through `jsonld` from the installed package.
+- [ ] Zenodo shows a record for the 3.1.1 release within the hour (`curl -s "https://zenodo.org/api/records?q=prov%20Huynh&sort=mostrecent" | python3 -c "import json,sys; print([h['metadata']['title'] for h in json.load(sys.stdin)['hits']['hits']][:3])"`).
+
+**Verify:** `.v/bin/python -c "import prov; print(prov.__version__)"` → `3.1.1`.
+
+**Steps:**
+
+- [ ] **Step 1: TestPyPI dry run**
+
+```bash
+gh workflow run release.yml --repo trungdong/prov --ref main
+sleep 20 && gh run list --repo trungdong/prov --workflow release.yml --limit 1
+gh run watch <run-id> --repo trungdong/prov --exit-status
+curl -s https://test.pypi.org/pypi/prov/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+```
+
+Expected: `3.1.1`; the run shows `publish-pypi` skipped.
+
+- [ ] **Step 2: Extract release notes and create the release**
+
+```bash
+python3 - <<'PY'
+import re
+text = open("HISTORY.md").read()
+m = re.search(r"^## 3\.1\.1 \([^)]*\)\n(.*?)(?=^## )", text, re.S | re.M)
+open("/tmp/notes-3.1.1.md", "w").write(m.group(1).strip() + "\n")
+print(open("/tmp/notes-3.1.1.md").read()[:400])
+PY
+gh release create 3.1.1 --repo trungdong/prov --target main --title 3.1.1 --notes-file /tmp/notes-3.1.1.md
+sleep 20 && gh run list --repo trungdong/prov --workflow release.yml --limit 1
+gh run watch <run-id> --repo trungdong/prov --exit-status
+```
+
+- [ ] **Step 3: Verify what shipped**
+
+```bash
+curl -s https://pypi.org/pypi/prov/3.1.1/json | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print(d['info']['version'], [u['packagetype'] for u in d['urls']])
+print(d['info']['requires_dist'])"
+rm -rf .v && uv venv .v && uv pip install --refresh --python .v/bin/python "prov[rdf,xml]==3.1.1"
+.v/bin/python -c "import prov; print(prov.__version__)"
+.v/bin/python - <<'PY'
+from prov.model import ProvDocument
+d = ProvDocument(); d.set_default_namespace("http://example.org/")
+d.entity("e1"); d.activity("a1"); d.wasGeneratedBy("e1", "a1")
+for fmt in ("json", "xml", "rdf", "jsonld"):
+    assert ProvDocument.deserialize(content=d.serialize(format=fmt), format=fmt) == d, fmt
+print("round trips ok")
+PY
+rm -rf .v
+```
+
+If `uv pip install` reports no such version, wait and retry with `--refresh` (index caching, see `docs/releasing.md` §5) before treating it as a failure; a real failure shows as a 404 from the `curl` and a red `publish-pypi` job.
+
+---
+
+### Task 18: Post-release close-out
+
+**Goal:** The DOI badge is in the README, the conda-forge bump is merged, milestones are tidy, and the execution-state memory is updated.
+
+**Files:**
+- Modify: `README.md` (badge line)
+- Repository: milestone `3.1.1`; stale milestone `3.1.0` closed
+- conda-forge: `conda-forge/prov-feedstock` bump PR
+
+**Acceptance Criteria:**
+- [ ] README's badge row carries `[![DOI](https://zenodo.org/badge/<repo-id>.svg)](https://zenodo.org/badge/latestdoi/<repo-id>)` with the numeric repository id, committed on `main` via a PR (Codacy gate applies to README).
+- [ ] The feedstock bump PR for 3.1.1 is merged and <https://anaconda.org/conda-forge/prov> shows 3.1.1.
+- [ ] Issues #130, #337, #338, #340 are closed; milestone `3.1.0` (empty) is closed; a `3.1.1` milestone containing those four issues is closed.
+- [ ] Memory file `release-3-1-1-execution-state.md` records completion with the PR numbers.
+
+**Verify:** `gh issue list --repo trungdong/prov --state closed --search "130 337 338 340"` lists all four; `gh pr list -R conda-forge/prov-feedstock --state merged --limit 3` shows the 3.1.1 bump.
+
+**Steps:**
+
+- [ ] **Step 1: DOI badge**
+
+```bash
+REPO_ID=$(gh api repos/trungdong/prov --jq .id)
+git checkout main && git pull && git checkout -b docs/doi-badge
+sed -i '' "s#^\[\!\[Supported Python version\]#[![DOI](https://zenodo.org/badge/${REPO_ID}.svg)](https://zenodo.org/badge/latestdoi/${REPO_ID})\n[![Supported Python version]#" README.md
+sed -n 1,12p README.md
+```
+
+If `sed` leaves a literal `\n`, insert the badge line by hand directly above the `Supported Python version` badge. Confirm the badge resolves: `curl -sI "https://zenodo.org/badge/${REPO_ID}.svg" | head -1` → 200 or a 302 to the DOI badge. Then:
+
+```bash
+git add README.md
+git commit -m "docs: add Zenodo DOI badge"
+git push -u origin docs/doi-badge
+gh pr create --base main --title "docs: add Zenodo DOI badge" --body "Adds the Zenodo badge minted by the 3.1.1 release to the README badge row, using the repository-id form that always resolves to the latest DOI."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 2: conda-forge**
+
+```bash
+gh pr list -R conda-forge/prov-feedstock --state open
+```
+
+Wait for the autotick-bot's 3.1.1 PR (a few hours). Review that run dependencies still mirror the four extras, that the sha256 matches `curl -sL https://pypi.org/pypi/prov/3.1.1/json | python3 -c "import json,sys; print([u['digests']['sha256'] for u in json.load(sys.stdin)['urls'] if u['packagetype']=='sdist'][0])"`, then merge. If `gh pr merge` reports "base branch policy prohibits the merge", run `gh auth refresh -h github.com -s workflow` and retry (`docs/releasing.md` §6).
+
+- [ ] **Step 3: Milestones and issues**
+
+```bash
+gh api -X PATCH repos/trungdong/prov/milestones/5 -f state=closed          # 3.1.0, empty
+gh api -X POST repos/trungdong/prov/milestones -f title=3.1.1 -f state=closed -f description="Point release, shipped $(date +%Y-%m-%d)"
+for n in 130 337 338 340; do gh issue edit $n --repo trungdong/prov --milestone 3.1.1; gh issue view $n --repo trungdong/prov --json state --jq .state; done
+```
+
+Every issue must print `CLOSED` (the PR bodies' `Closes #N` closed them on merge); close any that did not with `gh issue close $n --comment "Fixed in 3.1.1."`.
+
+- [ ] **Step 4: Confirm and record**
+
+Confirm <https://pypi.org/project/prov/> and <https://anaconda.org/conda-forge/prov> both show 3.1.1, and that <https://zenodo.org/search?q=prov%20Huynh> shows the record. Update the memory file `release-3-1-1-execution-state.md` (status COMPLETE, date, PR numbers, DOI, any new gotcha) and add any release-runbook gotcha to `docs/releasing.md` in a follow-up PR rather than to this plan.
+
+The announcement (Discussions post, LinkedIn, downstream pin bumps) is tracked outside this plan.
+
+---
+
+## Self-review
+
+**Spec coverage.** §2.1→T1, §2.2→T3, §2.3→T4, §2.4→T5, §2.5→T6, §2.6→T2, §2.7→T7, §2.8→T8, §2.9→T9, §3.1→T10, §3.2→T11, §3.3→T12, §3.4→T13, §3.5→T14 (labels, CoC, templates, CITATION + test, zenodo, licensing, cla removal, no FUNDING.yml), §3.6→T16, §4→T15/T17/T18 (version, HISTORY subsections, ROADMAP row, Zenodo before tag, badge follow-up, releasing.md mechanics), §6→T15 pre-flight and per-task suite counts, T4 byte-identity baseline.
+
+**Placeholders.** None remain; the one draft assertion in T4 was removed. `<run-id>` in T17 and `<repo-id>` in T18 are values read at run time by the preceding command.
+
+**Consistency.** `get_registered_namespaces()` (T3) is the existing `ProvBundle` method used by `test_get_registered_namespaces`; `ProvWarning` (T5) is exported from `prov.model`; `_link_uri`/`_quoted`/`_url_attr`/`_href_attr` (T4) are defined and used only in `prov.dot`; the suite count arithmetic in T15 sums the per-task additions (2+4+3+4+1+2+2+2+2 = 22).

--- a/docs/superpowers/specs/2026-09-10-release-3.1.1-design.md
+++ b/docs/superpowers/specs/2026-09-10-release-3.1.1-design.md
@@ -1,0 +1,267 @@
+# Release 3.1.1: point release design
+
+**Date:** 2026-09-10
+**Status:** Draft for maintainer review
+**Scope:** Bug fixes, hardening, test coverage, documentation and community
+scaffolding. No new features, no API changes, no dependency changes, Python
+floor unchanged at 3.10.
+
+## 1. Purpose
+
+3.1.1 clears the low-risk defects found by the September 2026 audit, hardens the
+two rendering paths against hostile documents, adds the contributor
+scaffolding the repository lacks, and gives the 3.x line the "what's new" page
+that the (still unmade) 3.0 announcement needs. Tagging it also mints the
+project's first Zenodo DOI.
+
+Everything here is a fix, a test, a document or a repository file. Anything
+that changes the public API, adds a feature, or alters decode semantics waits
+for 3.2.0.
+
+## 2. Code changes
+
+Each item names the current behaviour, the change, and the tests that pin it.
+Every code item gets a changelog line.
+
+### 2.1 `ProvBundle.__eq__` fast path
+
+`ProvBundle.__eq__` (`src/prov/model/bundle.py:553`) builds two record sets
+and then compares them with a nested loop that removes matches one at a time,
+which is O(n²) in the record count. The loop exists because
+`ProvRecord.__eq__` (`records.py:932`) is looser than `ProvRecord.__hash__`
+(`records.py:609`): a record without an identifier compares equal to one with
+an identifier when type and attributes match, while their hashes differ.
+
+Change. Compare the two sets with `==` first and return `True` when they are
+equal. Only when they differ fall through to the existing loop, which keeps
+the looser semantics for the anonymous-versus-identified case. Equal documents,
+the common case after a round trip, become O(n).
+
+Tests. A test that two documents with the same records added in different
+orders compare equal (exercises the fast path) and the existing equality suite
+for the slow path. No timing assertions.
+
+### 2.2 Deterministic bundle namespace declarations (#337)
+
+`ProvBundle.namespaces` (`bundle.py:346`) wraps the ordered registered
+namespaces in a `set`. Three consumers iterate that set: the PROV-XML
+namespace map (`provxml.py:187`), the PROV-O container binding
+(`provrdf.py:870`), and the bundle copy made by `ProvDocument.unified()`
+(`bundle.py:1754`). Set iteration order follows the hash seed, so a bundle
+with two or more namespaces declares them in a different order between runs,
+and a unified copy registers them in a different order.
+
+Change. The three consumers iterate the bundle's namespace manager's
+registered namespaces directly, in registration order, matching how the
+document level already behaves. `ProvBundle.namespaces` keeps its `set`
+return type; its public signature does not change.
+
+Tests. Serialize a bundle carrying five namespaces to PROV-XML and PROV-O and
+assert the declaration order equals registration order; unify a document with
+such a bundle and assert the copy's registered order. Five namespaces make a
+chance pass under the old behaviour one in 120.
+
+Byte output changes for affected PROV-XML documents. This is the fix the
+issue asks for and is recorded in the changelog as such.
+
+### 2.3 `prov.dot` link and label hardening
+
+`prov.dot` writes identifier URIs verbatim into Graphviz link attributes at
+four sites: the annotation row `href` (`dot.py:256`), the bundle cluster
+`URL` (`dot.py:280`), the element node `URL` (`dot.py:316`) and the generic
+node `URL` (`dot.py:337`). Annotation rows are HTML-escaped, but the
+`use_labels` node label (`dot.py:300` to `310`) interpolates the label and the
+identifier into an HTML-like label without escaping, and the plain label
+path wraps the identifier in double quotes without escaping quotes. A PROV
+identifier is document content, and rendered SVG makes these links live.
+
+Change. A private `_link_uri(uri)` returns the URI when its scheme is one of
+`http`, `https`, `mailto` or `urn`, or when it is scheme-less, and `None`
+otherwise; the four sites omit the attribute on `None`. HTML-like labels pass
+label and identifier text through `html.escape`; plain quoted labels escape
+backslash and double quote. Ordinary documents render byte-identically because
+real identifiers use `http(s)`.
+
+Tests. A `javascript:` identifier yields a node with no `URL` and an
+annotation row with no `href`; a label containing `<`, `&` and `"` renders
+escaped; existing DOT fixtures are unchanged.
+
+Changelog entry under a "Security" heading.
+
+### 2.4 Observable drops in `prov.graph`
+
+`prov_to_graph` (`graph.py:112` to `122`) skips a relation silently in two
+cases: when either of the first two formal attributes is unset, and when the
+attribute name is not a key of `INFERRED_ELEMENT_CLASS`. Users see edges
+missing from the graph with no signal.
+
+The second path is reachable: `prov:influencee` and `prov:influencer` are
+not keys of `INFERRED_ELEMENT_CLASS`, so a `wasInfluencedBy` whose endpoint is
+not declared as an element in the document is dropped. Every other relation
+class's first two formal attributes are keys.
+
+Change. Both paths issue `warnings.warn(..., ProvWarning)` naming the relation
+and the reason, so callers can filter by category. No type is inferred for an
+undeclared influence endpoint, since the element kind is genuinely unknown.
+The docstring gains a "Warns" section.
+
+Tests. A relation with an unset endpoint triggers exactly one `ProvWarning`
+and produces no edge; a `wasInfluencedBy` with an undeclared endpoint triggers
+one and produces no edge; a document with neither triggers none.
+
+### 2.5 PROV-O decoder over-reports unconverted attributes
+
+`decode_container` warns when `state.other_attributes` is truthy
+(`provrdf.py:1336`). The dict holds one key per subject with a list of
+leftover attributes, so it is truthy even when every list is empty. In the
+test run every instance of this warning reports empty lists, for example
+`{'http://example.org/e1': []}`.
+
+Change. Warn only when at least one list is non-empty, and report only the
+non-empty entries.
+
+The remaining volume of the test run's warnings is rdflib's own deprecation
+notices from its TriG serializer (`Dataset.contexts`, `Dataset.default_context`),
+raised inside rdflib and outside this project's control; nothing changes for
+those.
+
+Tests. Decoding a document that round-trips cleanly emits no warning from
+`prov`; decoding one with an unmapped predicate still warns and names it.
+
+### 2.6 Namespace lookup by URI
+
+`NamespaceManager.get_namespace(uri)` (`namespaces.py:65`) scans every
+registered namespace. The fallback in `_resolve_prefixed_string`
+(`namespaces.py:257`) scans too, but only for unregistered prefixes and by
+prefix match, so it stays.
+
+Change. Maintain a URI-to-namespace index alongside the prefix dict, updated
+wherever namespaces are added, replaced or renamed, and read it in
+`get_namespace`.
+
+Tests. Existing namespace tests plus a case covering lookup after a prefix
+rename and after re-registration of the same URI under another prefix.
+
+### 2.7 Close #130 with a regression test
+
+Attribute values are stored insertion-ordered since 3.0, so the
+non-determinism reported in #130 no longer occurs; a run of the issue's script
+under three hash seeds gives identical output. Add a test asserting PROV-N and
+PROV-JSON attribute order follows insertion order, document the guarantee in
+the PROV-N how-to, and close the issue.
+
+### 2.8 `force_types` coverage (#338)
+
+Add tests in `test_xml.py` parametrised over `force_types=True` and `False`,
+independent of the disabled round-trip scaffold, asserting the presence and
+absence of `xsi:type` on string, integer and datetime values.
+
+### 2.9 Own-warnings guard (#340)
+
+Add a non-blocking CI job that runs the suite with the ini-style
+`filterwarnings` that errors on `DeprecationWarning` and `FutureWarning`
+raised from `prov` submodules, separate from the matrix, with a comment
+explaining why the `-W` command-line form is not used. Do not add it to
+`pyproject.toml`.
+
+## 3. Documentation and repository changes
+
+### 3.1 Support-policy wording
+
+`README.md:41` to `43` and `SECURITY.md:13` to `19` say 2.x receives
+back-ported fixes "until 2.6.0". The back-port programme closed at 2.5.3 with
+no 2.6.0. Reword both to "security fixes only", and state that the last
+back-port release was 2.5.3.
+
+### 3.2 "What's new in 3" page
+
+`docs/whats-new-3.md`, listed under the Project toctree, summarising the 3.x
+line for someone still on 2.x: zero unconditional dependencies, the
+conformance audit and matrix, PROV-CONSTRAINTS unification, PROV-JSONLD, the
+upgrade guide, the 2.x policy, the roadmap, and a direct request to unpin
+2.1.1 and 1.5.1. The README roadmap paragraph links to it. It is the page the
+announcement points at.
+
+### 3.3 Architecture overview
+
+`docs/explanation/architecture.md`, listed under Explanation, describing the
+packages and their dependencies (`identifier`, `constants`, `model`,
+`serializers`, `graph`, `dot`, `scripts`), the record and bundle object model,
+the serializer registry and `read()` auto-detection, the extras, and where
+tests live. `CLAUDE.md` keeps its agent-specific rules and points at this page
+for the overview.
+
+### 3.4 Planning files leave `docs/`
+
+`docs/superpowers/` and `docs/test-gap-checklist.md` move to a top-level
+`planning/` directory (`planning/specs/`, `planning/plans/`,
+`planning/test-gap-checklist.md`) with `git mv`. Links in `ROADMAP.md` (two),
+`CLAUDE.md` (two) and `docs/upgrading-3.0.md` (one, which also still points at
+the `master` branch) are updated, `docs/conf.py`'s exclusion list drops the
+`superpowers` entry, and `CLAUDE.md` states that design specs and plans live
+under `planning/` so tooling writes new ones there. `docs/releasing.md` and
+`docs/dependencies.md` stay where they are.
+
+### 3.5 Community scaffolding
+
+- `CODE_OF_CONDUCT.md`: Contributor Covenant 2.1, contact address the
+  maintainer email in `pyproject.toml`.
+- `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml` and
+  `config.yml` (the last linking questions to Discussions and vulnerabilities
+  to `SECURITY.md`); `.github/PULL_REQUEST_TEMPLATE.md` with the checklist
+  from CONTRIBUTING's pull-request guidelines.
+- Labels `good first issue` and `help wanted` created on the repository.
+- `CITATION.cff` with the maintainer as author (ORCID
+  0000-0003-4937-2473), the repository URL, licence, and `version` matching
+  `prov.__version__`; a test asserts the two agree so releases cannot drift.
+- `.zenodo.json` with the same creator and licence metadata.
+- `CONTRIBUTING.md` gains a licensing paragraph stating that contributions are
+  accepted under the project's MIT licence on the inbound-equals-outbound
+  basis; the `cla/` directory and its two signed agreements are removed.
+- No `FUNDING.yml`; the maintainer has no GitHub Sponsors listing.
+
+### 3.6 Discussions
+
+GitHub Discussions is enabled at release time so the announcement post has a
+home and the issue-template config can link to it. This is a repository
+setting change made by the maintainer, not a file.
+
+## 4. Release
+
+- Version 3.1.1 in `src/prov/__init__.py`; `HISTORY.md` entry with Fixes,
+  Security, Tests, Documentation and Project subsections; a 3.1.1 row in
+  `ROADMAP.md`'s release table.
+- Before tagging, the maintainer enables the Zenodo GitHub integration for
+  the repository so the tag mints a DOI; the DOI badge is added to the README
+  in a follow-up commit once minted.
+- Release mechanics follow `docs/releasing.md` unchanged.
+- The announcement itself (Discussions post, What's new page link, LinkedIn,
+  downstream pin bumps) follows the release and is tracked outside this spec.
+
+## 5. Out of scope
+
+- #341 (PROV-O local-part colon round trip): decode semantics, 3.2.0.
+- #260, #261, #131: features.
+- Python 3.10 drop: first release after 2026-10-31 under the support policy.
+- Performance work beyond 2.1 and 2.6: 3.2.0, gated by the benchmark suite.
+- `FUNDING.yml` and DCO tooling.
+- `prov_to_graph`'s handling of bundle contents: a behaviour decision for
+  3.3.0.
+
+## 6. Verification
+
+- Full interpreter matrix, `mypy --strict`, `ruff check` and `ruff format
+  --check`, per `docs/releasing.md` pre-flight.
+- Coverage stays at or above the 97% gate.
+- Pass and skip counts change only by the tests this release adds; any new
+  skip or xfail is a regression.
+- DOT and serializer fixtures are byte-identical except for the #337 cases,
+  which the new tests cover.
+
+## 7. Decisions confirmed in review
+
+1. Inbound-equals-outbound licensing wording rather than DCO sign-off with CI
+   enforcement.
+2. `planning/` as the directory name for design specs and plans.
+3. The link-scheme allowlist: `http`, `https`, `mailto`, `urn`, scheme-less.
+4. `docs/whats-new-3.md` as the page name and its placement under Project.


### PR DESCRIPTION
Design spec and implementation plan for the 3.1.1 point release. The four section-7 decisions are approved as written. The plan (docs/superpowers/plans/2026-09-10-release-3.1.1.md, with its task file) maps the spec onto twelve PRs plus the release operations; Task 13 of the plan moves both files to planning/.