### PR TITLE
docs: tighten the README, installation page and tutorial

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ Guidance for Claude Code when working in this repository.
 
 ## Project overview
 
-`prov` is a Python implementation of the W3C PROV Data Model. Used by ProvStore, so treat the
-public API with care.
+`prov` is a Python implementation of the W3C PROV Data Model. Downstream projects depend on it, so
+treat the public API with care.
 
 ## Roadmap and planning
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,49 @@
-# Introduction
+# prov
 
-[![Latest Release](https://badge.fury.io/py/prov.svg)](http://badge.fury.io/py/prov)
-[![License](https://img.shields.io/pypi/l/prov.svg)](https://pypi.python.org/pypi/prov/)
+[![Latest Release](https://badge.fury.io/py/prov.svg)](https://badge.fury.io/py/prov)
+[![License](https://img.shields.io/pypi/l/prov.svg)](https://pypi.org/project/prov/)
 [![CI Status](https://github.com/trungdong/prov/workflows/CI/badge.svg)](https://github.com/trungdong/prov/actions?workflow=CI)
 [![Coverage Status](https://img.shields.io/coveralls/trungdong/prov.svg)](https://coveralls.io/r/trungdong/prov?branch=main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/73bdf6dda3884abf9f5e79352c07e66c)](https://app.codacy.com/gh/trungdong/prov/dashboard)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22696001.svg)](https://doi.org/10.5281/zenodo.22696001)
-[![Supported Python version](https://img.shields.io/pypi/pyversions/prov.svg)](https://pypi.python.org/pypi/prov/)
+[![Supported Python version](https://img.shields.io/pypi/pyversions/prov.svg)](https://pypi.org/project/prov/)
 
-A library for W3C Provenance Data Model supporting PROV-O (RDF), PROV-XML, PROV-JSON and PROV-JSONLD import/export
+A Python implementation of the [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/), with
+import and export in PROV-JSON, PROV-JSONLD, PROV-XML and PROV-O (RDF).
 
-- Free software: MIT license
-- Documentation: <http://prov.readthedocs.io/>.
-- Python 3 only.
+- Documentation: <https://prov.readthedocs.io/>
+- Licence: MIT
+- Python 3.10 or later
 
 ## Features
 
-- An implementation of the [W3C PROV Data Model](http://www.w3.org/TR/prov-dm/) in Python.
-- In-memory classes for PROV assertions, which can then be output as [PROV-N](http://www.w3.org/TR/prov-n/)
-- Serialization and deserialization support: [PROV-O](http://www.w3.org/TR/prov-o/) (RDF), [PROV-XML](http://www.w3.org/TR/prov-xml/), [PROV-JSON](http://www.w3.org/Submission/prov-json/) and [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/).
-- Exporting PROV documents into various graphical formats (e.g. PDF, PNG, SVG).
-- Convert a PROV document to a [Networkx MultiDiGraph](https://networkx.github.io/documentation/stable/reference/classes/multidigraph.html) and back.
+- In-memory classes for every PROV-DM record type, printable as
+  [PROV-N](https://www.w3.org/TR/prov-n/).
+- Serialization to and from [PROV-JSON](https://www.w3.org/submissions/prov-json/),
+  [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/),
+  [PROV-XML](https://www.w3.org/TR/prov-xml/) and [PROV-O](https://www.w3.org/TR/prov-o/) (RDF).
+- Export to graphical formats such as PDF, PNG and SVG through Graphviz.
+- Conversion to and from a [NetworkX](https://networkx.org/) `MultiDiGraph`.
+- Command-line tools, `prov-convert` and `prov-compare`.
 
-### Uses
+Start with the [tutorial](https://prov.readthedocs.io/en/latest/tutorial/getting-started.html).
+[ProvStore](https://openprovenance.org/store/), a free online repository for provenance
+documents, is built on this package.
 
-See [a short tutorial](http://trungdong.github.io/prov-python-short-tutorial.html) for using this package.
+## Status
 
-This package is used extensively by [ProvStore](https://openprovenance.org/store/),
-a free online repository for provenance documents.
-
-## Roadmap
-
-3.0.0 has been released, completing the staged modernisation (tooling, type hints,
-tests, documentation, standards conformance), and 3.1.0 added PROV-JSONLD. See
-[What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html) for a summary
-aimed at projects still on 2.x, and
-[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) for the plan
-and the 3.x API-stability promise.
-Feedback is welcome on the [issue tracker](https://github.com/trungdong/prov/issues).
+3.0.0 completed the modernisation programme (tooling, type hints, tests, documentation and
+standards conformance) and 3.1.0 added PROV-JSONLD.
+[What's new in 3](https://prov.readthedocs.io/en/latest/whats-new-3.html) summarises the 3.x
+line for projects still on 2.x.
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) lists the planned
+releases and the API-stability promise. Feedback is welcome on the
+[issue tracker](https://github.com/trungdong/prov/issues).
 
 ## Supported versions
 
-The latest 3.x release receives all fixes. The most recent 2.x release
-receives security fixes only; the last release to carry bug fixes
-back-ported from 3.x was 2.5.3. 1.x and earlier no longer receive fixes. See
-[SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md)
-for the full support table and how to report a vulnerability.
+The latest 3.x release receives all fixes. The most recent 2.x release receives security
+fixes only; 2.5.3 was the last release to carry bug fixes back-ported from 3.x. Releases
+before 2.0 receive no fixes.
+[SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md) has the support table
+and how to report a vulnerability.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ import and export in PROV-JSON, PROV-JSONLD, PROV-XML and PROV-O (RDF).
 - Command-line tools, `prov-convert` and `prov-compare`.
 
 Start with the [tutorial](https://prov.readthedocs.io/en/latest/tutorial/getting-started.html).
-[ProvStore](https://openprovenance.org/store/), a free online repository for provenance
-documents, is built on this package.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ import and export in PROV-JSON, PROV-JSONLD, PROV-XML and PROV-O (RDF).
 - Command-line tools, `prov-convert` and `prov-compare`.
 
 Start with the [tutorial](https://prov.readthedocs.io/en/latest/tutorial/getting-started.html).
+Over 7,000 public repositories on GitHub
+[depend on this package](https://github.com/trungdong/prov/network/dependents).
 
 ## Status
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,9 @@
-Prov Python package's documentation
-===================================
+prov documentation
+==================
+
+``prov`` is a Python implementation of the W3C PROV Data Model. Start with the tutorial,
+then use the how-to guides for individual tasks. The reference section documents the API
+and the explanation section covers the concepts behind it.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,32 +1,31 @@
 # Installation
 
-**Python 3 is required**.
-
-At the command line:
+`prov` needs Python 3.10 or later.
 
 ```bash
 python -m pip install prov
 ```
 
-This installs the core data model, PROV-JSON and PROV-JSONLD support, and the write-only
-PROV-N serializer. Several features live behind optional extras and raise
-`ModuleNotFoundError` (naming the extra to install) if used without them:
+This installs the core data model and the PROV-JSON, PROV-JSONLD and PROV-N serializers.
+PROV-N is write-only. Every other capability sits behind an optional extra and raises
+`ModuleNotFoundError`, naming the extra to install, when used without it.
 
-- `prov[rdf]` — PROV-O/RDF serialization (`rdflib`).
-- `prov[xml]` — PROV-XML serialization (`lxml`).
-- `prov[dot]` — graphical export via Graphviz (`prov.dot`, `prov_to_dot()`); also
-  needs a local `graphviz` binary.
-- `prov[graph]` — NetworkX graph interop (`prov.graph`, `prov_to_graph()`/
-  `graph_to_prov()`).
-- `prov[plot]` — the interactive-display path of `ProvBundle.plot()`/
-  `ProvDocument.plot()` (pulls in `matplotlib` as well as the `dot` extra's
-  dependencies, since `plot()` renders through `prov.dot`).
+| Extra | Enables | Installs |
+|---|---|---|
+| `rdf` | PROV-O (RDF) serializer and deserializer | `rdflib` |
+| `xml` | PROV-XML serializer and deserializer | `lxml` |
+| `dot` | Graphviz export through `prov.dot` | `pydot`, `networkx` |
+| `graph` | NetworkX conversion through `prov.graph` | `networkx` |
+| `plot` | The interactive display in `ProvBundle.plot()` | `matplotlib`, `pydot`, `networkx` |
 
-Extras combine, e.g.:
+The `dot` and `plot` extras also need a local [Graphviz](https://graphviz.org/download/)
+install, because rendering runs the `dot` executable.
+
+Extras combine:
 
 ```bash
 python -m pip install "prov[rdf,xml,dot,graph]"
 ```
 
-See `docs/dependencies.md` for the rationale behind each dependency and its version
-pin.
+[docs/dependencies.md](https://github.com/trungdong/prov/blob/main/docs/dependencies.md) in
+the repository explains each dependency and its version pin.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,14 +1,15 @@
 # Installation
 
-`prov` needs Python 3.10 or later.
+`prov` needs Python 3.10 or later. Support for Python 3.10 ends in the first release
+after its end of life on 2026-10-31.
 
 ```bash
 python -m pip install prov
 ```
 
 This installs the core data model and the PROV-JSON, PROV-JSONLD and PROV-N serializers.
-PROV-N is write-only. Every other capability sits behind an optional extra and raises
-`ModuleNotFoundError`, naming the extra to install, when used without it.
+PROV-N is write-only. Every other capability sits behind an optional extra. Using one
+without its extra raises an error that names the extra to install.
 
 | Extra | Enables | Installs |
 |---|---|---|

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -46,7 +46,7 @@ a1 = document.activity("a1", "2024-07-09T16:39:38", None, {pm.PROV_TYPE: "edit"}
 
 # Pass extra attributes with the ``other_attributes`` keyword.
 document.wasGeneratedBy(e2, a1, other_attributes={"ex:fct": "save"})
-document.wasAssociatedWith("a1", "ag2", None, None, {pm.PROV_ROLE: "author"})
+document.wasAssociatedWith("a1", "ag2", other_attributes={pm.PROV_ROLE: "author"})
 document.agent("ag2", {pm.PROV_TYPE: pm.PROV["Person"], "ex:name": "Bob"})
 ```
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,55 +1,53 @@
 # Getting started
 
-This tutorial walks you through the whole life cycle of a provenance document with
-`prov`: building it in memory, printing it as [PROV-N](https://www.w3.org/TR/prov-n/),
-saving it to (and loading it back from) [PROV-JSON](https://www.w3.org/Submission/prov-json/),
-and rendering it as a diagram. Every code block runs as written; paste them into a Python
-session in order, or copy them into a script.
+This tutorial follows one provenance document through its life cycle. You build it in
+memory, print it as [PROV-N](https://www.w3.org/TR/prov-n/), save it as
+[PROV-JSON](https://www.w3.org/submissions/prov-json/), load it back and render it as a
+diagram. Every code block runs as written. Paste them into a Python session in order, or
+copy them into a script.
 
-If you have not installed the library yet, see {doc}`../installation`. To follow the
-visualisation section you will also need a local [Graphviz](https://graphviz.org/) install
-(more on that below).
+If you have not installed the library yet, see {doc}`../installation`. The visualisation
+section also needs a local [Graphviz](https://graphviz.org/) install.
 
 ## Build a document
 
 A {py:class}`~prov.model.ProvDocument` is the top-level container for provenance
-statements. We start by declaring the namespaces our identifiers live in — a *default*
-namespace for the things this document is primarily about, and an `ex` prefix for
-everything else.
+statements. Start by declaring the namespaces your identifiers live in. The default
+namespace is for the things this document is about, and the `ex` prefix is for everything
+else.
 
 ```python
-import prov.model as prov
+import prov.model as pm
 
-document = prov.ProvDocument()
+document = pm.ProvDocument()
 document.set_default_namespace("http://anotherexample.org/")
 document.add_namespace("ex", "http://example.org/")
 ```
 
-Now we add an **entity** — the file whose provenance we are describing. Attributes are
-given as a list (or dict) of `(name, value)` pairs. Names can be `prov:*` constants such
-as {py:data}`prov.model.PROV_TYPE` or any prefixed name like `ex:path`.
+Now add an **entity**, the file whose provenance you are describing. Attributes are a list
+or dict of `(name, value)` pairs. A name is either a `prov:` constant such as
+{py:data}`prov.model.PROV_TYPE` or a prefixed name such as `ex:path`.
 
 ```python
 e2 = document.entity("e2", (
-    (prov.PROV_TYPE, "File"),
+    (pm.PROV_TYPE, "File"),
     ("ex:path", "/shared/crime.txt"),
     ("ex:creator", "Alice"),
     ("ex:content", "There was a lot of crime in London last month"),
 ))
 ```
 
-Next, the **activity** that produced the file, an **agent** responsible for it, and the
-relations that tie them together. The factory methods return the record they create, so
-you can pass either the record objects (`e2`, `a1`) or their string identifiers as
-references.
+Next add the **activity** that produced the file, an **agent** responsible for it, and the
+relations that tie them together. Each factory method returns the record it creates, so you
+can refer to a record either by the object (`e2`, `a1`) or by its identifier string.
 
 ```python
-a1 = document.activity("a1", "2024-07-09T16:39:38", None, {prov.PROV_TYPE: "edit"})
+a1 = document.activity("a1", "2024-07-09T16:39:38", None, {pm.PROV_TYPE: "edit"})
 
 # Pass extra attributes with the ``other_attributes`` keyword.
 document.wasGeneratedBy(e2, a1, other_attributes={"ex:fct": "save"})
-document.wasAssociatedWith("a1", "ag2", None, None, {prov.PROV_ROLE: "author"})
-document.agent("ag2", {prov.PROV_TYPE: prov.PROV["Person"], "ex:name": "Bob"})
+document.wasAssociatedWith("a1", "ag2", None, None, {pm.PROV_ROLE: "author"})
+document.agent("ag2", {pm.PROV_TYPE: pm.PROV["Person"], "ex:name": "Bob"})
 ```
 
 That is a complete provenance document. Print it in PROV-N, the human-readable notation
@@ -74,28 +72,27 @@ endDocument
 
 ## Save it and load it back
 
-{py:meth}`~prov.model.ProvDocument.serialize` writes the document out. With no
-destination it returns a string; given a file path it writes the file. The default format
-is PROV-JSON.
+{py:meth}`~prov.model.ProvDocument.serialize` writes the document out. With no destination
+it returns a string. With a file path it writes the file. The default format is PROV-JSON.
 
 ```python
 document.serialize("article-prov.json")
 ```
 
 {py:meth}`~prov.model.ProvDocument.deserialize` is the inverse. It accepts a file path or
-an open stream as `source`, or a string via the `content` keyword. Because a round trip
-through PROV-JSON preserves the model exactly, the loaded document compares equal to the
+an open stream as `source`, or a string through the `content` keyword. A round trip
+through PROV-JSON preserves the model exactly, so the loaded document compares equal to the
 original:
 
 ```python
-loaded = prov.ProvDocument.deserialize("article-prov.json")
+loaded = pm.ProvDocument.deserialize("article-prov.json")
 assert loaded == document
 ```
 
 ## Visualise it
 
-The {py:mod}`prov.dot` module turns a document into a [pydot](https://pypi.org/project/pydot/)
-graph, which you can write straight to an image file:
+{py:mod}`prov.dot` turns a document into a [pydot](https://pypi.org/project/pydot/) graph,
+which you can write straight to an image file. This needs the `dot` extra.
 
 ```python
 from prov.dot import prov_to_dot
@@ -105,22 +102,21 @@ dot.write_png("article-prov.png")
 ```
 
 ```{note}
-Rendering to PNG/PDF/SVG needs a local **Graphviz** installation (the `dot` executable),
-not just the `pydot` Python package. Install it from your package manager (for example
-`brew install graphviz` or `apt install graphviz`) or from <https://graphviz.org/download/>.
-For styling options — direction, labels, hiding attributes — see the graphics how-to guide.
+Rendering to PNG, PDF or SVG needs a local Graphviz installation, not just the `pydot`
+package. Install it from your package manager, for example `brew install graphviz` or
+`apt install graphviz`, or from <https://graphviz.org/download/>. The {doc}`../howto/graphics`
+guide covers layout direction, labels and hiding attributes.
 ```
 
 ## Bundles
 
-A **bundle** is a named set of statements with its own namespaces, letting you describe
-the provenance of provenance. A {py:class}`~prov.model.ProvDocument` is the only kind of
-bundle that may contain other, named bundles. Note how the same local name `e001` refers
-to two different entities because each bundle resolves it against a different default
-namespace:
+A **bundle** is a named set of statements with its own namespaces. It lets you describe the
+provenance of provenance. Only a {py:class}`~prov.model.ProvDocument` may contain named
+bundles. In the example below the local name `e001` names two different entities, because
+each bundle resolves it against its own default namespace:
 
 ```python
-d = prov.ProvDocument()
+d = pm.ProvDocument()
 d.set_default_namespace("http://example.org/0/")
 d.add_namespace("ex1", "http://example.org/1/")
 d.add_namespace("ex2", "http://example.org/2/")
@@ -151,10 +147,10 @@ endDocument
 
 ## Where next
 
-- **How-to guides** — task-focused recipes: serialising to the other formats (PROV-XML,
-  PROV-O/RDF, PROV-N, PROV-JSONLD), producing graphics, converting to and from a NetworkX
-  graph, and using the command-line tools.
-- **Reference** — the full API, generated from the source, under {doc}`../reference/index`.
-- **The PROV data model** — for the concepts behind entities, activities, agents and the
-  relations between them, read the W3C
-  [PROV-DM Primer](https://www.w3.org/TR/prov-primer/).
+- The how-to guides cover the other formats ({doc}`../howto/provxml`,
+  {doc}`../howto/provo-rdf`, {doc}`../howto/provn`, {doc}`../howto/provjsonld`), graphics,
+  NetworkX conversion and the command-line tools.
+- {doc}`../reference/index` documents the full API, generated from the source.
+- {doc}`../explanation/prov-dm` explains entities, activities, agents and the relations
+  between them. The W3C [PROV-DM Primer](https://www.w3.org/TR/prov-primer/) is the
+  authoritative introduction.

--- a/planning/specs/2026-09-10-docs-review.md
+++ b/planning/specs/2026-09-10-docs-review.md
@@ -27,7 +27,7 @@ Every page that states one of these facts states it this way.
 | Unpublished repo docs | Link with a full GitHub URL, never a relative path. |
 | Example import | `import prov.model as pm`. |
 
-## Defects found
+## Defects found and fixed
 
 | Page | Defect |
 |---|---|

--- a/planning/specs/2026-09-10-docs-review.md
+++ b/planning/specs/2026-09-10-docs-review.md
@@ -1,0 +1,71 @@
+# Public documentation review
+
+Review of every published page for accuracy, cross-page consistency and readability.
+Scope is the Sphinx site content plus README, CONTRIBUTING, SECURITY, HISTORY (facts only),
+LICENSE and the two CLI script headers. Docstrings, `planning/`, `ROADMAP.md`,
+`docs/dependencies.md` and `docs/releasing.md` are out of scope.
+
+## Canonical statements
+
+Every page that states one of these facts states it this way.
+
+| Fact | Canonical statement |
+|---|---|
+| Python | 3.10 or later. CPython 3.10 to 3.14 and PyPy 3.11 are tested. 3.10 is dropped in the first release after 2026-10-31. |
+| Runtime dependencies | None. Every third-party package sits behind an extra. |
+| Extras | `rdf` (rdflib), `xml` (lxml), `dot` (pydot, networkx), `graph` (networkx), `plot` (matplotlib, pydot, networkx). |
+| `plot()` | Needs `prov[plot]`. |
+| Graphviz | The `dot` extra also needs a local Graphviz binary. |
+| Formats | `json` (default), `xml`, `rdf`, `provn` (write-only), `jsonld`. |
+| Auto-detect order | `json`, `rdf`, `provn`, `xml`, `jsonld`. |
+| Support policy | 3.x receives all fixes. 2.x receives security fixes only; 2.5.3 was the last back-port release. Before 2.0 nothing. |
+| Next release | 3.2.0 adds a PROV-N parser (#122). |
+| `prov-convert` | Input is always PROV-JSON. Output is `json`, `xml`, `rdf`, `jsonld`, `provn` or any Graphviz format. |
+| `prov-compare` | Either file may be in any registered format. |
+| Copyright | 2026 in LICENSE, `docs/conf.py` and both CLI script headers. |
+| Repository links | `https://`, branch `main`. |
+| Unpublished repo docs | Link with a full GitHub URL, never a relative path. |
+| Example import | `import prov.model as pm`. |
+
+## Defects found
+
+| Page | Defect |
+|---|---|
+| `docs/howto/graphics.md` | Calls pydot a core dependency. It needs `prov[dot]` since 3.0. |
+| `docs/howto/networkx.md` | Calls networkx a core dependency. It needs `prov[graph]` since 3.0. |
+| `docs/howto/provjson.md` | Auto-detect order omits PROV-JSONLD. |
+| `docs/upgrading-3.0.md` | Says `plot()` needs `prov[dot]`. It needs `prov[plot]`. |
+| `docs/howto/provjsonld.md` | Quoted `mentionOf` error text no longer matches the library. |
+| `README.md`, `docs/installation.md` | Say "Python 3" where the floor is 3.10. |
+| `README.md` | Links an external short tutorial instead of the site tutorial. `http://` links. |
+| `docs/installation.md`, `CONTRIBUTING.md` | Relative link to `docs/dependencies.md`, which is not published. |
+| `docs/howto/cli.md` | Format tables copy stale help text. `rdf` and `jsonld` output and any registered compare format work. |
+| `src/prov/scripts/*.py` | Help text lists only `json`, `xml`, `provn`; `convert_file` docstring claims input auto-detection; LICENSE URL uses `master`; copyright 2025. |
+| `docs/changelog-archive.md` | Dead networkx link; `master` links. |
+| `docs/explanation/unification-flattening.md` | `master` link. |
+| `docs/whats-new-3.md` | Audit list omits PROV-N. |
+| `LICENSE` | Copyright 2025; mixed dash styles in the year ranges. |
+
+## Style brief
+
+- British English. No em dashes in prose. A spaced dash before a gloss in a table cell is fine.
+- One idea per sentence. Under about twenty words in instructions and reference text.
+- State the fact. No "note that", no "worth noting", no rating of facts.
+- No release archaeology in how-to or tutorial pages. Describe present behaviour. Version history belongs in HISTORY.
+- Tutorial teaches one path. How-to answers one question per section. Reference states facts. Explanation gives reasons.
+- Link a page once per section. Repeat cross-references only where the reader needs to go there.
+- Code examples import with `import prov.model as pm`.
+
+## Clusters
+
+1. Entry funnel. `README.md`, `docs/installation.md`, `docs/tutorial/getting-started.md`, `docs/index.rst`.
+2. Format how-tos. `docs/howto/*.md`.
+3. Reference and explanation. `docs/reference/*.md`, `docs/explanation/*.md`.
+4. Project pages. `CONTRIBUTING.md`, `SECURITY.md`, `docs/whats-new-3.md`, `docs/upgrading-3.0.md`, `HISTORY.md`, `docs/changelog-archive.md`, `LICENSE`, `src/prov/scripts/*.py`.
+
+## Gates per PR
+
+- `sphinx-build -W` clean.
+- Every Python block in the edited pages runs.
+- `codacy-analysis analyze` on each changed file reports no issues.
+- Full test matrix for the PR that touches `src/prov/scripts/`.


### PR DESCRIPTION
First of four PRs from a review of the published documentation for accuracy, cross-page consistency and readability. The ledger of canonical statements and defects is in planning/specs/2026-09-10-docs-review.md.

This PR covers the entry funnel: README, installation, the getting-started tutorial and the site index.

Fixes: the Python floor is stated as 3.10 rather than "Python 3"; the README links the site tutorial instead of an external page and uses https links; the installation page links docs/dependencies.md by GitHub URL because that file is excluded from the Sphinx build; the dot and plot extras are documented as needing a Graphviz binary.

Readability: the extras are a table; the tutorial imports prov.model as pm like the how-to guides, and loses narration and em dashes.

Verified: sphinx-build -W is clean, every Python block in the tutorial runs as written, codacy-analysis reports 0 issues on the changed files.