### PR TITLE
perf: linear bundle equality and indexed namespace lookup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
 - `ProvBundle.__eq__` (and therefore `ProvDocument.__eq__`) compares equal
   bundles in linear time by testing record-set equality first, falling back
   to the record-by-record search only when the sets differ
+- `NamespaceManager.get_namespace()` looks a URI up by index instead of
+  scanning every known namespace; where a URI is both registered and the
+  default namespace, the registered one is now returned consistently
 
 ### Security
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,21 @@
 # History
 
+## 3.1.1 (unreleased)
+
+### Fixes
+
+- `ProvBundle.__eq__` (and therefore `ProvDocument.__eq__`) compares equal
+  bundles in linear time by testing record-set equality first, falling back
+  to the record-by-record search only when the sets differ
+
+### Security
+
+### Tests
+
+### Documentation
+
+### Project
+
 ## 3.1.0 (2026-08-07)
 
 - New PROV-JSONLD serializer and deserializer, selected with `format="jsonld"`

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -557,7 +557,13 @@ class ProvBundle:
         this_records = set(self.get_records())
         if len(this_records) != len(other_records):
             return False
-        #  check if all records for equality
+        if this_records == other_records:
+            # The common case (e.g. after a round trip): every record has a
+            # hash-equal counterpart, settled in O(n).
+            return True
+        # ProvRecord.__eq__ is looser than ProvRecord.__hash__ (a record
+        # without an identifier equals one with, given the same type and
+        # attributes), so records that hash differently may still match.
         for record_a in this_records:
             #  Manually look for the record
             found = False

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -10,6 +10,7 @@ from prov.identifier import Identifier, Namespace, QualifiedName
 from prov.model.records import NSCollection, QualifiedNameCandidate
 
 DEFAULT_NAMESPACES = {"prov": PROV, "xsd": XSD, "xsi": XSI}
+_DEFAULT_NAMESPACES_BY_URI = {ns.uri: ns for ns in DEFAULT_NAMESPACES.values()}
 
 
 class NamespaceManager(dict[str, Namespace]):
@@ -55,6 +56,10 @@ class NamespaceManager(dict[str, Namespace]):
     def get_namespace(self, uri: str) -> Namespace | None:
         """Return the known namespace with the given URI.
 
+        Lookup is by index, not by scan. When more than one known namespace
+        has the URI, the built-in ``prov``/``xsd``/``xsi`` namespaces win,
+        then the explicitly registered namespace, then the default namespace.
+
         Args:
             uri: The namespace URI to look up.
 
@@ -62,9 +67,11 @@ class NamespaceManager(dict[str, Namespace]):
             The matching :class:`~prov.identifier.Namespace`, or ``None`` if no
             known namespace has that URI.
         """
-        for namespace in self.values():
-            if uri == namespace._uri:
-                return namespace
+        namespace = _DEFAULT_NAMESPACES_BY_URI.get(uri) or self._uri_map.get(uri)
+        if namespace is not None:
+            return namespace
+        if self._default is not None and self._default.uri == uri:
+            return self._default
         return None
 
     def get_registered_namespaces(self) -> Iterable[Namespace]:

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -11,7 +11,7 @@ import shutil
 
 import pytest
 
-from prov.constants import PROV_INTERNATIONALIZEDSTRING, XSD
+from prov.constants import PROV, PROV_INTERNATIONALIZEDSTRING, XSD
 from prov.identifier import Namespace
 from prov.model import (
     Literal,
@@ -550,6 +550,36 @@ def test_get_namespace_miss_and_hit():
     ns = Namespace("ex", "http://example.org/")
     nm.add_namespace(ns)
     assert nm.get_namespace("http://example.org/") == ns
+
+
+def test_get_namespace_finds_built_in_and_default_namespaces():
+    nm = NamespaceManager(default="http://default.example.org/")
+    assert nm.get_namespace(PROV.uri) == PROV
+    assert nm.get_namespace("http://default.example.org/") is nm.get_default_namespace()
+
+
+def test_get_namespace_after_prefix_rename_returns_renamed_namespace():
+    nm = NamespaceManager()
+    nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+    renamed = nm.add_namespace(Namespace("ex", "http://b.example.org/"))
+    assert renamed.prefix == "ex_1"
+    assert nm.get_namespace("http://b.example.org/") is renamed
+    assert nm.get_namespace("http://a.example.org/").prefix == "ex"
+
+
+def test_get_namespace_after_reregistering_uri_under_other_prefix():
+    nm = NamespaceManager()
+    first = nm.add_namespace(Namespace("ex", "http://a.example.org/"))
+    again = nm.add_namespace(Namespace("other", "http://a.example.org/"))
+    assert again is first
+    assert "other" not in nm
+    assert nm.get_namespace("http://a.example.org/") is first
+
+
+def test_get_namespace_prefers_registered_over_default_for_same_uri():
+    nm = NamespaceManager(default="http://shared.example.org/")
+    registered = nm.add_namespace(Namespace("sh", "http://shared.example.org/"))
+    assert nm.get_namespace("http://shared.example.org/") is registered
 
 
 def test_add_namespace_reuses_renamed_namespace_from_cache():

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -719,6 +719,43 @@ def test_not_equal_when_matching_bundle_content_differs():
     assert d1 != d2
 
 
+# ProvBundle.__eq__: the set-equality fast path and the slow path it
+# falls back to when ProvRecord.__eq__ is looser than ProvRecord.__hash__.
+
+
+def test_equal_when_same_records_added_in_different_order():
+    d1 = ProvDocument()
+    d1.set_default_namespace("http://example.org/")
+    d1.entity("e1")
+    d1.activity("a1")
+    d1.wasGeneratedBy("e1", "a1")
+
+    d2 = ProvDocument()
+    d2.set_default_namespace("http://example.org/")
+    d2.wasGeneratedBy("e1", "a1")
+    d2.activity("a1")
+    d2.entity("e1")
+
+    assert d1 == d2
+    assert d2 == d1
+
+
+def test_anonymous_relation_still_equals_identified_relation():
+    # ProvRecord.__eq__ skips the identifier check when *this* record has no
+    # identifier, while __hash__ includes it; the two records hash
+    # differently, so set equality fails and __eq__ must fall through to the
+    # record-by-record loop to find the match.
+    d1 = ProvDocument()
+    d1.set_default_namespace("http://example.org/")
+    d1.wasGeneratedBy("e1", "a1")
+
+    d2 = ProvDocument()
+    d2.set_default_namespace("http://example.org/")
+    d2.wasGeneratedBy("e1", "a1", identifier="g1")
+
+    assert d1 == d2
+
+
 def test_unified_with_no_bundles():
     doc = ProvDocument()
     doc.add_namespace("ex", "http://example.org/")


### PR DESCRIPTION
Two small performance fixes from the September 2026 audit, per the 3.1.1 design spec sections 2.1 and 2.6.

ProvBundle.__eq__ tests record-set equality before its record-by-record search, so equal documents (the common case after a round trip) compare in linear time; the search still runs when the sets differ, preserving the anonymous-versus-identified leniency of ProvRecord.__eq__.

NamespaceManager.get_namespace() reads the existing URI index instead of scanning every known namespace, with documented precedence (built-in, then registered, then default).

No public signature changes. Suite: 1652 passed, 26 skipped.