### PR TITLE
security: check prov.dot link schemes on the decoded URI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,8 +34,14 @@ files the repository lacked. No API, dependency or Python-floor changes.
   link attributes unless the scheme is `http`, `https`, `mailto`, `urn` or
   absent, and escapes labels and identifiers in both HTML-like and quoted
   node labels; a hostile document could previously plant `javascript:` links
-  or break out of a label in rendered SVG. Ordinary documents render
-  byte-identically
+  or break out of a label in rendered SVG. The scheme is checked on the
+  decoded form of the URI, because Graphviz passes HTML character
+  references such as `&#58;` through to SVG unchanged and every consumer
+  decodes them, so an undecoded check could not catch a namespace URI that
+  smuggled a `javascript:` link this way. Annotation-row `href` values are
+  now HTML-escaped too. Ordinary documents render byte-identically, except
+  that identifier URIs containing `&` now change bytes in the escaped
+  `href`
 
 ### Tests
 

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -15,7 +15,7 @@ References:
 import typing
 from dataclasses import dataclass, field
 from datetime import datetime
-from html import escape
+from html import escape, unescape
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -194,9 +194,17 @@ def _link_uri(uri: str) -> str | None:
 
     Identifiers are document content and rendered SVG makes link attributes
     live, so only ``http``, ``https``, ``mailto``, ``urn`` and scheme-less
-    URIs are linked.
+    URIs are linked. The scheme is read from the decoded form of the URI,
+    because Graphviz passes HTML character references through to SVG, where
+    the consumer decodes them.
     """
-    scheme = urlsplit(uri).scheme.lower()
+    decoded = uri
+    for _ in range(3):
+        candidate = unescape(decoded)
+        if candidate == decoded:
+            break
+        decoded = candidate
+    scheme = urlsplit(decoded.strip()).scheme.lower()
     return uri if scheme == "" or scheme in _LINK_SCHEMES else None
 
 

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -157,6 +157,30 @@ def test_javascript_scheme_identifier_gets_no_url_or_href():
     assert 'href="javascript' not in dot_text
 
 
+@pytest.mark.parametrize(
+    "namespace_uri",
+    ["javascript&#58;", "javascript&#x3A;", "javascript&colon;", " javascript:"],
+    ids=["decimal-ref", "hex-ref", "named-ref", "leading-space"],
+)
+def test_encoded_or_padded_javascript_scheme_gets_no_url_or_href(namespace_uri):
+    # Graphviz passes character references through to SVG, where the consumer
+    # decodes them, so the scheme check must run on the decoded form.
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.add_namespace("js", namespace_uri)
+    js = doc.valid_qualified_name("js:alert")
+    doc.entity("ex:safe", other_attributes={"ex:link": js})
+    doc.entity("js:payload")
+
+    dot_text = prov_to_dot(doc).to_string()
+
+    assert 'URL="http://example.org/safe"' in dot_text
+    assert 'URL="javascript' not in dot_text
+    assert 'URL=" javascript' not in dot_text
+    assert 'href="javascript' not in dot_text
+    assert 'href=" javascript' not in dot_text
+
+
 def test_bundle_with_javascript_identifier_gets_no_url():
     doc = ProvDocument()
     doc.add_namespace("js", "javascript:")


### PR DESCRIPTION
Follow-up to the 3.1.1 prov.dot hardening, found by the whole-release review.

_link_uri() classified the raw URI string, so an identifier URI written with an HTML character reference (javascript&#58;, &#x3A;, &colon;) had no scheme as far as urlsplit was concerned and was linked; Graphviz passes character references through to SVG, where the consumer decodes them back to javascript:. The scheme is now read from the decoded, whitespace-stripped form (bounded to three unescape passes, which decodes more aggressively than any single SVG consumer), while the emitted URL text is unchanged, so ordinary documents stay byte-identical (verified against the DOT baseline).

Four parametrised tests cover decimal, hex and named references and a leading space. The HISTORY.md Security bullet now states the decoded-form check and the annotation href escaping byte change. Suite: 1672 passed, 26 skipped.