### PR TITLE
fix: declare bundle namespaces in registration order

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,12 @@
 - `NamespaceManager.get_namespace()` looks a URI up by index instead of
   scanning every known namespace; where a URI is both registered and the
   default namespace, the registered one is now returned consistently
+- PROV-XML and PROV-O serializers declare a bundle's namespaces in
+  registration order instead of hash-seed-dependent set order, and
+  `ProvDocument.add_bundle()` registers a copied document's namespaces in the
+  same order; PROV-XML byte output changes for bundles carrying two or more
+  of their own namespaces
+  ([#337](https://github.com/trungdong/prov/issues/337))
 
 ### Security
 

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -1757,7 +1757,7 @@ class ProvDocument(ProvBundle):
                     "Cannot add a document with nested bundles as a bundle."
                 )
             # Make it a new ProvBundle
-            new_bundle = ProvBundle(namespaces=bundle.namespaces)
+            new_bundle = ProvBundle(namespaces=list(bundle.get_registered_namespaces()))
             new_bundle.update(bundle)
             bundle = new_bundle
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -867,17 +867,17 @@ class ProvRDFSerializer(Serializer):
             nm = container.namespace_manager
             nm.bind("prov", PROV.uri)
 
-        for namespace in bundle.namespaces:
+        for namespace in bundle.get_registered_namespaces():
             container.bind(namespace.prefix, namespace.uri)
-        # #96: `bundle.namespaces` excludes the bundle's default namespace
-        # (a separate concept from the core prov/xsd/xsi namespaces that
-        # `get_registered_namespaces` excludes -- `set_default_namespace`
-        # never writes to the registered-namespace dict), so it needs its
-        # own bind() call here, under the empty prefix, for its terms to
-        # render as `:local` rather than a full IRI. Note this widens the
-        # surface of #294: a default- or bundle-namespace term whose local
-        # part ends in a character rdflib cannot abbreviate is now bound
-        # but still emitted as a full IRI, and fails to decode.
+        # #96: `get_registered_namespaces()` excludes the bundle's default
+        # namespace (a separate concept from the core prov/xsd/xsi
+        # namespaces that it also excludes -- `set_default_namespace` never
+        # writes to the registered-namespace dict), so it needs its own
+        # bind() call here, under the empty prefix, for its terms to render
+        # as `:local` rather than a full IRI. Note this widens the surface
+        # of #294: a default- or bundle-namespace term whose local part ends
+        # in a character rdflib cannot abbreviate is now bound but still
+        # emitted as a full IRI, and fails to decode.
         default_namespace = bundle.get_default_namespace()
         if default_namespace is not None:
             container.bind("", default_namespace.uri)

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -184,7 +184,7 @@ class ProvXMLSerializer(Serializer):
         if self.document._namespaces._default:  # type: ignore[union-attr]
             # TODO: Check if the below works as expected.
             nsmap[None] = self.document._namespaces._default.uri  # type: ignore[union-attr, index]
-        for namespace in bundle.namespaces:
+        for namespace in bundle.get_registered_namespaces():
             if namespace not in nsmap:
                 nsmap[namespace.prefix] = namespace.uri
 

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -828,3 +828,20 @@ def test_plot_unknown_format_raises_value_error(plot_doc, tmp_path):
     path = tmp_path / "out.not-a-real-format"
     with pytest.raises(ValueError):
         plot_doc.plot(filename=str(path))
+
+
+def test_add_bundle_from_document_keeps_namespace_order():
+    # #337: ProvDocument.add_bundle() copies a document's namespaces into
+    # the new bundle in registration order.
+    source = ProvDocument()
+    prefixes = [f"ex{i}" for i in range(1, 6)]
+    for i, prefix in enumerate(prefixes, start=1):
+        source.add_namespace(prefix, f"http://example.org/ns{i}/")
+        source.entity(f"{prefix}:e{i}")
+
+    target = ProvDocument()
+    target.set_default_namespace("http://example.org/")
+    target.add_bundle(source, identifier="b1")
+
+    bundle = next(iter(target.bundles))
+    assert [ns.prefix for ns in bundle.get_registered_namespaces()] == prefixes

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -1190,3 +1190,29 @@ def test_resolve_iri_skips_bound_namespace_equal_to_the_iri_itself():
     assert identifier.namespace.uri == "http://example.org/"
     assert identifier.namespace.prefix == "top"
     assert identifier.localpart == "thing"
+
+
+BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
+
+
+def test_bundle_namespace_order_follows_registration_in_rdf():
+    # #337: bundle namespaces are bound on the bundle graph in registration
+    # order. rdflib sorts prefixes when it serializes, so the bound order on
+    # the graph is the observable.
+    document = ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    bundle = document.bundle("b1")
+    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
+        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
+        bundle.entity(f"{prefix}:e{i}")
+
+    serializer = ProvRDFSerializer(document)
+    graph = serializer.encode_container(
+        bundle, identifier=URIRef("http://example.org/b1")
+    )
+    bound = [
+        prefix
+        for prefix, _ in graph.namespace_manager.namespaces()
+        if prefix in BUNDLE_NAMESPACE_ORDER
+    ]
+    assert bound == BUNDLE_NAMESPACE_ORDER

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -3,6 +3,7 @@ import difflib
 import inspect
 import io
 import os
+import re
 import warnings
 
 import pytest
@@ -835,3 +836,26 @@ def _perform_round_trip(filename, force_types=False):
     with io.BytesIO() as new_xml:
         document.serialize(format="xml", destination=new_xml, force_types=force_types)
         compare_xml(filename, new_xml)
+
+
+BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
+
+
+def _document_with_ordered_bundle_namespaces():
+    document = prov.ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    bundle = document.bundle("b1")
+    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
+        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
+        bundle.entity(f"{prefix}:e{i}")
+    return document
+
+
+def test_bundle_namespace_order_follows_registration_in_xml():
+    # #337: five namespaces give a one-in-120 chance of the old
+    # set-iteration order matching by accident.
+    xml_bytes = (
+        _document_with_ordered_bundle_namespaces().serialize(format="xml").encode()
+    )
+    declared = re.findall(rb"xmlns:(ex\d)=", xml_bytes)
+    assert [p.decode() for p in declared] == BUNDLE_NAMESPACE_ORDER


### PR DESCRIPTION
Closes #337. Per the 3.1.1 design spec section 2.2.

The three consumers of ProvBundle.namespaces (the PROV-XML namespace map, the PROV-O container binding, and the bundle copy ProvDocument.add_bundle() makes from a document) now iterate get_registered_namespaces() in registration order instead of the set, so declaration order no longer depends on PYTHONHASHSEED. ProvBundle.namespaces itself is unchanged.

Byte output changes for PROV-XML bundles carrying two or more of their own namespaces, as the issue asks. Three new tests with five namespaces each, verified under PYTHONHASHSEED 1 to 6 (all failed before the fix, all pass after). Suite: 1655 passed, 26 skipped.