### PR TITLE
fix: warn when prov_to_graph drops a relation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,10 @@
   same order; PROV-XML byte output changes for bundles carrying two or more
   of their own namespaces
   ([#337](https://github.com/trungdong/prov/issues/337))
+- `prov.graph.prov_to_graph()` warns with `prov.model.ProvWarning` when it
+  drops a relation (an unset endpoint, or an undeclared endpoint whose type
+  cannot be inferred, which only a `wasInfluencedBy` can trigger) instead of
+  skipping it silently
 
 ### Security
 

--- a/src/prov/graph.py
+++ b/src/prov/graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # defer eval: MultiDiGraph isn't subscriptable
 
+import warnings
 from typing import Any
 
 try:
@@ -39,6 +40,7 @@ from prov.model import (
     ProvEntity,
     ProvRecord,
     ProvRelation,
+    ProvWarning,
 )
 
 __author__ = "Trung Dong Huynh"
@@ -85,7 +87,7 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
     already added as a node, a bare node is created for it using
     :data:`INFERRED_ELEMENT_CLASS`. Relations whose first two formal
     attributes are not both populated, or whose attribute type is not in
-    :data:`INFERRED_ELEMENT_CLASS`, are silently skipped.
+    :data:`INFERRED_ELEMENT_CLASS`, are skipped with a :class:`~prov.model.ProvWarning`.
 
     Args:
         prov_document: The :class:`~prov.model.ProvDocument` instance to
@@ -98,6 +100,12 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
     Raises:
         ProvUnificationError: Propagated, unhandled, from
             :meth:`~prov.model.ProvBundle.unified`.
+
+    Warns:
+        ProvWarning: For each relation skipped because one of its first two
+            formal attributes is unset, or because an undeclared endpoint's
+            element type cannot be inferred (its attribute has no
+            :data:`INFERRED_ELEMENT_CLASS` entry).
     """
     g: nx.MultiDiGraph[Any] = nx.MultiDiGraph()
     unified = prov_document.unified()
@@ -111,16 +119,31 @@ def prov_to_graph(prov_document: ProvDocument) -> nx.MultiDiGraph[Any]:
         attr_pair_1, attr_pair_2 = relation.formal_attributes[:2]
         # only need the QualifiedName (i.e. the value of the attribute)
         qn1, qn2 = attr_pair_1[1], attr_pair_2[1]
-        if qn1 and qn2:  # only proceed if both ends of the relation exist
-            try:
-                if qn1 not in node_map:
-                    node_map[qn1] = INFERRED_ELEMENT_CLASS[attr_pair_1[0]](None, qn1)
-                if qn2 not in node_map:
-                    node_map[qn2] = INFERRED_ELEMENT_CLASS[attr_pair_2[0]](None, qn2)
-            except KeyError:
-                # Unsupported attribute; cannot infer the type of the element
-                continue  # skipping this relation
-            g.add_edge(node_map[qn1], node_map[qn2], relation=relation)
+        if not (qn1 and qn2):
+            warnings.warn(
+                f"Skipping {relation!r}: both of its first two formal "
+                "attributes must be set to add it as an edge",
+                ProvWarning,
+                stacklevel=2,
+            )
+            continue
+        try:
+            if qn1 not in node_map:
+                node_map[qn1] = INFERRED_ELEMENT_CLASS[attr_pair_1[0]](None, qn1)
+            if qn2 not in node_map:
+                node_map[qn2] = INFERRED_ELEMENT_CLASS[attr_pair_2[0]](None, qn2)
+        except KeyError as exc:
+            # No element class is inferred for this attribute (the
+            # influencee/influencer of a generic influence), so an undeclared
+            # endpoint has no known kind and the relation cannot be drawn.
+            warnings.warn(
+                f"Skipping {relation!r}: endpoint referenced by {exc.args[0]} "
+                "is not declared as an element and its type cannot be inferred",
+                ProvWarning,
+                stacklevel=2,
+            )
+            continue
+        g.add_edge(node_map[qn1], node_map[qn2], relation=relation)
     return g
 
 

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -1,9 +1,11 @@
+import warnings
+
 import pytest
 
 nx = pytest.importorskip("networkx", reason="prov.graph requires the graph extra")
 
 from prov.graph import graph_to_prov, prov_to_graph
-from prov.model import ProvActivity, ProvDocument, ProvEntity
+from prov.model import ProvActivity, ProvDocument, ProvEntity, ProvWarning
 from prov.tests.examples import primer_example, tests
 
 
@@ -35,14 +37,16 @@ def document():
     return d
 
 
-def test_relation_with_missing_end_is_skipped(document):
-    # A generation record with no activity: the "if qn1 and qn2" guard
-    # should skip adding an edge for it since one QualifiedName is None.
+def test_relation_with_missing_end_is_skipped_with_warning(document):
+    # A generation record with no activity: one endpoint is None, so the
+    # relation cannot become an edge. The drop is reported, not silent.
     document.generation(entity="ex:e1", activity=None)
 
-    g = prov_to_graph(document)
+    with pytest.warns(ProvWarning, match="Generation") as record:
+        g = prov_to_graph(document)
 
     assert list(g.edges()) == []
+    assert len(record) == 1
 
 
 def test_relation_endpoints_get_inferred_nodes(document):
@@ -63,21 +67,35 @@ def test_relation_endpoints_get_inferred_nodes(document):
     assert len(g.edges()) == 1
 
 
-def test_relation_with_uninferrable_endpoint_type_is_skipped(document):
-    # ProvInfluence's formal attributes (influencee/influencer) are not
-    # keys of INFERRED_ELEMENT_CLASS, so a generic influence relation
-    # between two undeclared identifiers hits the "except KeyError:
-    # continue" branch and is dropped, while later relations are still
-    # processed normally.
+def test_relation_with_uninferrable_endpoint_type_is_skipped_with_warning(document):
+    # prov:influencee/prov:influencer are the only first-two formal
+    # attributes with no INFERRED_ELEMENT_CLASS entry, so an influence
+    # between undeclared identifiers cannot get placeholder nodes. It is
+    # reported and dropped; later relations are still processed.
     document.influence("ex:inf1", "ex:inf2")
     document.wasGeneratedBy("ex:e2", "ex:a2")
 
-    g = prov_to_graph(document)
+    with pytest.warns(ProvWarning, match="Influence") as record:
+        g = prov_to_graph(document)
 
+    assert len(record) == 1
     assert len(g.nodes()) == 2
     assert len(g.edges()) == 1
     (_, _, edge_data) = next(iter(g.edges(data=True)))
     assert edge_data["relation"].get_type().localpart == "Generation"
+
+
+def test_complete_document_emits_no_warning(document):
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.wasGeneratedBy("ex:e1", "ex:a1")
+    document.influence("ex:e1", "ex:a1")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ProvWarning)
+        g = prov_to_graph(document)
+
+    assert len(g.edges()) == 2
 
 
 def test_ignores_non_record_and_bundle_less_nodes():


### PR DESCRIPTION
Per the 3.1.1 design spec section 2.4.

Both silent skip paths in prov_to_graph() now issue a ProvWarning naming the relation and the reason, so callers can filter by category. No type is inferred for an undeclared influence endpoint since its kind is unknown. The docstring gains a Warns section. Suite: 1660 passed, 26 skipped.