### PR TITLE
refactor: simplify the 3.1.1 additions and apply the agreed polish

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,8 @@
 ## 3.1.1 (2026-09-10)
 
 3.1.1 is a point release: bug fixes, hardening of the graphical export, test
-coverage for long-open issues, a "What's new in 3" page, and the community
-files the repository lacked. No API, dependency or Python-floor changes.
+coverage for long-open issues, a "What's new in 3" page, and community and
+citation files for the repository. No API, dependency or Python-floor changes.
 
 ### Fixes
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -63,10 +63,10 @@ naming the extra to install when the format is one of the optional ones.
 
 ## Extras
 
-The core package has no runtime dependencies. `rdflib`, `lxml`, `networkx`, `pydot` and
-`matplotlib` sit behind the `rdf`, `xml`, `graph`, `dot` and `plot` extras respectively
-(see {doc}`../installation`). `prov.graph` and `prov.dot` raise `ModuleNotFoundError`
-naming the extra when imported without it.
+The core package has no runtime dependencies. `rdflib` sits behind the `rdf` extra, `lxml`
+behind `xml`, `networkx` behind `graph`, `pydot` and `networkx` behind `dot`, and
+`matplotlib`, `pydot` and `networkx` behind `plot` (see {doc}`../installation`). `prov.graph`
+and `prov.dot` raise `ModuleNotFoundError` naming the extra when imported without it.
 
 ## Tests
 

--- a/planning/specs/2026-09-10-release-3.1.1-design.md
+++ b/planning/specs/2026-09-10-release-3.1.1-design.md
@@ -46,7 +46,7 @@ for the slow path. No timing assertions.
 `ProvBundle.namespaces` (`bundle.py:346`) wraps the ordered registered
 namespaces in a `set`. Three consumers iterate that set: the PROV-XML
 namespace map (`provxml.py:187`), the PROV-O container binding
-(`provrdf.py:870`), and the bundle copy made by `ProvDocument.unified()`
+(`provrdf.py:870`), and the bundle copy `ProvDocument.add_bundle()` makes from a document
 (`bundle.py:1754`). Set iteration order follows the hash seed, so a bundle
 with two or more namespaces declares them in a different order between runs,
 and a unified copy registers them in a different order.

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -198,13 +198,7 @@ def _link_uri(uri: str) -> str | None:
     because Graphviz passes HTML character references through to SVG, where
     the consumer decodes them.
     """
-    decoded = uri
-    for _ in range(3):
-        candidate = unescape(decoded)
-        if candidate == decoded:
-            break
-        decoded = candidate
-    scheme = urlsplit(decoded.strip()).scheme.lower()
+    scheme = urlsplit(unescape(uri).strip()).scheme.lower()
     return uri if scheme == "" or scheme in _LINK_SCHEMES else None
 
 

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -67,7 +67,9 @@ class NamespaceManager(dict[str, Namespace]):
             The matching :class:`~prov.identifier.Namespace`, or ``None`` if no
             known namespace has that URI.
         """
-        namespace = _DEFAULT_NAMESPACES_BY_URI.get(uri) or self._uri_map.get(uri)
+        namespace = _DEFAULT_NAMESPACES_BY_URI.get(uri)
+        if namespace is None:
+            namespace = self._uri_map.get(uri)
         if namespace is not None:
             return namespace
         if self._default is not None and self._default.uri == uri:

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1334,14 +1334,12 @@ class ProvRDFSerializer(Serializer):
         self._decode_triples(graph, bundle, state, relation_mapper, predicate_mapper)
         self._emit_decoded_records(bundle, state)
 
-        # Every subject gets a (possibly empty) entry while decoding; only
-        # entries still holding attributes are unconverted.
-        unconverted = {
-            subj: attrs for subj, attrs in state.other_attributes.items() if attrs
-        }
-        if unconverted:
+        # Entries are created only when an attribute is gathered and are
+        # removed as records consume them, so whatever remains is unconverted.
+        if state.other_attributes:
             warnings.warn(
-                "The following attributes were not converted: " + str(unconverted),
+                "The following attributes were not converted: "
+                + str(state.other_attributes),
                 UserWarning,
                 stacklevel=2,
             )
@@ -1442,7 +1440,6 @@ class ProvRDFSerializer(Serializer):
             subj = str(subj_node)
             # predicates in RDF are always URIRefs; rdflib types them as Node
             pred = cast(URIRef, pred_node)
-            state.other_attributes.setdefault(subj, [])
             if pred == RDF.type:
                 continue
             if pred in relation_mapper:
@@ -1594,7 +1591,7 @@ class ProvRDFSerializer(Serializer):
                 # by walking every combination in _emit_decoded_records().
                 state.formal_attributes[subj][qname_key] = None
         elif "qualified" not in str(pred_new) and "asInBundle" not in str(pred_new):
-            state.other_attributes[subj].append((str(pred_new), obj1))
+            state.other_attributes.setdefault(subj, []).append((str(pred_new), obj1))
 
     def _emit_decoded_records(
         self, bundle: pm.ProvBundle, state: "_DecodeState"

--- a/src/prov/tests/conftest.py
+++ b/src/prov/tests/conftest.py
@@ -14,7 +14,7 @@ import os
 import pytest
 from hypothesis import settings
 
-from prov.model import ProvDocument, ProvMention
+from prov.model import ProvBundle, ProvDocument, ProvMention
 
 # Hypothesis profiles for the property-based round-trip tests
 # (``test_property_roundtrip.py``). The local ``default`` profile is
@@ -106,6 +106,21 @@ def _document_record_strings(doc: ProvDocument) -> set[str]:
         for bundle in doc.bundles:
             records.update(f"{bundle.identifier} | {r}" for r in bundle.get_records())
     return records
+
+
+ORDERED_NAMESPACE_PREFIXES = [f"ex{i}" for i in range(1, 6)]
+
+
+def add_ordered_namespaces(container: ProvBundle) -> list[str]:
+    """Register five namespaces on ``container`` in a fixed order, one entity each.
+
+    Five namespaces give a one-in-120 chance that hash-seed set order matches
+    registration order by accident (#337).
+    """
+    for i, prefix in enumerate(ORDERED_NAMESPACE_PREFIXES, start=1):
+        container.add_namespace(prefix, f"http://example.org/ns{i}/")
+        container.entity(f"{prefix}:e{i}")
+    return list(ORDERED_NAMESPACE_PREFIXES)
 
 
 def pytest_assertrepr_compare(config, op, left, right):

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -140,6 +140,27 @@ def test_unresolvable_unification_falls_back_to_original_bundle():
 # and rendered SVG makes link attributes live.
 
 
+def _node_with_label_fragment(dot, fragment):
+    """The one node whose label contains ``fragment``."""
+    matches = [n for n in dot.get_nodes() if fragment in (n.get_label() or "")]
+    assert len(matches) == 1, fragment
+    return matches[0]
+
+
+def _assert_javascript_links_dropped(doc):
+    """``ex:safe`` keeps its links; the ``js:`` node and annotation get none."""
+    dot = prov_to_dot(doc)
+
+    safe = _node_with_label_fragment(dot, "ex:safe")
+    assert safe.get("URL") == '"http://example.org/safe"'
+    payload = _node_with_label_fragment(dot, "js:payload")
+    assert payload.get("URL") is None
+    annotation = _node_with_label_fragment(dot, "ex:link")
+    assert 'href="http://example.org/link"' in annotation.get_label()
+    assert 'href="javascript' not in annotation.get_label()
+    assert 'href=" javascript' not in annotation.get_label()
+
+
 def test_javascript_scheme_identifier_gets_no_url_or_href():
     doc = ProvDocument()
     doc.add_namespace("ex", "http://example.org/")
@@ -149,12 +170,7 @@ def test_javascript_scheme_identifier_gets_no_url_or_href():
     )
     doc.entity("js:payload", other_attributes={"js:attr": "value"})
 
-    dot_text = prov_to_dot(doc).to_string()
-
-    assert 'URL="http://example.org/safe"' in dot_text
-    assert 'href="http://example.org/link"' in dot_text
-    assert 'URL="javascript' not in dot_text
-    assert 'href="javascript' not in dot_text
+    _assert_javascript_links_dropped(doc)
 
 
 @pytest.mark.parametrize(
@@ -172,13 +188,7 @@ def test_encoded_or_padded_javascript_scheme_gets_no_url_or_href(namespace_uri):
     doc.entity("ex:safe", other_attributes={"ex:link": js})
     doc.entity("js:payload")
 
-    dot_text = prov_to_dot(doc).to_string()
-
-    assert 'URL="http://example.org/safe"' in dot_text
-    assert 'URL="javascript' not in dot_text
-    assert 'URL=" javascript' not in dot_text
-    assert 'href="javascript' not in dot_text
-    assert 'href=" javascript' not in dot_text
+    _assert_javascript_links_dropped(doc)
 
 
 def test_bundle_with_javascript_identifier_gets_no_url():
@@ -187,9 +197,10 @@ def test_bundle_with_javascript_identifier_gets_no_url():
     bundle = doc.bundle("js:bundle")
     bundle.entity("js:e1")
 
-    dot_text = prov_to_dot(doc).to_string()
+    dot = prov_to_dot(doc)
 
-    assert 'URL="javascript' not in dot_text
+    (cluster,) = dot.get_subgraphs()
+    assert cluster.get("URL") is None
 
 
 def test_html_label_special_characters_are_escaped():

--- a/src/prov/tests/test_graphs.py
+++ b/src/prov/tests/test_graphs.py
@@ -46,7 +46,7 @@ def test_relation_with_missing_end_is_skipped_with_warning(document):
         g = prov_to_graph(document)
 
     assert list(g.edges()) == []
-    assert len(record) == 1
+    assert sum(issubclass(w.category, ProvWarning) for w in record) == 1
 
 
 def test_relation_endpoints_get_inferred_nodes(document):
@@ -78,7 +78,7 @@ def test_relation_with_uninferrable_endpoint_type_is_skipped_with_warning(docume
     with pytest.warns(ProvWarning, match="Influence") as record:
         g = prov_to_graph(document)
 
-    assert len(record) == 1
+    assert sum(issubclass(w.category, ProvWarning) for w in record) == 1
     assert len(g.nodes()) == 2
     assert len(g.edges()) == 1
     (_, _, edge_data) = next(iter(g.edges(data=True)))

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -29,6 +29,7 @@ from prov.model import (
     parse_xsd_datetime,
 )
 from prov.tests import examples
+from prov.tests.conftest import add_ordered_namespaces
 
 logger = logging.getLogger(__name__)
 
@@ -836,10 +837,7 @@ def test_add_bundle_from_document_keeps_namespace_order():
     # #337: ProvDocument.add_bundle() copies a document's namespaces into
     # the new bundle in registration order.
     source = ProvDocument()
-    prefixes = [f"ex{i}" for i in range(1, 6)]
-    for i, prefix in enumerate(prefixes, start=1):
-        source.add_namespace(prefix, f"http://example.org/ns{i}/")
-        source.entity(f"{prefix}:e{i}")
+    prefixes = add_ordered_namespaces(source)
 
     target = ProvDocument()
     target.set_default_namespace("http://example.org/")

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -27,7 +27,7 @@ from prov.serializers.provrdf import (
     ProvRDFSerializer,
     literal_rdf_representation,
 )
-from prov.tests.conftest import roundtrip_document
+from prov.tests.conftest import add_ordered_namespaces, roundtrip_document
 
 logger = logging.getLogger(__name__)
 
@@ -1193,9 +1193,6 @@ def test_resolve_iri_skips_bound_namespace_equal_to_the_iri_itself():
     assert identifier.localpart == "thing"
 
 
-BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
-
-
 def test_bundle_namespace_order_follows_registration_in_rdf():
     # #337: bundle namespaces are bound on the bundle graph in registration
     # order. rdflib sorts prefixes when it serializes, so the bound order on
@@ -1203,20 +1200,19 @@ def test_bundle_namespace_order_follows_registration_in_rdf():
     document = ProvDocument()
     document.set_default_namespace("http://example.org/")
     bundle = document.bundle("b1")
-    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
-        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
-        bundle.entity(f"{prefix}:e{i}")
+    prefixes = add_ordered_namespaces(bundle)
 
     serializer = ProvRDFSerializer(document)
     graph = serializer.encode_container(
         bundle, identifier=URIRef("http://example.org/b1")
     )
+
     bound = [
         prefix
         for prefix, _ in graph.namespace_manager.namespaces()
-        if prefix in BUNDLE_NAMESPACE_ORDER
+        if prefix in prefixes
     ]
-    assert bound == BUNDLE_NAMESPACE_ORDER
+    assert bound == prefixes
 
 
 NOT_CONVERTED = "The following attributes were not converted"

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -20,7 +20,7 @@ from prov.serializers.provxml import (
     _unescape_ncname_localpart,
     xml_qname_to_QualifiedName,
 )
-from prov.tests.conftest import roundtrip_document
+from prov.tests.conftest import add_ordered_namespaces, roundtrip_document
 
 EX_NS = ("ex", "http://example.com/ns/ex#")
 EX_TR = ("tr", "http://example.com/ns/tr#")
@@ -839,27 +839,16 @@ def _perform_round_trip(filename, force_types=False):
         compare_xml(filename, new_xml)
 
 
-BUNDLE_NAMESPACE_ORDER = [f"ex{i}" for i in range(1, 6)]
-
-
-def _document_with_ordered_bundle_namespaces():
+def test_bundle_namespace_order_follows_registration_in_xml():
+    # #337: bundle namespaces are declared in registration order.
     document = prov.ProvDocument()
     document.set_default_namespace("http://example.org/")
-    bundle = document.bundle("b1")
-    for i, prefix in enumerate(BUNDLE_NAMESPACE_ORDER, start=1):
-        bundle.add_namespace(prefix, f"http://example.org/ns{i}/")
-        bundle.entity(f"{prefix}:e{i}")
-    return document
+    prefixes = add_ordered_namespaces(document.bundle("b1"))
 
+    xml_bytes = document.serialize(format="xml").encode()
 
-def test_bundle_namespace_order_follows_registration_in_xml():
-    # #337: five namespaces give a one-in-120 chance of the old
-    # set-iteration order matching by accident.
-    xml_bytes = (
-        _document_with_ordered_bundle_namespaces().serialize(format="xml").encode()
-    )
     declared = re.findall(rb"xmlns:(ex\d)=", xml_bytes)
-    assert [p.decode() for p in declared] == BUNDLE_NAMESPACE_ORDER
+    assert [p.decode() for p in declared] == prefixes
 
 
 # #338: force_types coverage, independent of the disabled _perform_round_trip


### PR DESCRIPTION
A simplify round over the whole 3.1.1 release diff (four review angles: reuse, simplification, efficiency, altitude), plus the five polish items agreed after the final review.

Simplifications: prov.dot's link-scheme check uses a single html.unescape pass (the one decode an SVG consumer performs); the PROV-O decoder stops pre-registering empty leftover-attribute entries per subject, which was the root cause of the over-warning, so the warn site tests the dict directly; the five-namespace builder shared by the #337 tests lives in conftest.py; the prov.dot security tests assert per node and per annotation rather than by substring on the rendered text.

Polish: explicit None checks in NamespaceManager.get_namespace(), ProvWarning-only counts in the prov.graph warning tests, the transitive pulls of the dot and plot extras on the architecture page, a flatter lead sentence in the 3.1.1 changelog, and the corrected third consumer in design spec section 2.2.

No behaviour change: suite 1672 passed, 26 skipped, 0 xfailed; DOT output of the canonical examples byte-identical; zero empty-list warnings; mypy and ruff clean.

One deliberate classification change: prov.dot now decodes character references once before checking the scheme, matching the single decode an SVG consumer performs. A doubly encoded scheme such as javascript&amp;#58; therefore decodes to a scheme-less string and is linked, where the earlier three-pass loop blocked it; the resulting link is inert because no consumer decodes twice.