### PR TITLE
docs: 2.x policy wording and What's new in 3 page

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,6 +39,9 @@
 
 - `README.md` and `SECURITY.md` now state the 2.x support policy as it
   stands: security fixes only, with 2.5.3 the last back-port release
+- New [What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html)
+  page summarising the 3.x line for projects still on 2.x, linked from the
+  README
 
 ### Project
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,9 @@
 
 ### Documentation
 
+- `README.md` and `SECURITY.md` now state the 2.x support policy as it
+  stands: security fixes only, with 2.5.3 the last back-port release
+
 ### Project
 
 - A non-blocking CI job fails if `prov` raises a `DeprecationWarning` or

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ a free online repository for provenance documents.
 ## Roadmap
 
 3.0.0 has been released, completing the staged modernisation (tooling, type hints,
-tests, documentation, standards conformance). See
+tests, documentation, standards conformance), and 3.1.0 added PROV-JSONLD. See
+[What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html) for a summary
+aimed at projects still on 2.x, and
 [ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) for the plan
 and the 3.x API-stability promise.
 Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/issues).

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/iss
 ## Supported versions
 
 The latest 3.x release receives all fixes. The most recent 2.x release
-receives security fixes, plus bug fixes back-ported from 3.x up to and
-including 2.6.0, after which it reverts to security fixes only; 1.x and
-earlier no longer receive fixes. See
+receives security fixes only; the last release to carry bug fixes
+back-ported from 3.x was 2.5.3. 1.x and earlier no longer receive fixes. See
 [SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md)
 for the full support table and how to report a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,20 +3,18 @@
 ## Supported Versions
 
 The latest `3.x` release is actively maintained and receives all fixes.
-The most recent `2.x` release receives security fixes and, for a bounded
-period, bug fixes back-ported from `3.x`. `1.x` and earlier are no longer
-supported.
+The most recent `2.x` release receives security fixes only. `1.x` and
+earlier are no longer supported.
 
 | Version | Supported          | Fixes                                       |
 | ------- | ------------------ | ------------------------------------------- |
 | 3.x     | :white_check_mark: | All fixes                                   |
-| 2.x     | :white_check_mark: | Security fixes, plus back-ported bug fixes until `2.6.0` |
+| 2.x     | :white_check_mark: | Security fixes only                         |
 | < 2.0   | :x:                | None                                        |
 
-The back-porting window is scope-bounded, not open-ended: `2.x` receives
-back-ported bug fixes up to and including the `2.6.0` release, after which
-it reverts to security fixes only. New features and behaviour-breaking
-corrections are never back-ported — they stay on `3.x`.
+Bug fixes are no longer back-ported to `2.x`: the back-port programme that
+followed the 3.0.0 release closed with `2.5.3`. New features and
+behaviour-breaking corrections were never back-ported and stay on `3.x`.
 
 Both supported lines require Python 3.10 or later: `3.x` from the outset,
 and `2.x` from `2.3.0` onwards. Earlier `2.x` releases support Python 3.9+;

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Prov Python package's documentation
 
    readme
    installation
+   whats-new-3
    upgrading-3.0
    contributing
    authors

--- a/docs/whats-new-3.md
+++ b/docs/whats-new-3.md
@@ -62,8 +62,9 @@ carry bug fixes back-ported from 3.x. See
 
 ## If you pin `prov==2.1.1` or `prov==1.5.1`
 
-Those pins predate the 3.x work. Both versions are outside the support policy, and both
-predate the 2.x line. Lift the pin to `prov>=3` and add the extras your code uses.
+Those pins predate the 3.x work. Both are outside the current support policy. 1.5.1
+predates the 2.x line and 2.1.1 is an early 2.x release from before the modernisation
+work. Lift the pin to `prov>=3` and add the extras your code uses.
 Please open an issue if anything in the upgrade guide does not cover your case.
 
 ## What comes next

--- a/docs/whats-new-3.md
+++ b/docs/whats-new-3.md
@@ -1,0 +1,74 @@
+# What's new in 3
+
+This page is for projects still on `prov` 2.x, or pinned to an older release. It says what
+the 3.x line changed, what it costs to move, and why the pin can go.
+
+## Nothing to install that you do not use
+
+3.0.0 removed every unconditional runtime dependency. `pip install prov` installs the
+library alone; each format or capability that needs a third-party package is an extra:
+
+| Extra | Enables | Pulls in |
+|---|---|---|
+| `rdf` | PROV-O (RDF) serializer and deserializer | `rdflib` |
+| `xml` | PROV-XML serializer and deserializer | `lxml` |
+| `graph` | NetworkX conversion (`prov.graph`) | `networkx` |
+| `dot` | Graphviz export (`prov.dot`) | `pydot`, `networkx` |
+| `plot` | `ProvBundle.plot()` | `matplotlib`, `pydot`, `networkx` |
+
+PROV-JSON, PROV-N and PROV-JSONLD need no extra. See {doc}`installation`.
+
+## Standards conformance, audited
+
+Before 3.0.0 the library was audited against W3C PROV-DM, PROV-CONSTRAINTS, PROV-O,
+PROV-XML and PROV-JSON. The {doc}`reference/conformance` page records, concept by concept,
+how each serializer round-trips it and which gaps are permanent limitations of a format
+rather than defects. The audit's fixes shipped in 3.0.0, each with tests showing the old and
+new behaviour.
+
+## Unification follows PROV-CONSTRAINTS
+
+`unified()` implements the PROV-CONSTRAINTS key constraints: records sharing an identifier
+are merged by term unification of their formal attributes, and records that cannot be
+merged (different concrete values for the same formal attribute, or incompatible types)
+raise `ProvUnificationError` instead of being silently combined. Bundles unify
+independently. See {doc}`explanation/unification-flattening`.
+
+## PROV-JSONLD
+
+3.1.0 added a serializer and deserializer for
+[PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), selected with
+`format="jsonld"`, implemented with the standard library alone. It joins PROV-JSON,
+PROV-XML and PROV-O in the shared round-trip test matrix and in `prov.read()`'s format
+auto-detection. See {doc}`howto/provjsonld`.
+
+## Typed and documented
+
+Every public name carries type hints and the package ships `py.typed`, so type checkers see
+the API. The documentation is organised as tutorial, how-to guides, reference and
+explanation, and the API reference is generated from the docstrings.
+
+## Moving from 2.x
+
+For most code the upgrade needs no change. The two things that can need attention are the
+extras above (install the ones you use) and `unified()` raising on records it previously
+merged silently. {doc}`upgrading-3.0` lists every change, what triggers it, and what to do.
+
+## The 2.x line
+
+The most recent 2.x release receives security fixes only; 2.5.3 was the last release to
+carry bug fixes back-ported from 3.x. See
+[SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md).
+
+## If you pin `prov==2.1.1` or `prov==1.5.1`
+
+Those pins predate the 3.x work. Both versions are outside the support policy, and both
+predate the 2.x line. Lift the pin to `prov>=3` and add the extras your code uses.
+Please open an issue if anything in the upgrade guide does not cover your case.
+
+## What comes next
+
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) has the ordered list
+of planned releases. Next is a PROV-N parser (3.2.0), making the notation readable as well
+as writable. Python 3.10 support ends in the first release after its end of life on
+2026-10-31.


### PR DESCRIPTION
Per the 3.1.1 design spec sections 3.1 and 3.2.

README.md and SECURITY.md drop the "until 2.6.0" wording (the back-port programme closed at 2.5.3, with no 2.6.0) in favour of security fixes only.

docs/whats-new-3.md, under the Project toctree, summarises the 3.x line for someone still on 2.x and asks projects pinned to 2.1.1 or 1.5.1 to lift the pin; the README roadmap paragraph links to it. It is the page the 3.x announcement will point at. Sphinx builds clean and the local Codacy run reports no issues.