### PR TITLE
ci: add non-blocking own-warnings guard

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,6 +105,36 @@ jobs:
       - name: Degradation tests
         run: uv run --no-sync pytest src/prov/tests/test_minimal_install.py -v
 
+  own-warnings:
+    # Non-blocking guard (#340): prov must raise no DeprecationWarning or
+    # FutureWarning of its own. It runs apart from the matrix so a failure
+    # names exactly one cause, and rdflib's deprecation notices (attributed
+    # to rdflib's own modules) stay out of scope.
+    #
+    # The ini-style filterwarnings form is deliberate. pytest's command-line
+    # `-W error::DeprecationWarning:prov` escapes and anchors the module
+    # field, so it matches only warnings raised in prov/__init__.py and is a
+    # silent no-op for every submodule. The ini-style path treats the module
+    # field as a regular expression, so `prov` matches every submodule. It
+    # is not added to pyproject.toml because rdflib's warning surface is not
+    # a stability contract and must not redden every contributor's run.
+    name: own-warnings guard (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          python-version: "3.12"
+      - name: Run the suite with prov's own deprecation warnings as errors
+        env:
+          HYPOTHESIS_PROFILE: ci
+        run: |
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
+          uv run --no-sync pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,9 @@ Pytest-native throughout: plain `assert`, module-level `test_*` functions, no
   disabled `_perform_round_trip` glob scaffold is intentional (design doc §4).
 - `strategies.py`/`test_property_roundtrip.py` — Hypothesis round-trip property over
   `ROUNDTRIP_FORMATS`; known-lossy constructs excluded at generation time with issue refs.
+- CI's `own-warnings` job (non-blocking) fails if `prov` raises a `DeprecationWarning` or
+  `FutureWarning` of its own. It uses pytest's ini-style `filterwarnings` because the `-W`
+  command-line form anchors the module field and silently ignores submodules (#340).
 
 New shared record types, attributes, or serializer behaviors go into the shared parametrized
 modules so every target is exercised — not into per-format tests.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,6 +39,10 @@
 
 ### Project
 
+- A non-blocking CI job fails if `prov` raises a `DeprecationWarning` or
+  `FutureWarning` of its own
+  ([#340](https://github.com/trungdong/prov/issues/340))
+
 ## 3.1.0 (2026-08-07)
 
 - New PROV-JSONLD serializer and deserializer, selected with `format="jsonld"`


### PR DESCRIPTION
Closes #340. Per the 3.1.1 design spec section 2.9.

A separate, non-blocking job runs the suite with the ini-style filterwarnings that errors on DeprecationWarning and FutureWarning raised from any prov submodule. The job comment records why the -W command-line form is not used (it anchors the module field and is a silent no-op for submodules). Nothing is added to pyproject.toml. Verified locally: green on the current tree, red with a probe warning inserted in prov.model.bundle (1468 failures), and the -W form stays green with the same probe in place.

Because the job carries continue-on-error, a failure shows as a warning marker in the checks list rather than a red X; it never blocks merge.