### PR TITLE
docs: correct and tighten the how-to guides

### DIFF
--- a/docs/howto/cli.md
+++ b/docs/howto/cli.md
@@ -1,13 +1,13 @@
 # Use the command-line tools
 
-`prov` installs two console scripts: `prov-convert` (format/graphics conversion) and
-`prov-compare` (equivalence checking). Both wrap the same {py:class}`~prov.model.ProvDocument`
-API described in the other how-to pages.
+`prov` installs two console scripts. `prov-convert` converts a document between formats or
+renders it as an image. `prov-compare` checks two documents for equivalence. Both wrap the
+{py:class}`~prov.model.ProvDocument` API described in the other how-to guides.
 
 ## `prov-convert`
 
-Convert a PROV-JSON document to PROV-N, PROV-XML, PROV-O/RDF, PROV-JSONLD, or any image
-format supported by Graphviz.
+Convert a PROV-JSON document to PROV-N, PROV-XML, PROV-O (RDF), PROV-JSONLD, or any image
+format Graphviz supports.
 
 ### Synopsis
 
@@ -19,18 +19,17 @@ prov-convert [-h] [-f FORMAT] [-V] [infile] [outfile]
 
 | Flag | Argument | Default | Meaning |
 | --- | --- | --- | --- |
-| `-f`, `--format` | `FORMAT` | `json` | Output format: `json`, `xml`, `provn`, or any format name GraphViz's `dot` accepts (e.g. `svg`, `pdf`, `png`) |
-| `-V`, `--version` | — | — | Print the version and exit |
-| `-h`, `--help` | — | — | Print usage and exit |
-| `infile` (positional) | — | stdin | Input file — **always read as PROV-JSON**, there is no input-format flag |
-| `outfile` (positional) | — | stdout | Output file, written in `--format` |
+| `-f`, `--format` | `FORMAT` | `json` | Output format: `json`, `xml`, `rdf`, `jsonld`, `provn`, or any Graphviz output format such as `svg`, `pdf` or `png` |
+| `-V`, `--version` | | | Print the version and exit |
+| `-h`, `--help` | | | Print usage and exit |
+| `infile` | | stdin | Input file, always read as PROV-JSON |
+| `outfile` | | stdout | Output file, written in `--format` |
 
-`prov-convert` has no flag to choose the *input* format — the input is always
-deserialized as PROV-JSON (`ProvDocument.deserialize(infile)`, which defaults to
-`format="json"`). To convert from PROV-XML or RDF, load and re-serialize the document as
-PROV-JSON first (or write a two-line Python script using
-{py:meth}`~prov.model.ProvDocument.deserialize`/{py:meth}`~prov.model.ProvDocument.serialize`
-directly — see the format-specific how-to pages).
+There is no flag for the input format. The input is always read as PROV-JSON. To convert
+from another format, load the document in Python and serialize it with
+{py:meth}`~prov.model.ProvDocument.serialize`, as the format guides show.
+
+Image formats need the `dot` extra and a local Graphviz install. See {doc}`graphics`.
 
 ### Examples
 
@@ -40,24 +39,24 @@ Convert a PROV-JSON file to PROV-N:
 prov-convert -f provn document.json document.provn
 ```
 
-Convert a PROV-JSON file to an SVG diagram (needs a local Graphviz install, see
-{doc}`graphics`):
+Convert a PROV-JSON file to an SVG diagram:
 
 ```bash
 prov-convert -f svg document.json document.svg
 ```
 
-Read from stdin, write PROV-JSON (the default) to stdout:
+Read from stdin and write PROV-JSON, the default, to stdout:
 
 ```bash
 cat document.json | prov-convert > copy.json
 ```
 
-### Exit behaviour
+### Exit codes
 
-- Success: exit code `0`; the converted document is written to `outfile`.
-- Unsupported `--format` value, or any other error (bad input, missing file): the error is
-  printed to stderr prefixed with the program name, and the process exits with code `2`.
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. The converted document is in `outfile`. |
+| `2` | Error, such as an unsupported format, unreadable input or a missing file. The message goes to stderr. |
 
 ```bash
 prov-convert -f bogus document.json out.bogus
@@ -68,9 +67,8 @@ echo $?  # 2
 
 ## `prov-compare`
 
-Compare two PROV documents for equivalence (after
-{py:meth}`~prov.model.ProvBundle.unified`-style equality — the same `==` used throughout
-`prov`), each independently loadable as PROV-JSON or PROV-XML.
+Compare two documents for equality, using the same `==` as the library. Each file may be
+in any registered format.
 
 ### Synopsis
 
@@ -82,16 +80,11 @@ prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] [file1] [file2]
 
 | Flag | Argument | Default | Meaning |
 | --- | --- | --- | --- |
-| `-f`, `--format1` | `FORMAT1` | `json` | File 1's format: `json` or `xml` |
-| `-F`, `--format2` | `FORMAT2` | `json` | File 2's format: `json` or `xml` |
-| `-V`, `--version` | — | — | Print the version and exit |
-| `-h`, `--help` | — | — | Print usage and exit |
-| `file1`, `file2` (positional) | — | — | The two files to compare |
-
-Although the help text says "`json` or `xml`", any format name registered with
-{py:class}`prov.serializers.Registry` is actually accepted (e.g. `rdf`), because the flag
-value is passed straight through to
-{py:meth}`~prov.model.ProvDocument.deserialize`(format=...).
+| `-f`, `--format1` | `FORMAT1` | `json` | Format of `file1`: `json`, `xml`, `rdf` or `jsonld` |
+| `-F`, `--format2` | `FORMAT2` | `json` | Format of `file2`: `json`, `xml`, `rdf` or `jsonld` |
+| `-V`, `--version` | | | Print the version and exit |
+| `-h`, `--help` | | | Print usage and exit |
+| `file1`, `file2` | | | The two files to compare |
 
 ### Examples
 
@@ -107,17 +100,17 @@ Compare a PROV-JSON file against a PROV-XML file:
 prov-compare -f json -F xml document.json document.xml
 ```
 
-### Exit behaviour
+### Exit codes
 
-`prov-compare` has no textual "equal"/"different" output on success — it communicates the
-result purely through the exit code:
+`prov-compare` prints nothing on success. The result is the exit code.
 
-- Exit code `0`: the two documents are equivalent (`doc1 == doc2`).
-- Exit code `1`: the two documents differ (`doc1 != doc2`).
-- Exit code `2`: an error occurred (e.g. a file could not be parsed); a message is printed
-  to stderr.
+| Code | Meaning |
+| --- | --- |
+| `0` | The documents are equal. |
+| `1` | The documents differ. |
+| `2` | Error, such as a file that could not be parsed. The message goes to stderr. |
 
 ```bash
-prov-compare document.json document.json; echo $?   # 0 (identical)
-prov-compare document.json copy2.json; echo $?       # 1 (different)
+prov-compare document.json document.json; echo $?   # 0
+prov-compare document.json copy2.json; echo $?       # 1
 ```

--- a/docs/howto/graphics.md
+++ b/docs/howto/graphics.md
@@ -9,8 +9,8 @@ python -m pip install "prov[dot]"
 ```
 
 ```{important}
-The `dot` extra installs the `pydot` package. Rendering also needs the Graphviz `dot`
-executable, which you install separately:
+The `dot` extra installs the `pydot` and `networkx` packages. Rendering also needs the
+Graphviz `dot` executable, which you install separately:
 
 - macOS: `brew install graphviz`
 - Debian and Ubuntu: `apt install graphviz`

--- a/docs/howto/graphics.md
+++ b/docs/howto/graphics.md
@@ -1,20 +1,24 @@
-# Render a document as a graph (PNG/SVG/PDF)
+# Render a document as a graph (PNG, SVG, PDF)
 
 `prov.dot` turns a document into a [pydot](https://pypi.org/project/pydot/) graph, which
-can then be written out in any format Graphviz supports.
+Graphviz can write in any format it supports. It needs the `dot` extra and a local
+Graphviz install.
+
+```bash
+python -m pip install "prov[dot]"
+```
 
 ```{important}
-Rendering needs a local **Graphviz** installation (the `dot` executable) in addition to the
-`pydot` Python package (which is a core dependency of `prov`, always installed). Installing
-`pydot` alone is not enough — this is the most common source of confusion:
+The `dot` extra installs the `pydot` package. Rendering also needs the Graphviz `dot`
+executable, which you install separately:
 
-- **macOS**: `brew install graphviz`
-- **Debian/Ubuntu**: `apt install graphviz`
-- **Windows**: download and run the installer from <https://graphviz.org/download/>
+- macOS: `brew install graphviz`
+- Debian and Ubuntu: `apt install graphviz`
+- Windows: the installer from <https://graphviz.org/download/>
 
-Without it, `dot.write_*()` calls below fail (typically with a `FileNotFoundError` for the
-`dot` executable, surfaced by `pydot` as an assertion/`Exception` depending on version) —
-verify Graphviz is on `PATH` with `dot -V` before debugging your own code.
+Without it every `write_*()` call below fails, usually with an error about the missing
+`dot` executable. Check with `dot -V` that Graphviz is on your `PATH` before debugging
+your own code.
 ```
 
 ## Convert a document to a `pydot.Dot`
@@ -32,9 +36,9 @@ document.wasGeneratedBy(e, a)
 dot = prov_to_dot(document)
 ```
 
-## Write PNG, SVG, or PDF
+## Write PNG, SVG or PDF
 
-`pydot.Dot` has a `write_<format>` method for most Graphviz output formats:
+`pydot.Dot` has a `write_<format>` method for each Graphviz output format:
 
 ```python
 dot.write_png("document.png")
@@ -44,8 +48,8 @@ dot.write_pdf("document.pdf")
 
 ## Layout direction
 
-`direction` controls the rank direction Graphviz lays the graph out in — `"BT"`
-(bottom-to-top, the default), `"TB"`, `"LR"`, or `"RL"`:
+`direction` sets the rank direction. The default is `"BT"`, bottom to top. The other
+values are `"TB"`, `"LR"` and `"RL"`:
 
 ```python
 dot_lr = prov_to_dot(document, direction="LR")
@@ -54,8 +58,8 @@ dot_lr.write_svg("document-lr.svg")
 
 ## Hide attribute annotations
 
-By default every element and relation gets an attached note node listing its non-formal
-attributes. Turn either off to declutter dense graphs:
+By default every element and relation gets a note node listing its non-formal attributes.
+Turn either off to declutter a dense graph:
 
 ```python
 dot_plain = prov_to_dot(
@@ -67,8 +71,8 @@ dot_plain = prov_to_dot(
 
 ## Use labels instead of identifiers
 
-Pass `use_labels=True` to show each element's `prov:label` (falling back to its
-identifier) as the node text instead of always showing the identifier:
+Pass `use_labels=True` to show each element's `prov:label` as the node text. An element
+without a label falls back to its identifier:
 
 ```python
 document.entity("e1", {pm.PROV_LABEL: "Crime report"})
@@ -77,9 +81,9 @@ dot_labelled = prov_to_dot(document, use_labels=True)
 
 ## Hide n-ary relation elements
 
-Relations with more than two formal attributes (e.g. a `wasDerivedFrom` recording an
-activity and usage/generation) render every element by default. Set `show_nary=False` to
-draw only the first two:
+A relation with more than two formal attributes, such as a `wasDerivedFrom` that also
+records an activity, usage and generation, draws every element by default. Set
+`show_nary=False` to draw only the first two:
 
 ```python
 dot_binary = prov_to_dot(document, show_nary=False)
@@ -98,4 +102,4 @@ dot = prov_to_dot(
 )
 ```
 
-See {py:func}`prov.dot.prov_to_dot` for the full parameter reference.
+{py:func}`prov.dot.prov_to_dot` documents every parameter.

--- a/docs/howto/networkx.md
+++ b/docs/howto/networkx.md
@@ -1,15 +1,18 @@
-# Convert to/from a NetworkX graph
+# Convert to and from a NetworkX graph
 
-`prov.graph` converts a document to and from a
-[NetworkX](https://networkx.org/) `MultiDiGraph`, useful for running graph algorithms
-(centrality, shortest paths, community detection, ...) that `prov` itself does not
-implement. `networkx` is a core dependency — no extra install needed.
+`prov.graph` converts a document to and from a [NetworkX](https://networkx.org/)
+`MultiDiGraph`, so you can run graph algorithms such as centrality, shortest paths or
+community detection over it. It needs the `graph` extra:
+
+```bash
+python -m pip install "prov[graph]"
+```
 
 ## Document to graph
 
-{py:func}`~prov.graph.prov_to_graph` returns one node per element (entity/activity/agent)
-and one edge per relation. It unifies the document first, so records describing the same
-identifier are merged into a single node:
+{py:func}`~prov.graph.prov_to_graph` returns one node per element (entity, activity or
+agent) and one edge per relation. It unifies the document first, so records that share an
+identifier become one node:
 
 ```python
 import prov.model as pm
@@ -29,14 +32,16 @@ print(list(g.edges(data=True)))
 # [(<ProvEntity: e1>, <ProvActivity: a1>, {'relation': <ProvGeneration: (e1, a1)>})]
 ```
 
-Each node *is* the `prov` element record (a {py:class}`~prov.model.ProvElement`); each edge
-carries the originating {py:class}`~prov.model.ProvRelation` under the `"relation"` key so
-you don't lose PROV-specific information (relation type, extra attributes) while using
-NetworkX.
+Each node is the {py:class}`~prov.model.ProvElement` record itself. Each edge carries its
+{py:class}`~prov.model.ProvRelation` under the `"relation"` key, so the relation type and
+its attributes stay available while you work in NetworkX.
+
+A relation whose endpoint is unset, or undeclared with a type that cannot be inferred, is
+dropped with a {py:class}`~prov.model.ProvWarning`.
 
 ## Run a NetworkX algorithm
 
-Because nodes are hashable `prov` objects, any NetworkX algorithm works directly:
+Nodes are hashable `prov` objects, so any NetworkX algorithm works directly:
 
 ```python
 import networkx as nx
@@ -46,21 +51,13 @@ print(nx.is_directed_acyclic_graph(g))
 
 ## Graph back to document
 
-{py:func}`~prov.graph.graph_to_prov` reverses the conversion for a graph previously
-produced by `prov_to_graph` (or built to match its shape — nodes are `ProvRecord`
-instances with a bundle, edges carry a `"relation"` record in their data):
+{py:func}`~prov.graph.graph_to_prov` reverses the conversion. The graph must have the
+shape `prov_to_graph` produces. Nodes are {py:class}`~prov.model.ProvRecord` instances
+with a bundle, and each edge carries a `"relation"` record in its data:
 
 ```python
 from prov.graph import graph_to_prov
 
-reloaded = graph_to_prov(g)
-assert reloaded == document
-```
-
-## Round trip
-
-```python
-g = prov_to_graph(document)
 reloaded = graph_to_prov(g)
 assert reloaded == document
 ```

--- a/docs/howto/provjson.md
+++ b/docs/howto/provjson.md
@@ -1,8 +1,8 @@
 # Work with PROV-JSON
 
-[PROV-JSON](https://openprovenance.org/prov-json/) is the default format used by
-{py:meth}`~prov.model.ProvDocument.serialize`/{py:meth}`~prov.model.ProvDocument.deserialize`.
-It needs no extra dependency — the serializer is always available.
+[PROV-JSON](https://www.w3.org/submissions/prov-json/) is the default format for
+{py:meth}`~prov.model.ProvDocument.serialize` and
+{py:meth}`~prov.model.ProvDocument.deserialize`. It needs no extra.
 
 ## Serialize to a file
 
@@ -18,7 +18,7 @@ document.serialize("document.json")  # format="json" is the default
 
 ## Serialize to a string
 
-Omit `destination` (or pass `None`) to get the serialization back as a string:
+Omit `destination`, or pass `None`, to get the serialization back as a string:
 
 ```python
 json_str = document.serialize()
@@ -47,12 +47,14 @@ Use the `content` keyword instead of `source`:
 loaded = pm.ProvDocument.deserialize(content=json_str, format="json")
 ```
 
+(auto-detect)=
+
 ## Auto-detect the format with `prov.read()`
 
-{py:func}`prov.read` tries every registered deserializer in turn — PROV-JSON, then
-PROV-O/RDF, then PROV-N, then PROV-XML — until one both succeeds and produces a non-empty
-document, so it works without knowing the format up front. PROV-JSON is tried first, so
-valid PROV-JSON content always auto-detects correctly:
+{py:func}`prov.read` reads a document without being told its format. It tries every
+registered deserializer in turn, in the order PROV-JSON, PROV-O (RDF), PROV-N, PROV-XML,
+PROV-JSONLD, and returns the first result that is a non-empty document. PROV-JSON is tried
+first, so valid PROV-JSON always auto-detects.
 
 ```python
 import prov
@@ -61,13 +63,16 @@ loaded = prov.read("document.json")
 assert loaded == document
 ```
 
-Passing `format="json"` explicitly skips the trial-and-error and gives a proper traceback
-if the content is not valid JSON.
+A seekable stream, such as an open file or `io.StringIO`, is rewound between attempts. A
+non-seekable stream is consumed by the first attempt, so pass `format=` for those.
+
+Auto-detection swallows every deserializer's error. When no format succeeds it raises a
+generic `TypeError`. Pass `format=` explicitly when you want the real error from one
+deserializer.
 
 ## Common errors
 
-Malformed JSON raises the standard library's decoder error, not a `prov`-specific
-exception:
+Malformed JSON raises the standard library's decoder error:
 
 ```python
 try:
@@ -80,9 +85,18 @@ except Exception as e:
 JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 ```
 
-Since 2.5.0, `prov.read()` swallows *every* candidate deserializer's failure during
-auto-detection — including a candidate that raises, and a candidate that parses
-successfully but yields an empty document (e.g. an empty file) — and always raises the
-fallback `TypeError` ("Could not read from the source...") once every registered format has
-been tried without success. Pass `format=` explicitly if you want a predictable,
-format-specific error instead of that generic `TypeError`.
+Valid JSON with the wrong structure raises
+`prov.serializers.provjson.ProvJSONException`:
+
+```python
+from prov.serializers.provjson import ProvJSONException
+
+try:
+    pm.ProvDocument.deserialize(content='{"entity": "oops"}', format="json")
+except ProvJSONException as e:
+    print(f"{type(e).__name__}: {e}")
+```
+
+```text
+ProvJSONException: The 'entity' value must be a JSON object; found str: 'oops'
+```

--- a/docs/howto/provjson.md
+++ b/docs/howto/provjson.md
@@ -28,7 +28,7 @@ print(json_str)
 ## Deserialize from a file or stream
 
 ```python
-loaded = pm.ProvDocument.deserialize("document.json")
+loaded = pm.ProvDocument.deserialize("document.json")  # format="json" is the default
 assert loaded == document
 ```
 

--- a/docs/howto/provjsonld.md
+++ b/docs/howto/provjsonld.md
@@ -53,8 +53,9 @@ print(jsonld_str)
 ```
 
 The first entry of `@context` holds the document's namespace prefixes. The default
-namespace appears as both `@vocab` and `@base`, because `@vocab` alone does not govern
-`@id` values. The second entry references the submission's context, which resolves the
+namespace appears as both `@vocab` and `@base`. `@vocab` expands unprefixed property
+names, and `@base` expands unprefixed `@id` values such as `e1`, which would otherwise
+resolve against the document's own location. The second entry references the submission's context, which resolves the
 unprefixed types such as `Entity` and `Generation`. A named bundle nests inside the
 top-level `@graph` as an object with `@type: "Bundle"`, its own `@context` and its own
 `@graph`.

--- a/docs/howto/provjsonld.md
+++ b/docs/howto/provjsonld.md
@@ -1,9 +1,8 @@
 # Work with PROV-JSONLD
 
 [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/) is a W3C member submission
-describing a JSON-LD representation of the PROV Data Model. It is selected with
-`format="jsonld"`. Like PROV-JSON, it needs no extra dependency — the serializer is
-implemented against the standard library only and is always available.
+that represents the PROV Data Model in JSON-LD. Select it with `format="jsonld"`. It needs
+no extra.
 
 ## Serialize to a file
 
@@ -53,32 +52,27 @@ print(jsonld_str)
 }
 ```
 
-A document's registered namespace prefixes (and its default namespace, as both `@vocab` and
-`@base` -- JSON-LD's `@vocab` alone does not govern `@id` values or `@id`-typed terms like
-`entity`/`activity`, so `@base` is needed too) become the first entry of `@context`; every
-unprefixed `@type` (`Entity`, `Activity`, `Generation`, ...) is resolved against the
-submission's context, referenced as the second entry. Named bundles nest as `{"@type":
-"Bundle", "@id", "@context", "@graph"}` objects inside the top-level `@graph`.
+The first entry of `@context` holds the document's namespace prefixes. The default
+namespace appears as both `@vocab` and `@base`, because `@vocab` alone does not govern
+`@id` values. The second entry references the submission's context, which resolves the
+unprefixed types such as `Entity` and `Generation`. A named bundle nests inside the
+top-level `@graph` as an object with `@type: "Bundle"`, its own `@context` and its own
+`@graph`.
 
 ## Choose how the context is referenced
 
-The `context` keyword controls how the submission's context (the second entry of
-`@context`) is emitted:
+The `context` keyword controls the second entry of `@context`:
 
-- `context="url"` (the default) references it by URL, exactly as shown above. This is the
-  smaller, more common output, but a consumer needs network access to resolve
-  `https://openprovenance.org/prov-jsonld/context.jsonld` to fully process the document as
-  JSON-LD.
-- `context="embed"` inlines the vendored context object instead, so the document is fully
-  self-contained:
+- `context="url"`, the default, references the submission's context by URL, as above. The
+  output is smaller, but a consumer needs network access to process it as JSON-LD.
+- `context="embed"` inlines the context object, so the document is self-contained:
 
   ```python
   document.serialize(format="jsonld", context="embed")
   ```
 
-Any other value raises `ValueError`. Prefer `context="embed"` when the output needs to be
-processed offline or archived without a dependency on the submission's context URL staying
-reachable.
+Any other value raises `ValueError`. Use `context="embed"` for output that will be
+archived or processed offline.
 
 ## Deserialize from a file or stream
 
@@ -102,9 +96,9 @@ loaded = pm.ProvDocument.deserialize(content=jsonld_str, format="jsonld")
 
 ## Auto-detect the format with `prov.read()`
 
-{py:func}`prov.read` tries every registered deserializer in turn — PROV-JSON, PROV-O/RDF,
-PROV-N, PROV-XML, then PROV-JSONLD last — until one both succeeds and produces a non-empty
-document:
+{py:func}`prov.read` tries PROV-JSONLD last, after the four other formats, so valid
+PROV-JSONLD still auto-detects. See {ref}`auto-detect` in the PROV-JSON guide for how
+detection works and when to pass `format=` instead.
 
 ```python
 import prov
@@ -113,16 +107,16 @@ loaded = prov.read("document.jsonld")
 assert loaded == document
 ```
 
-Passing `format="jsonld"` explicitly skips the trial-and-error and gives a proper traceback
-if the content is not valid PROV-JSONLD.
-
 ## Input scope
 
-The deserializer only accepts the submission's canonical §4 *compacted* shape — one JSON
-object per PROV-DM statement under a top-level `"@graph"`, exactly the shape this
-serializer writes. It does not run general-purpose JSON-LD processing (no expansion,
-flattening, or framing), so expanded or flattened JSON-LD that is otherwise valid
-PROV-JSONLD is rejected. Malformed or unrecognised JSON-LD raises
+The deserializer accepts the submission's compacted shape only. That is one JSON object per
+PROV-DM statement under a top-level `"@graph"`, which is the shape this serializer writes.
+It does not run a JSON-LD processor, so expanded or flattened JSON-LD is rejected even when
+it is otherwise valid PROV-JSONLD. It does accept
+[ProvToolbox](https://lucmoreau.github.io/ProvToolbox/)'s `prov:`-prefixed spellings of
+the type and special terms, such as `"prov:Entity"` and `"prov:type"`.
+
+Malformed or unrecognised JSON-LD raises
 `prov.serializers.provjsonld.ProvJSONLDException`:
 
 ```python
@@ -138,8 +132,7 @@ except ProvJSONLDException as e:
 ProvJSONLDException: A PROV-JSONLD document requires both "@context" and "@graph"; found keys ['entity']
 ```
 
-Malformed JSON itself (not valid JSON at all) raises the standard library's decoder error,
-not `ProvJSONLDException`:
+Input that is not valid JSON at all raises the standard library's decoder error instead:
 
 ```python
 try:
@@ -152,16 +145,11 @@ except Exception as e:
 JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 ```
 
-The decoder additionally tolerates [ProvToolbox](https://lucmoreau.github.io/ProvToolbox/)'s
-`prov:`-prefixed spellings of the type and special terms (`"prov:Entity"` alongside
-`"Entity"`, `"prov:type"` alongside `"type"`), so documents produced by that reference
-implementation read in without modification.
-
 ## Limitations
 
-`mentionOf` (PROV-DM's Mention relation) cannot be represented: the submission defines no
-JSON-LD term for it. `serialize()` raises `ProvJSONLDException` for any document containing
-a `ProvMention` record:
+The submission defines no term for `mentionOf`, PROV-DM's Mention relation, so
+PROV-JSONLD cannot represent it. `serialize()` raises `ProvJSONLDException` for any
+document containing a {py:class}`~prov.model.ProvMention` record:
 
 ```python
 document = pm.ProvDocument()
@@ -174,17 +162,15 @@ except ProvJSONLDException as e:
 ```
 
 ```text
-ProvJSONLDException: PROV-JSONLD cannot represent mentionOf (None): the submission defines no Mention term; see docs/reference/conformance.md
+ProvJSONLDException: PROV-JSONLD cannot represent mentionOf: the submission defines no Mention term; see docs/reference/conformance.md
 ```
 
-This is a permanent limitation of the PROV-JSONLD submission, not a gap in this library; see
-{doc}`../reference/conformance` for the full write-up alongside the equivalent PROV-O
-limitation.
+This is a limitation of the submission, not of the library. {doc}`../reference/conformance`
+records it alongside the equivalent PROV-O limitation.
 
 ## Media type and file extension
 
-The submission associates PROV-JSONLD with the `application/ld+json` media type; by
-convention, files use the `.jsonld` extension, as in the examples above. `prov` does not
-dispatch on either of these — the format is always selected via `format="jsonld"` or
-auto-detected by content — but they are worth using for interoperability with other JSON-LD
-tooling.
+The submission associates PROV-JSONLD with the `application/ld+json` media type, and files
+conventionally use the `.jsonld` extension. `prov` dispatches on neither. The format is
+selected with `format="jsonld"` or auto-detected from content. Use them anyway for
+interoperability with other JSON-LD tooling.

--- a/docs/howto/provn.md
+++ b/docs/howto/provn.md
@@ -1,17 +1,17 @@
 # Work with PROV-N
 
 ```{important}
-**PROV-N is write-only.** `prov` can produce [PROV-N](https://www.w3.org/TR/prov-n/) text,
-but there is no parser: deserializing PROV-N raises `NotImplementedError`. If you need to
-read a document back, save it in PROV-JSON, PROV-XML, PROV-O/RDF, or PROV-JSONLD instead.
+PROV-N is write-only. `prov` produces [PROV-N](https://www.w3.org/TR/prov-n/) text but has
+no parser, so deserializing PROV-N raises `NotImplementedError`. Save a document in
+PROV-JSON, PROV-JSONLD, PROV-XML or PROV-O if you need to read it back.
 ```
 
-PROV-N needs no extra dependency.
+PROV-N needs no extra.
 
 ## Get the PROV-N text directly
 
-{py:meth}`~prov.model.ProvBundle.get_provn` returns the notation as a string without going
-through the serializer registry at all — this is the simplest way to print or inspect it:
+{py:meth}`~prov.model.ProvBundle.get_provn` returns the notation as a string. This is the
+simplest way to print or inspect a document:
 
 ```python
 import prov.model as pm
@@ -28,7 +28,7 @@ print(document.get_provn())
 ## Serialize to a file
 
 `format="provn"` goes through the same {py:meth}`~prov.model.ProvDocument.serialize` API
-as the other formats, for consistency with tooling that dispatches on `format`:
+as the other formats, for tooling that dispatches on `format`:
 
 ```python
 document.serialize("document.provn", format="provn")
@@ -43,10 +43,9 @@ assert provn_str == document.get_provn()
 
 ## Attribute order is stable
 
-Attribute values are written in the order they were added to a record, in PROV-N and in
-every other format. Since 3.0.0 a record stores its attribute values insertion-ordered, so
-two runs of the same program produce the same text and PROV-N output is safe to use in
-doctests and golden files:
+A record stores its attribute values in the order they were added, and every format
+writes them in that order. Two runs of the same program produce the same text, so PROV-N
+output is safe to use in doctests and golden files:
 
 ```python
 document.entity("e2", [(pm.PROV_TYPE, "foo"), (pm.PROV_TYPE, "bar")])
@@ -56,7 +55,7 @@ print(document.get_provn())
 
 ## Deserializing raises `NotImplementedError`
 
-There is no PROV-N reader, in the library or via `prov.read()`'s auto-detection:
+There is no PROV-N reader, in the library or in `prov.read()`'s auto-detection:
 
 ```python
 try:
@@ -65,5 +64,5 @@ except NotImplementedError:
     print("PROV-N has no deserializer")
 ```
 
-If your workflow needs a round trip, keep a PROV-JSON (or PROV-XML/RDF/JSONLD) copy alongside
-any PROV-N output — see {doc}`provjson`.
+Keep a copy in another format alongside any PROV-N output if your workflow needs a round
+trip. See {doc}`provjson`.

--- a/docs/howto/provo-rdf.md
+++ b/docs/howto/provo-rdf.md
@@ -93,5 +93,24 @@ BadSyntax
 ```
 
 Two relations that share an identifier but differ in a formal attribute cannot round-trip
-through PROV-O. Decoding such RDF raises `prov.model.ProvException`.
-{doc}`../reference/conformance` explains why.
+through PROV-O, because PROV-O stores a relation as one node named by its identifier.
+Decoding such RDF raises `prov.model.ProvException`:
+
+```python
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+document.wasGeneratedBy("e1", "a1", time="2024-01-01T00:00:00", identifier="g1")
+document.wasGeneratedBy("e1", "a1", time="2024-01-02T00:00:00", identifier="g1")
+trig_str = document.serialize(format="rdf")
+
+try:
+    pm.ProvDocument.deserialize(content=trig_str, format="rdf")
+except pm.ProvException as e:
+    print(type(e).__name__)
+```
+
+```text
+ProvException
+```
+
+{doc}`../reference/conformance` explains the limitation.

--- a/docs/howto/provo-rdf.md
+++ b/docs/howto/provo-rdf.md
@@ -1,14 +1,13 @@
 # Work with PROV-O (RDF)
 
-[PROV-O](https://www.w3.org/TR/prov-o/) support needs the optional `rdflib` dependency:
+[PROV-O](https://www.w3.org/TR/prov-o/) needs the `rdf` extra, which installs `rdflib`:
 
 ```bash
 python -m pip install "prov[rdf]"
 ```
 
-The serialization format is selected with `format="rdf"`. A second, RDF-specific keyword,
-`rdf_format`, chooses the concrete RDF syntax (`"trig"` by default) — do not confuse the
-two.
+Two keywords are involved. `format="rdf"` selects PROV-O. `rdf_format` chooses the
+concrete RDF syntax and defaults to `"trig"`.
 
 ## Serialize to a file
 
@@ -24,10 +23,16 @@ document.wasGeneratedBy(e, a)
 document.serialize("document.trig", format="rdf")  # rdf_format="trig" is the default
 ```
 
+## Serialize to a string
+
+```python
+trig_str = document.serialize(format="rdf")
+```
+
 ## Choose a different RDF syntax
 
-`rdf_format` accepts anything `rdflib` can serialize to, e.g. `"turtle"`, `"xml"`
-(RDF/XML), `"nt"`, `"nquads"`:
+`rdf_format` accepts any syntax `rdflib` can write, such as `"turtle"`, `"xml"` for
+RDF/XML, `"nt"` or `"nquads"`:
 
 ```python
 turtle_str = document.serialize(format="rdf", rdf_format="turtle")
@@ -35,16 +40,10 @@ print(turtle_str)
 ```
 
 ```{important}
-Only quad-based syntaxes (`"trig"` — the default — and `"nquads"`) preserve **bundles** as
-separate named graphs. Triple-based syntaxes such as `"turtle"` or `"xml"` flatten every
-bundle's statements into a single graph, discarding which bundle each statement came from.
-Stick with the default TriG if your document has bundles.
-```
-
-## Serialize to a string
-
-```python
-trig_str = document.serialize(format="rdf")
+Only quad-based syntaxes, `"trig"` and `"nquads"`, keep bundles as separate named graphs.
+Triple-based syntaxes such as `"turtle"` and `"xml"` flatten every bundle into one graph
+and lose which bundle each statement came from. Keep the default TriG if your document has
+bundles.
 ```
 
 ## Deserialize from a file or stream
@@ -54,7 +53,7 @@ loaded = pm.ProvDocument.deserialize("document.trig", format="rdf")
 assert loaded == document
 ```
 
-Pass the matching `rdf_format` if the input is not TriG:
+Pass the matching `rdf_format` when the input is not TriG:
 
 ```python
 loaded = pm.ProvDocument.deserialize(content=turtle_str, format="rdf", rdf_format="turtle")
@@ -68,8 +67,8 @@ loaded = pm.ProvDocument.deserialize(content=trig_str, format="rdf")
 
 ## Auto-detect the format with `prov.read()`
 
-PROV-O/RDF is the second format `prov.read()` tries (after PROV-JSON), so genuine RDF
-content auto-detects reliably:
+{py:func}`prov.read` tries PROV-O second, after PROV-JSON. See {ref}`auto-detect` in the
+PROV-JSON guide for how detection works and when to pass `format=` instead.
 
 ```python
 import prov
@@ -92,3 +91,7 @@ except Exception as e:
 ```text
 BadSyntax
 ```
+
+Two relations that share an identifier but differ in a formal attribute cannot round-trip
+through PROV-O. Decoding such RDF raises `prov.model.ProvException`.
+{doc}`../reference/conformance` explains why.

--- a/docs/howto/provxml.md
+++ b/docs/howto/provxml.md
@@ -1,6 +1,6 @@
 # Work with PROV-XML
 
-[PROV-XML](https://www.w3.org/TR/prov-xml/) support needs the optional `lxml` dependency:
+[PROV-XML](https://www.w3.org/TR/prov-xml/) needs the `xml` extra, which installs `lxml`:
 
 ```bash
 python -m pip install "prov[xml]"
@@ -25,11 +25,11 @@ xml_str = document.serialize(format="xml")
 print(xml_str)
 ```
 
-## Force xsd:type attributes
+## Write `xsi:type` on every attribute
 
-By default `xsi:type` is only written for `prov:type`, `prov:location`, and `prov:value`,
-matching the PROV-XML spec examples. Pass `force_types=True` to write it for every
-non-`prov:` attribute too:
+By default `xsi:type` is written only for `prov:type`, `prov:location` and `prov:value`,
+matching the examples in the PROV-XML specification. Pass `force_types=True` to write it
+for every non-`prov:` attribute too:
 
 ```python
 xml_str_typed = document.serialize(format="xml", force_types=True)
@@ -50,34 +50,21 @@ loaded = pm.ProvDocument.deserialize(content=xml_str, format="xml")
 
 ## Auto-detect the format with `prov.read()`
 
-`prov.read()` tries each registered deserializer in turn — PROV-JSON, then PROV-O/RDF, then
-PROV-N, then PROV-XML, then PROV-JSONLD — treating any failure from a candidate as "not this
-format" and moving on to the next one, stopping at the first deserializer that both succeeds
-and produces a non-empty document. Valid PROV-XML therefore auto-detects, whether the source
-is a file path or raw content:
+{py:func}`prov.read` tries PROV-XML fourth, after PROV-JSON, PROV-O and PROV-N. Valid
+PROV-XML auto-detects from a file path, raw content or a seekable stream. See
+{ref}`auto-detect` in the PROV-JSON guide for how detection works and when to pass
+`format=` instead.
 
 ```python
 import prov
 
-loaded = prov.read("document.xml")  # no format given
-assert loaded == document
-```
-
-A seekable stream source (an open file object, `io.StringIO`, `io.BytesIO`, ...) is rewound
-between auto-detection attempts, so it also auto-detects; a non-seekable stream is consumed
-by the first candidate, so pass `format="xml"` explicitly for those.
-
-Passing `format="xml"` explicitly skips the trial-and-error and gives the real traceback if
-the content is not valid PROV-XML:
-
-```python
-loaded = prov.read("document.xml", format="xml")
+loaded = prov.read("document.xml")
 assert loaded == document
 ```
 
 ## Common errors
 
-Malformed XML raises `lxml`'s own syntax error, not a `prov`-specific exception:
+Malformed XML raises `lxml`'s own syntax error:
 
 ```python
 try:
@@ -89,3 +76,6 @@ except Exception as e:
 ```text
 XMLSyntaxError: Start tag expected, '<' not found, line 1, column 1 (<string>, line 1)
 ```
+
+The parser does not resolve external DTD entities and never touches the network. A
+document that relies on entity expansion reads back with those values empty.


### PR DESCRIPTION
Second of four PRs from the documentation review (ledger in PR #424).

Fixes: the graphics and NetworkX guides called pydot and networkx core dependencies, which stopped being true in 3.0.0; the PROV-JSON guide omitted PROV-JSONLD from the auto-detection order; the PROV-JSONLD guide quoted a stale error message; the CLI guide's format tables copied stale help text and omitted rdf and jsonld output and the compare formats beyond json and xml.

Readability: prov.read() is explained once in the PROV-JSON guide under a labelled section and linked from the other format guides; exit codes are tables; narration, em dashes and version history are gone.

Verified: sphinx-build -W is clean, every Python block in the eight guides runs as written, every prov-convert and prov-compare format in the tables was exercised, codacy-analysis reports 0 issues on the changed files.