### PR TITLE
fix: warn about unconverted PROV-O attributes only when some remain

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,9 @@
   drops a relation (an unset endpoint, or an undeclared endpoint whose type
   cannot be inferred, which only a `wasInfluencedBy` can trigger) instead of
   skipping it silently
+- The PROV-O deserializer no longer warns "attributes were not converted"
+  for documents that decode cleanly; the warning fires only when a subject
+  is left with unconverted attributes and names only those subjects
 
 ### Security
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1334,10 +1334,14 @@ class ProvRDFSerializer(Serializer):
         self._decode_triples(graph, bundle, state, relation_mapper, predicate_mapper)
         self._emit_decoded_records(bundle, state)
 
-        if state.other_attributes:
+        # Every subject gets a (possibly empty) entry while decoding; only
+        # entries still holding attributes are unconverted.
+        unconverted = {
+            subj: attrs for subj, attrs in state.other_attributes.items() if attrs
+        }
+        if unconverted:
             warnings.warn(
-                "The following attributes were not converted: "
-                + str(state.other_attributes),
+                "The following attributes were not converted: " + str(unconverted),
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -10,6 +10,7 @@ import datetime
 import logging
 import os
 import struct
+import warnings
 from glob import glob
 from io import BytesIO, StringIO
 
@@ -1216,3 +1217,43 @@ def test_bundle_namespace_order_follows_registration_in_rdf():
         if prefix in BUNDLE_NAMESPACE_ORDER
     ]
     assert bound == BUNDLE_NAMESPACE_ORDER
+
+
+NOT_CONVERTED = "The following attributes were not converted"
+
+
+def test_clean_round_trip_emits_no_not_converted_warning():
+    document = ProvDocument()
+    document.set_default_namespace("http://example.org/")
+    document.entity("e1", other_attributes={"prov:label": "an entity"})
+    document.activity("a1")
+    document.wasGeneratedBy("e1", "a1")
+    document.wasAttributedTo("e1", "ag1")
+    rdf_text = document.serialize(format="rdf", rdf_format="trig")
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=NOT_CONVERTED)
+        reloaded = ProvDocument.deserialize(
+            content=rdf_text, format="rdf", rdf_format="trig"
+        )
+
+    assert reloaded == document
+
+
+def test_unmapped_subject_still_warns_and_is_named():
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    ex:e1 a prov:Entity .
+    ex:orphan a ex:Custom .
+    """
+
+    with pytest.warns(UserWarning, match=NOT_CONVERTED) as record:
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+    # Filter to UserWarnings only (rdflib may emit DeprecationWarnings)
+    user_warnings = [r for r in record if issubclass(r.category, UserWarning)]
+    assert len(user_warnings) == 1
+    message = str(user_warnings[0].message)
+    assert "http://example.org/orphan" in message
+    assert "http://example.org/e1" not in message


### PR DESCRIPTION
Per the 3.1.1 design spec section 2.5.

decode_container() keyed one entry per subject, so the dict was truthy even when every list was empty; every such warning in the test run reported empty lists. It now warns only when at least one list is non-empty and reports only those entries. The remaining test-run warnings are rdflib's own TriG deprecation notices, outside this project's control. Two new tests. Suite: 1662 passed, 26 skipped.