### PR TITLE
docs: tighten the reference and explanation pages

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -3,7 +3,7 @@
 `prov` is one package, `src/prov/`, in layers that depend in one direction with one
 deliberate exception. `prov.model` imports `prov.serializers` so that `serialize()` and
 `deserialize()` can dispatch through the registry, and the format modules import
-`prov.model` back. The cycle is broken by the registry importing the format modules lazily,
+`prov.model` back. The registry breaks the cycle by importing the format modules lazily,
 on first use. Reading the layers in order gives the shape of the library.
 
 ## Layers
@@ -19,22 +19,22 @@ on first use. Reading the layers in order gives the shape of the library.
 | `prov.scripts` | The `prov-convert` and `prov-compare` command-line tools | `prov.model`, `prov.serializers` |
 
 `prov.model` is a package (`records.py`, `bundle.py`, `namespaces.py`) whose `__init__.py`
-re-exports every public name at its historic `prov.model` location, so user code imports
-from `prov.model` and never from the submodules. Both `prov.model.__init__` and
+re-exports every public name at its historic `prov.model` location. User code imports from
+`prov.model` and never from the submodules. Both `prov.model.__init__` and
 `prov.model.bundle` import `prov.serializers` at module load time.
 
 ## The object model
 
-A `ProvRecord` is a PROV type, an optional identifier, and an ordered multi-valued attribute
+A `ProvRecord` is a PROV type, an optional identifier and an ordered multi-valued attribute
 map. `ProvElement` (entity, activity, agent) and `ProvRelation` (generation, usage,
 derivation and the rest) split the PROV-DM world between them. Each concrete class declares
-its formal attributes in order; everything else on the record is an "other" attribute.
+its formal attributes in order. Everything else on the record is an "other" attribute.
 
 A {py:class}`~prov.model.ProvBundle` owns records and a namespace manager, and offers a
 factory method per record type (`entity()`, `wasGeneratedBy()`, ...). A
 {py:class}`~prov.model.ProvDocument` is a bundle that can also contain named bundles, and
 is the unit that serializes. Records are created through the bundle so that identifiers
-resolve against its namespaces; the bundle records every namespace a record mentions.
+resolve against its namespaces. The bundle records every namespace a record mentions.
 
 Two transformations produce new documents rather than mutating the original.
 {py:meth}`~prov.model.ProvDocument.flattened` lifts bundle contents to the top level, and
@@ -56,8 +56,8 @@ the only attempt that can succeed on a non-seekable stream.
 
 The registry is populated lazily, on the first call to {py:func}`prov.serializers.get` or
 {py:func}`prov.read`, by `Registry.load_serializers()`. Formats whose parser is an optional
-dependency (`rdf`, `xml`) are registered only if that dependency imports successfully;
-otherwise they are left out of the registry, so its shape depends on what is installed.
+dependency (`rdf`, `xml`) are registered only if that dependency imports successfully.
+Otherwise they are left out of the registry, so its shape depends on what is installed.
 Requesting a format that is not registered raises {py:class}`~prov.serializers.DoNotExist`,
 naming the extra to install when the format is one of the optional ones.
 
@@ -74,7 +74,7 @@ The test suite lives inside the package, at `src/prov/tests/`, and ships with it
 coverage runs once per target through a parametrised round-trip fixture. The targets are the
 in-memory model and the four round-trippable formats, PROV-JSON, PROV-XML, PROV-O and
 PROV-JSONLD. PROV-N is excluded because it is write-only. This exercises a new record type
-or attribute shape against every target at once; per-format modules keep only what is
+or attribute shape against every target at once, and per-format modules keep only what is
 specific to that format. `examples.py` holds the canonical example documents that several
 modules and the DOT smoke tests reuse, and a Hypothesis property test round-trips generated
 documents through those same four formats.

--- a/docs/explanation/prov-dm.md
+++ b/docs/explanation/prov-dm.md
@@ -1,11 +1,10 @@
 # The PROV Data Model
 
 `prov` is a Python implementation of the [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/)
-(PROV-DM). This page explains the concepts that PROV-DM defines, how they map onto the classes
-and factory methods in {py:mod}`prov.model`, and how the library thinks about identifiers and
-namespaces. It is background reading rather than a step-by-step guide: for a hands-on walk
-through building a document see {doc}`../tutorial/getting-started`, and for the exhaustive API
-listing see {doc}`../reference/index`.
+(PROV-DM). This page explains the concepts PROV-DM defines, how they map onto the classes
+and factory methods in {py:mod}`prov.model`, and how the library treats identifiers and
+namespaces. It is background reading. For a hands-on walk through building a document see
+{doc}`../tutorial/getting-started`, and for the full API see {doc}`../reference/index`.
 
 ## What provenance is
 
@@ -14,60 +13,63 @@ The W3C defines provenance as
 > a record that describes the people, institutions, entities, and activities involved in
 > producing, influencing, or delivering a piece of data or a thing.
 >
-> — [PROV-DM](https://www.w3.org/TR/prov-dm/), §1
+> [PROV-DM](https://www.w3.org/TR/prov-dm/), §1
 
-Concretely, that is a record of where something came from: the entities involved in producing
-it, the activities that acted on those entities, the agents responsible, and how all of these
-relate over time. A provenance record lets a consumer of some data answer questions such as
-"which source files was this report derived from?", "who ran the process that generated it?",
-and "was it revised after it was first published?". PROV is the W3C's interoperable model for
-expressing exactly these facts so that they can be exchanged between systems.
+In practice that is a record of where something came from. It names the entities involved
+in producing it, the activities that acted on those entities, the agents responsible, and
+how all of these relate over time. With such a record, a consumer of some data can answer
+questions such as "which source files was this report derived from?", "who ran the process
+that generated it?" and "was it revised after it was first published?". PROV is the W3C's
+interoperable model for expressing these facts so that systems can exchange them.
 
-PROV deliberately describes provenance *as asserted* — it captures someone's account of what
-happened, not an absolute truth. Two people can make different, even conflicting, assertions
-about the same thing, and both are valid PROV. This matters when we come to unification and
-flattening (see {doc}`unification-flattening`).
+PROV describes provenance as asserted. It captures someone's account of what happened,
+not an absolute truth. Two people can make different, even conflicting, assertions about
+the same thing, and both are valid PROV. This matters for unification and flattening (see
+{doc}`unification-flattening`).
 
-## The core: entities, activities, and agents
+## The core: entities, activities and agents
 
-Everything in PROV is built from three kinds of thing, which PROV-DM defines as follows
-(§5.1.1, §5.1.2, and §5.3.1 of [PROV-DM](https://www.w3.org/TR/prov-dm/)):
+Everything in PROV is built from three kinds of thing, which PROV-DM defines in §5.1.1,
+§5.1.2 and §5.3.1:
 
 - An **entity** is "a physical, digital, conceptual, or other kind of thing with some fixed
-  aspects" — a file, a document, a dataset, a physical object. In `prov` an entity is a
-  {py:class}`~prov.model.ProvEntity`, created with {py:meth}`~prov.model.ProvBundle.entity`.
+  aspects", such as a file, a document, a dataset or a physical object. In `prov` an entity
+  is a {py:class}`~prov.model.ProvEntity`, created with
+  {py:meth}`~prov.model.ProvBundle.entity`.
 - An **activity** is "something that occurs over a period of time and acts upon or with
-  entities" — running a program, editing a document, publishing a report. It is a
-  {py:class}`~prov.model.ProvActivity`, created with {py:meth}`~prov.model.ProvBundle.activity`.
+  entities", such as running a program, editing a document or publishing a report. It is a
+  {py:class}`~prov.model.ProvActivity`, created with
+  {py:meth}`~prov.model.ProvBundle.activity`.
 - An **agent** is "something that bears some form of responsibility for an activity taking
-  place, for the existence of an entity, or for another agent's activity" — a person, an
-  organisation, or a piece of software. It is a {py:class}`~prov.model.ProvAgent`, created with
-  {py:meth}`~prov.model.ProvBundle.agent`.
+  place, for the existence of an entity, or for another agent's activity", such as a person,
+  an organisation or a piece of software. It is a {py:class}`~prov.model.ProvAgent`, created
+  with {py:meth}`~prov.model.ProvBundle.agent`.
 
-The wording above is quoted from PROV-DM; the examples and the mapping to `prov` classes are
-this library's own.
+The quoted wording is PROV-DM's. The examples and the mapping to `prov` classes are this
+library's own.
 
-These three node types are joined by **relations** (edges) such as *wasGeneratedBy*,
-*used*, *wasDerivedFrom*, and *wasAssociatedWith*. In `prov`, nodes are subclasses of
+**Relations** join these three node types. Examples are *wasGeneratedBy*, *used*,
+*wasDerivedFrom* and *wasAssociatedWith*. In `prov`, nodes are subclasses of
 {py:class}`~prov.model.ProvElement` and relations are subclasses of
-{py:class}`~prov.model.ProvRelation`; both descend from {py:class}`~prov.model.ProvRecord`,
-the common base class for every PROV statement. A record carries a set of
-`(QualifiedName, value)` attribute pairs, some of which are *formal attributes* fixed per
-record type (for example, a generation's formal attributes are the entity and the activity).
+{py:class}`~prov.model.ProvRelation`. Both descend from
+{py:class}`~prov.model.ProvRecord`, the common base class for every PROV statement. A
+record carries `(QualifiedName, value)` attribute pairs. Some of these are *formal
+attributes* fixed per record type. A generation's formal attributes, for example, are the
+entity and the activity.
 
 ## The six components of PROV-DM
 
-PROV-DM organises its vocabulary into six *components*. `prov` mirrors this grouping in the
-section structure of {py:mod}`prov.model`. Every PROV-DM type and relation maps to a `prov`
-class and to a factory method on {py:class}`~prov.model.ProvBundle` (which
-{py:class}`~prov.model.ProvDocument` inherits). Many relation factories have both a canonical
-method name and a friendlier PROV-N-style alias; both are shown below and are fully
+PROV-DM organises its vocabulary into six *components*. Every PROV-DM type and relation
+maps to a `prov` class and to a factory method on {py:class}`~prov.model.ProvBundle`,
+which {py:class}`~prov.model.ProvDocument` inherits. Many relation factories have both a
+canonical method name and a PROV-N-style alias. The tables show both, and they are
 interchangeable.
 
-### Component 1 — Entities and Activities
+### Component 1: Entities and Activities
 
-The temporal backbone of provenance: entities, activities, and the relations describing how
-activities generate, use, start, end, and invalidate entities, and how they communicate.
+The temporal backbone of provenance. Entities, activities, and the relations describing
+how activities generate, use, start, end and invalidate entities, and how they
+communicate.
 
 | PROV-DM concept | `prov` class | `ProvBundle` factory method |
 | --- | --- | --- |
@@ -80,7 +82,7 @@ activities generate, use, start, end, and invalidate entities, and how they comm
 | End (*wasEndedBy*) | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` |
 | Invalidation (*wasInvalidatedBy*) | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` |
 
-### Component 2 — Derivations
+### Component 2: Derivations
 
 How one entity is derived from another, with three specialised kinds of derivation.
 
@@ -91,14 +93,14 @@ How one entity is derived from another, with three specialised kinds of derivati
 | Quotation (*wasQuotedFrom*) | {py:class}`~prov.model.ProvDerivation` | `quotation()` / `wasQuotedFrom()` |
 | Primary Source (*hadPrimarySource*) | {py:class}`~prov.model.ProvDerivation` | `primary_source()` / `hadPrimarySource()` |
 
-Revision, quotation, and primary source are, in PROV-DM, *subtypes* of derivation. `prov`
-represents all four with the single class {py:class}`~prov.model.ProvDerivation`; the three
-subtype factories add the corresponding `prov:type` (`prov:Revision`, `prov:Quotation`,
-`prov:PrimarySource`) to the record.
+Revision, quotation and primary source are PROV-DM subtypes of derivation. `prov`
+represents all four with the single class {py:class}`~prov.model.ProvDerivation`. The
+three subtype factories add the corresponding `prov:type` (`prov:Revision`,
+`prov:Quotation`, `prov:PrimarySource`) to the record.
 
-### Component 3 — Agents, Responsibility, and Influence
+### Component 3: Agents, Responsibility and Influence
 
-Who is responsible for what, and the most general relation of all — influence.
+Who is responsible for what, and the most general relation of all, influence.
 
 | PROV-DM concept | `prov` class | `ProvBundle` factory method |
 | --- | --- | --- |
@@ -108,35 +110,34 @@ Who is responsible for what, and the most general relation of all — influence.
 | Delegation (*actedOnBehalfOf*) | {py:class}`~prov.model.ProvDelegation` | `delegation()` / `actedOnBehalfOf()` |
 | Influence (*wasInfluencedBy*) | {py:class}`~prov.model.ProvInfluence` | `influence()` / `wasInfluencedBy()` |
 
-PROV-DM also defines agent *subtypes* — Person, Organization, and SoftwareAgent — and the
+PROV-DM also defines the agent subtypes Person, Organization and SoftwareAgent, and the
 Plan entity subtype used with associations. These are not separate classes or factories in
-`prov`; you express them by adding a `prov:type` attribute whose value is the pre-defined
-*qualified name* (for example, `agent("ag", {prov.PROV_TYPE: prov.PROV["Person"]})`).
-Note that the value must be a qualified name: a plain string such as `"prov:Person"` is
-stored (and serialized) as just that string, which per PROV-DM §5.7.2.4 does not denote
-the pre-defined type at all.
+`prov`. You express them by adding a `prov:type` attribute whose value is the predefined
+qualified name, for example `agent("ag", {pm.PROV_TYPE: pm.PROV["Person"]})`. The value
+must be a qualified name. A plain string such as `"prov:Person"` is stored and serialized
+as that string, which under PROV-DM §5.7.2.4 does not denote the predefined type.
 
-### Component 4 — Bundles
+### Component 4: Bundles
 
 PROV-DM defines a **bundle** as "a named set of provenance descriptions, and is itself an
 entity, so allowing provenance of provenance to be expressed"
-([PROV-DM](https://www.w3.org/TR/prov-dm/), §5.4.1). A bundle lets you attribute a body of PROV
-to whoever asserted it. In `prov`, a bundle is a {py:class}`~prov.model.ProvBundle`, and a
-{py:class}`~prov.model.ProvDocument` is the special top-level bundle that may itself contain
-named bundles.
+([PROV-DM](https://www.w3.org/TR/prov-dm/), §5.4.1). A bundle lets you attribute a body of
+PROV to whoever asserted it. In `prov` a bundle is a {py:class}`~prov.model.ProvBundle`,
+and a {py:class}`~prov.model.ProvDocument` is the top-level bundle that may contain named
+bundles.
 
 | PROV-DM concept | `prov` class | factory method |
 | --- | --- | --- |
 | Bundle | {py:class}`~prov.model.ProvBundle` | {py:meth}`ProvDocument.bundle() <prov.model.ProvDocument.bundle>` |
 
-Only a {py:class}`~prov.model.ProvDocument` may contain bundles; a plain
-{py:class}`~prov.model.ProvBundle` may not nest further. See {doc}`unification-flattening`
-for how {py:meth}`~prov.model.ProvDocument.flattened` collapses bundle contents back up into
-the document.
+Only a {py:class}`~prov.model.ProvDocument` may contain bundles. A plain
+{py:class}`~prov.model.ProvBundle` cannot nest further. {doc}`unification-flattening`
+describes how {py:meth}`~prov.model.ProvDocument.flattened` lifts bundle contents back up
+into the document.
 
-### Component 5 — Alternate Entities
+### Component 5: Alternate Entities
 
-Relations that connect different entities that present aspects of the same underlying thing.
+Relations between entities that present aspects of the same underlying thing.
 
 | PROV-DM concept | `prov` class | `ProvBundle` factory method |
 | --- | --- | --- |
@@ -144,11 +145,11 @@ Relations that connect different entities that present aspects of the same under
 | Alternate (*alternateOf*) | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` |
 | Mention (*mentionOf*) | {py:class}`~prov.model.ProvMention` | `mention()` / `mentionOf()` |
 
-Mention is a specialisation that additionally names the bundle in which the more specific
-entity is described; {py:class}`~prov.model.ProvMention` is a subclass of
+Mention is a specialisation that also names the bundle in which the more specific entity
+is described. {py:class}`~prov.model.ProvMention` is a subclass of
 {py:class}`~prov.model.ProvSpecialization`.
 
-### Component 6 — Collections
+### Component 6: Collections
 
 Entities that are collections of other entities, and membership in them.
 
@@ -158,21 +159,21 @@ Entities that are collections of other entities, and membership in them.
 | Membership (*hadMember*) | {py:class}`~prov.model.ProvMembership` | `membership()` / `hadMember()` |
 
 A collection is an ordinary {py:class}`~prov.model.ProvEntity` carrying the
-`prov:Collection` type; the `collection()` factory adds that type for you. (PROV-DM's
-`EmptyCollection` is likewise expressed as the `prov:EmptyCollection` type rather than a
-dedicated class.)
+`prov:Collection` type, which the `collection()` factory adds for you. PROV-DM's
+`EmptyCollection` is likewise expressed with the `prov:EmptyCollection` type rather than a
+dedicated class.
 
 ## Qualified names and namespaces
 
-Every identifier in PROV — of a record, and of every attribute name — is a *qualified name*:
-a namespace prefix plus a local part, such as `ex:crime`, which expands to a full IRI. This is
-the same mechanism as in XML and RDF, and it is what makes PROV documents from different
-sources interoperable: two systems agree on meaning by agreeing on IRIs, not on bare local
-names.
+Every identifier in PROV, of a record and of every attribute name, is a *qualified name*.
+It is a namespace prefix plus a local part, such as `ex:crime`, which expands to a full
+IRI. This is the same mechanism as in XML and RDF, and it is what makes PROV documents from
+different sources interoperable. Two systems agree on meaning by agreeing on IRIs, not on
+bare local names.
 
-In `prov` this is modelled by {py:class}`~prov.identifier.Namespace` and
-{py:class}`~prov.identifier.QualifiedName` in {py:mod}`prov.identifier`. A namespace bundles a
-prefix with a base URI; asking it for a local name yields a qualified name:
+`prov` models this with {py:class}`~prov.identifier.Namespace` and
+{py:class}`~prov.identifier.QualifiedName` in {py:mod}`prov.identifier`. A namespace pairs
+a prefix with a base URI. Asking it for a local name yields a qualified name:
 
 ```python
 from prov.identifier import Namespace
@@ -184,16 +185,17 @@ print(qn.uri)               # http://example.org/crime
 ```
 
 You rarely construct these by hand. A bundle keeps a `NamespaceManager` that records the
-namespaces you register and resolves prefixes as you build statements. Declare namespaces on
-a document with {py:meth}`~prov.model.ProvBundle.add_namespace` (and an optional *default*
-namespace with {py:meth}`~prov.model.ProvBundle.set_default_namespace`), after which any string
-you pass as an identifier or attribute name — `"ex:crime"`, `"crime"` — is resolved to a
-{py:class}`~prov.identifier.QualifiedName` against the registered namespaces:
+namespaces you register and resolves prefixes as you build statements. Declare namespaces
+on a document with {py:meth}`~prov.model.ProvBundle.add_namespace`, and optionally a
+default namespace with {py:meth}`~prov.model.ProvBundle.set_default_namespace`. After that,
+any string you pass as an identifier or attribute name, such as `"ex:crime"` or `"crime"`,
+is resolved to a {py:class}`~prov.identifier.QualifiedName` against the registered
+namespaces:
 
 ```python
-import prov.model as prov
+import prov.model as pm
 
-document = prov.ProvDocument()
+document = pm.ProvDocument()
 document.set_default_namespace("http://example.org/")
 document.add_namespace("ex", "http://example.org/ns#")
 
@@ -201,26 +203,26 @@ document.entity("crime")               # resolves against the default namespace
 document.entity("ex:report")           # resolves against the ex prefix
 ```
 
-A prefix must be registered before it is used; passing `"ex:report"` before adding the `ex`
-namespace raises {py:class}`~prov.model.ProvExceptionInvalidQualifiedName`. The `prov:` prefix
-for the PROV vocabulary itself is always available, which is why constants such as
-{py:data}`~prov.constants.PROV_TYPE` and {py:data}`~prov.constants.PROV_ROLE` can be used
+A prefix must be registered before it is used. Passing `"ex:report"` before adding the
+`ex` namespace raises {py:class}`~prov.model.ProvExceptionInvalidQualifiedName`. The
+`prov:` prefix for the PROV vocabulary itself is always available, which is why constants
+such as {py:data}`~prov.constants.PROV_TYPE` and {py:data}`~prov.constants.PROV_ROLE` work
 without registering anything.
 
 ## The wider PROV world
 
-PROV-DM is one document in a family of W3C Recommendations. `prov` implements the model and
-several of its serialisations:
+PROV-DM is one document in a family of W3C Recommendations. `prov` implements the model
+and several of its serializations:
 
-- [**PROV-DM**](https://www.w3.org/TR/prov-dm/) — the data model described on this page.
-- [**PROV-N**](https://www.w3.org/TR/prov-n/) — the human-readable notation, produced by
-  {py:meth}`~prov.model.ProvDocument.get_provn` and used throughout these docs. `prov` writes
-  PROV-N but does not parse it.
-- [**PROV-O**](https://www.w3.org/TR/prov-o/) — the mapping of PROV-DM onto an OWL ontology
-  for expression as RDF, handled by the `rdf` serializer.
+- [PROV-DM](https://www.w3.org/TR/prov-dm/), the data model described on this page.
+- [PROV-N](https://www.w3.org/TR/prov-n/), the human-readable notation, produced by
+  {py:meth}`~prov.model.ProvDocument.get_provn` and used throughout these docs. `prov`
+  writes PROV-N but does not parse it.
+- [PROV-O](https://www.w3.org/TR/prov-o/), the mapping of PROV-DM onto an OWL ontology for
+  expression as RDF, handled by the `rdf` serializer.
 
-`prov` additionally supports the [PROV-JSON](https://www.w3.org/submissions/prov-json/),
-PROV-XML, and [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/) serialisations. For
-choosing and using each format see the how-to guides ({doc}`../howto/provjson`,
-{doc}`../howto/provo-rdf`, {doc}`../howto/provxml`, {doc}`../howto/provn`,
-{doc}`../howto/provjsonld`).
+`prov` also supports the [PROV-JSON](https://www.w3.org/submissions/prov-json/),
+[PROV-XML](https://www.w3.org/TR/prov-xml/) and
+[PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/) serializations. The how-to
+guides ({doc}`../howto/provjson`, {doc}`../howto/provo-rdf`, {doc}`../howto/provxml`,
+{doc}`../howto/provn`, {doc}`../howto/provjsonld`) show how to use each format.

--- a/docs/explanation/prov-dm.md
+++ b/docs/explanation/prov-dm.md
@@ -115,7 +115,8 @@ Plan entity subtype used with associations. These are not separate classes or fa
 `prov`. You express them by adding a `prov:type` attribute whose value is the predefined
 qualified name, for example `agent("ag", {pm.PROV_TYPE: pm.PROV["Person"]})`. The value
 must be a qualified name. A plain string such as `"prov:Person"` is stored and serialized
-as that string, which under PROV-DM §5.7.2.4 does not denote the predefined type.
+as that literal string. Under PROV-DM §5.7.2.4 such a string does not denote the
+predefined type.
 
 ### Component 4: Bundles
 

--- a/docs/explanation/unification-flattening.md
+++ b/docs/explanation/unification-flattening.md
@@ -1,37 +1,38 @@
 # Unification and flattening
 
-A PROV document is an *account* — a set of assertions someone makes about what happened. Real
-documents accumulate structure that is convenient to build but awkward to consume: the same
-entity described in two separate statements, or facts split across named bundles. `prov`
-offers two transformations that tidy this up: {py:meth}`~prov.model.ProvDocument.flattened`
-and {py:meth}`~prov.model.ProvBundle.unified`. This page explains what each one does, shows a
-worked example of each, and explains how far `unified()` goes towards the W3C
-specification's normalization.
+A PROV document is an account, a set of assertions someone makes about what happened. Real
+documents accumulate structure that is convenient to build but awkward to consume. The
+same entity may be described in two separate statements, or facts may be split across
+named bundles. `prov` offers two transformations that tidy this up,
+{py:meth}`~prov.model.ProvDocument.flattened` and
+{py:meth}`~prov.model.ProvBundle.unified`. This page explains what each does, shows a
+worked example of each, and says how far `unified()` goes towards the W3C specification's
+normalization.
 
-Both transformations are **non-destructive**: they return a new document (or bundle) and leave
+Both transformations are non-destructive. They return a new document or bundle and leave
 the original untouched.
 
 ## Flattening
 
 A {py:class}`~prov.model.ProvDocument` may contain named bundles, each holding its own
-records. {py:meth}`~prov.model.ProvDocument.flattened` produces a new document in which every
-record from every bundle has been moved up to the top level, alongside the document's own
-records. The bundle *structure* is discarded — only the statements survive.
+records. {py:meth}`~prov.model.ProvDocument.flattened` produces a new document in which
+every record from every bundle has moved up to the top level, alongside the document's own
+records. The bundle structure is discarded. Only the statements survive.
 
-This is a purely structural move. Flattening does not merge, deduplicate, or reconcile anything;
-if the same entity is described both in the document and inside a bundle, both statements simply
-end up side by side at the top level. (If the document has no bundles, `flattened()` returns the
-document itself unchanged.)
+Flattening is a purely structural move. It does not merge, deduplicate or reconcile
+anything. If the same entity is described both in the document and inside a bundle, both
+statements end up side by side at the top level. If the document has no bundles,
+`flattened()` returns the document itself unchanged.
 
 ### Worked example
 
-Start with a document that has one top-level entity and a bundle containing two more records
-and a relation:
+Start with a document that has one top-level entity and a bundle containing two more
+records and a relation:
 
 ```python
-import prov.model as prov
+import prov.model as pm
 
-d = prov.ProvDocument()
+d = pm.ProvDocument()
 d.set_default_namespace("http://example.org/")
 d.entity("e1")
 b = d.bundle("bundle1")
@@ -55,7 +56,7 @@ document
 endDocument
 ```
 
-Calling `flattened()` lifts the bundle's three records up next to `e1` and drops the
+`flattened()` lifts the bundle's three records up next to `e1` and drops the
 `bundle … endBundle` wrapper:
 
 ```python
@@ -75,69 +76,69 @@ endDocument
 
 ## Unification
 
-{py:meth}`~prov.model.ProvBundle.unified` addresses a different kind of redundancy: the same
-thing described by more than one statement. When a document is built incrementally, or merged
-from several sources, an entity or activity may be asserted several times, each assertion
-carrying a few attributes. Unification combines those into one record.
+{py:meth}`~prov.model.ProvBundle.unified` addresses a different kind of redundancy, the
+same thing described by more than one statement. When a document is built incrementally or
+merged from several sources, an entity or activity may be asserted several times, each
+assertion carrying a few attributes. Unification combines those into one record.
 
 ### What `unified()` does
 
-For each **identifier** that appears on more than one record, `unified()` builds a single
-merged record by *term unification* of those records' formal attributes, following the key
+For each identifier that appears on more than one record, `unified()` builds a single
+merged record by term unification of those records' formal attributes, following the key
 constraints of the W3C specification. Position by position:
 
-- an **absent** formal attribute is an existential ("unknown") and unifies with anything;
-- two **equal** concrete values unify to that value;
-- two **different** concrete values do not unify, and the merge raises
+- an absent formal attribute is an existential ("unknown") and unifies with anything;
+- two equal concrete values unify to that value;
+- two different concrete values do not unify, and the merge raises
   {py:class}`~prov.model.ProvUnificationError`.
 
-The records' remaining ("extra") attributes are unioned onto the merged record. Because those
-are held in a set, identical values are deduplicated while distinct values all accumulate.
+The records' remaining ("extra") attributes are unioned onto the merged record. They are
+held in a set, so identical values are deduplicated while distinct values all accumulate.
 Records with a unique identifier, and records with no identifier at all, pass through
 untouched.
 
-`unified()` is the *only* place in `prov` that can raise over a same-identifier conflict.
-Building or asserting records — `bundle.entity(...)`, `bundle.activity(...)`, and friends —
-never checks for one, by design: PROV statements are legitimately asserted incomplete, one
-piece at a time, expecting a later `unified()` call (or none at all) to reconcile them.
-Validating a document *without* merging it is a separate, opt-in concern, tracked as
-[issue #62](https://github.com/trungdong/prov/issues/62).
+`unified()` is the only place in `prov` that can raise over a same-identifier conflict.
+Building or asserting records with `bundle.entity(...)`, `bundle.activity(...)` and the
+rest never checks for one, by design. PROV statements are legitimately asserted
+incomplete, one piece at a time, expecting a later `unified()` call, or none at all, to
+reconcile them. Validating a document without merging it is a separate, opt-in concern,
+tracked as [#62](https://github.com/trungdong/prov/issues/62).
 
 {py:meth}`ProvDocument.unified() <prov.model.ProvDocument.unified>` applies this to the
-document's top-level records and, independently, to each contained bundle, **preserving** the
-bundle structure (unlike `flattened()`) — nothing is merged across a bundle boundary, per the
-specification's §7.2. {py:meth}`ProvBundle.unified() <prov.model.ProvBundle.unified>` does it
-for a single bundle.
+document's top-level records and, independently, to each contained bundle. It preserves the
+bundle structure, unlike `flattened()`, and nothing merges across a bundle boundary, as
+§7.2 of the specification requires.
+{py:meth}`ProvBundle.unified() <prov.model.ProvBundle.unified>` does the same for a single
+bundle.
 
-Calling `flattened().unified()` — flattening a document first, then unifying the result — is a
-different, deliberate tool: because `flattened()` has already discarded the bundle structure,
-the subsequent `unified()` sees one scope and merges same-identifier records **across** what
-used to be bundle boundaries. No PROV-CONSTRAINTS rule licenses that; it is a single-instance
-view for callers who want the broadest possible merge and accept that two bundles asserting the
-same local name might describe different real-world things. `prov` keeps this idiom working
-(it is exercised in the test suite), but it sits outside PROV-CONSTRAINTS semantics — reach for
-plain `document.unified()` when per-bundle scoping matters.
+`flattened().unified()` is a different, deliberate tool. `flattened()` has already
+discarded the bundle structure, so the following `unified()` sees one scope and merges
+same-identifier records across what used to be bundle boundaries. No PROV-CONSTRAINTS rule
+licenses that. It is a single-instance view for callers who want the broadest possible
+merge and accept that two bundles asserting the same local name might describe different
+real-world things. `prov` keeps this idiom working and exercises it in the test suite, but
+it sits outside PROV-CONSTRAINTS semantics. Use plain `document.unified()` when per-bundle
+scoping matters.
 
-Four limits are worth knowing:
+Four limits apply:
 
 - **Only identifiers drive merging.** Two records merge if and only if they carry the same
   qualified-name identifier. Most PROV relations are asserted without an identifier, so
   relations are almost never unified.
 - **Records of incompatible types raise; spec-permitted overlaps stay separate.** Term
-  unification as described above applies within a group of records that share both an
-  identifier *and* a base record type. Across types sharing one identifier, `unified()`
-  consults the PROV-CONSTRAINTS type-compatibility rules (Constraints 53/54/55): an
-  `entity(x)` and an `activity(x)` sharing the identifier `x` raise
-  {py:class}`~prov.model.ProvUnificationError` naming both types — the specification makes
-  entities and activities disjoint — while an `agent(x)` and an `entity(x)` sharing `x` are
-  *not* disjoint under the specification, so `unified()` keeps them as two separate,
-  independently-merged records rather than combining or rejecting them.
+  unification applies within a group of records that share both an identifier and a base
+  record type. Across types sharing one identifier, `unified()` consults the
+  PROV-CONSTRAINTS type-compatibility rules (Constraints 53, 54 and 55). An `entity(x)` and
+  an `activity(x)` raise {py:class}`~prov.model.ProvUnificationError` naming both types,
+  because the specification makes entities and activities disjoint. An `agent(x)` and an
+  `entity(x)` are not disjoint under the specification, so `unified()` keeps them as two
+  separate, independently merged records.
 - **The placeholder `-` is not represented.** PROV-N distinguishes an omitted term from an
-  explicit `-`, which is a constant and unifies only with itself; `prov`'s model has no way to
-  express the latter (every deserializer drops the distinction), so an absent formal attribute
-  always behaves as an existential.
-- **No inference or key-based unification.** The model does not use PROV's *keys* (for example,
-  the fact that an entity has at most one generation) to unify records that lack a shared
+  explicit `-`, which is a constant and unifies only with itself. `prov`'s model has no way
+  to express the latter, and every deserializer drops the distinction, so an absent formal
+  attribute always behaves as an existential.
+- **No inference or key-based unification.** The model does not use PROV's keys (for
+  example, that an entity has at most one generation) to unify records that lack a shared
   identifier, and it draws no new conclusions.
 
 ### Worked example
@@ -145,9 +146,9 @@ Four limits are worth knowing:
 Assert the same entity `e1` twice, each time with a different attribute:
 
 ```python
-import prov.model as prov
+import prov.model as pm
 
-d = prov.ProvDocument()
+d = pm.ProvDocument()
 d.set_default_namespace("http://example.org/")
 d.add_namespace("ex", "http://example.org/ns#")
 d.entity("e1", {"ex:type": "File"})
@@ -166,7 +167,8 @@ document
 endDocument
 ```
 
-`unified()` collapses the two `e1` statements into one, with the union of their attributes:
+`unified()` collapses the two `e1` statements into one, with the union of their
+attributes:
 
 ```python
 print(d.unified().get_provn())
@@ -184,26 +186,26 @@ endDocument
 ### How this differs from the specification
 
 The W3C [PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) Recommendation defines
-*normalization* precisely, as the combination of several inference and constraint rules:
-*term unification* driven by uniqueness constraints (keys), the merging of records that these
-rules force to be equal, and the rejection of documents that violate constraints such as
-type disjointness or event ordering. A conforming normalization can conclude that two
-differently written records denote the same thing, and can declare a document *invalid*.
+*normalization* as the combination of several inference and constraint rules. These are
+term unification driven by uniqueness constraints (keys), the merging of records that
+these rules force to be equal, and the rejection of documents that violate constraints
+such as type disjointness or event ordering. A conforming normalization can conclude that
+two differently written records denote the same thing, and can declare a document invalid.
 
-`prov`'s `unified()` implements the term-unification half of that picture, keyed on the record
-identifier, and rejects documents whose same-identifier, same-type records hold irreconcilable
-attribute values, or whose same-identifier records span types the specification makes disjoint.
-Two things it does *not* do:
+`prov`'s `unified()` implements the term-unification half of that picture, keyed on the
+record identifier. It rejects documents whose same-identifier, same-type records hold
+irreconcilable attribute values, or whose same-identifier records span types the
+specification makes disjoint. Two things it does not do:
 
-- It does not perform the *inference* half. The uniqueness constraints that key on something
-  other than the record identifier (Constraints 24–29 — for example, that two generations of
-  the same entity by the same activity must be the same generation) are not applied, so
-  `unified()` never concludes that two differently identified records denote the same thing.
-  Those belong to an opt-in validation engine, tracked as
-  [issue #62](https://github.com/trungdong/prov/issues/62).
-- It does not check constraints that have nothing to do with merging, such as event ordering.
+- It does not perform the inference half. The uniqueness constraints keyed on something
+  other than the record identifier (Constraints 24 to 29, for example that two generations
+  of the same entity by the same activity must be the same generation) are not applied, so
+  `unified()` never concludes that two differently identified records denote the same
+  thing. Those belong to an opt-in validation engine, tracked as
+  [#62](https://github.com/trungdong/prov/issues/62).
+- It does not check constraints unrelated to merging, such as event ordering.
 
-So `unified()` is a normalization step, not a validator: do not rely on it to certify that a
-document is valid PROV, nor to reconcile records that do not already share an identifier. See
-the [roadmap](https://github.com/trungdong/prov/blob/master/ROADMAP.md) for where the
+So `unified()` is a normalization step, not a validator. Do not rely on it to certify that
+a document is valid PROV, or to reconcile records that do not already share an identifier.
+The [roadmap](https://github.com/trungdong/prov/blob/main/ROADMAP.md) shows where the
 validation engine sits among the planned releases.

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -38,7 +38,8 @@ This is a permanent limitation, not an open bug
 guessing attribute values on decode were both considered and rejected. Serializing such a
 document stays legal, because `prov` never enforces structural constraints at assertion
 time ([#257](https://github.com/trungdong/prov/issues/257)). `unified()` does detect the
-conflict, as part of its PROV-CONSTRAINTS support (see {doc}`../upgrading-3.0`).
+conflict, as part of its PROV-CONSTRAINTS support (see
+{doc}`../explanation/unification-flattening`).
 
 ### No `mentionOf` term in PROV-JSONLD (JSON-LD, permanent)
 
@@ -103,10 +104,8 @@ record itself as subject.
 | Quotation §5.2.3 | {py:class}`~prov.model.ProvDerivation` + `prov:Quotation` type | `quotation()` / `wasQuotedFrom()` | `wasDerivedFrom` (plus `[prov:type='prov:Quotation']`) | ✓ | ✓ | ✓ | ✓ |
 | Primary Source §5.2.4 | {py:class}`~prov.model.ProvDerivation` + `prov:PrimarySource` type | `primary_source()` / `hadPrimarySource()` | `wasDerivedFrom` (plus `[prov:type='prov:PrimarySource']`) | ✓ | ✓ | ✓ | ✓ |
 
-Revision, quotation and primary source are PROV-DM subtypes of derivation, not separate
-PROV-N records. `prov` implements all four with the single
-{py:class}`~prov.model.ProvDerivation` class. The three subtype factories call
-`derivation()` and add the corresponding `prov:type`, so `get_provn()` on a `revision()`
+The three subtypes share the {py:class}`~prov.model.ProvDerivation` class and differ only
+in `prov:type` (see {doc}`../explanation/prov-dm`), so `get_provn()` on a `revision()`
 record emits `wasDerivedFrom(..., [prov:type='prov:Revision'])` rather than a
 `wasRevisionOf(...)` keyword. `ADDITIONAL_N_MAP` carries the `wasRevisionOf`,
 `wasQuotedFrom` and `hadPrimarySource` keywords for contexts such as PROV-XML that treat
@@ -125,11 +124,8 @@ these as top-level types, but PROV-N output from this library always uses
 | Delegation §5.3.4 | {py:class}`~prov.model.ProvDelegation` | `delegation()` / `actedOnBehalfOf()` | `actedOnBehalfOf` | ✓ | ✓ | ✓ | ✓ |
 | Influence §5.3.5 | {py:class}`~prov.model.ProvInfluence` | `influence()` / `wasInfluencedBy()` | `wasInfluencedBy` | ✓ | ✓ | ✓ | ✓ |
 
-PROV-DM defines Person, Organization and SoftwareAgent as agent subtypes, and Plan as an
-entity subtype used with associations. `prov` has no dedicated classes for the agent
-subtypes. Express them with `agent("ag", {PROV_TYPE: PROV["Person"]})`. Plan needs no
-special handling, because it is an entity passed as the `plan=` argument to
-`association()`. This is a design choice, explained in {doc}`../explanation/prov-dm`.
+The agent subtypes and Plan have no dedicated classes. They are expressed through
+`prov:type` and the `plan=` argument, as {doc}`../explanation/prov-dm` explains.
 Convenience factories for the three agent subtypes and for `EmptyCollection` (Component 6)
 are tracked as [#260](https://github.com/trungdong/prov/issues/260).
 

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -1,92 +1,100 @@
 # Conformance matrix
 
-This page maps each PROV-DM concept onto `prov`'s classes and factory methods, and shows how
-well each serializer round-trips it. It's revisited at every release — last revised for the
-3.1.1 release (2026-09-10), which changed no round-trip result; the JSON-LD column was added for
-3.1.0's **PROV-JSONLD** serializer/deserializer (`format="jsonld"`, {doc}`../howto/provjsonld`).
+This page maps each PROV-DM concept to `prov`'s classes and factory methods and shows how
+each serializer round-trips it. It is revised at every release. The last revision was for
+3.1.1 (2026-09-10), which changed no round-trip result. The JSON-LD column arrived with
+3.1.0's PROV-JSONLD serializer (`format="jsonld"`, {doc}`../howto/provjsonld`).
 
-Every cell is checked directly against the current source code and the shared test suite, not
-against the spec text alone. For conceptual background on PROV-DM's six components, see
-{doc}`../explanation/prov-dm`; this page is the detailed reference underneath that explanation.
+Every cell is checked against the current source code and the shared test suite, not
+against the specification text alone. {doc}`../explanation/prov-dm` gives the conceptual
+background for PROV-DM's six components. This page is the detailed reference under it.
 
 ## Round-trip column key
 
-- **JSON** / **XML** / **RDF** / **JSON-LD** — ✓ means `deserialize(serialize(doc)) == doc` for
-  every shared test case; otherwise a caveat below explains what still fails and why. JSON-LD
-  here means [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/) (a W3C member
-  submission), implemented natively with no `rdflib`/JSON-LD-processor dependency. Its decoder
-  only accepts the submission's canonical compacted shape, not arbitrary expanded or flattened
-  JSON-LD, plus [ProvToolbox](https://lucmoreau.github.io/ProvToolbox/)'s `prov:`-prefixed
-  spellings of the type and special terms.
-- **PROV-N** — output-only: `prov` has no PROV-N parser (issue
-  [#122](https://github.com/trungdong/prov/issues/122), planned for 3.2.0), so there's nothing
-  to round-trip — the column would just show what `get_provn()` emits.
+- **JSON**, **XML**, **RDF**, **JSON-LD**. A tick means `deserialize(serialize(doc)) == doc`
+  for every shared test case. Otherwise a caveat below explains what fails and why. JSON-LD
+  means [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), a W3C member
+  submission, implemented without `rdflib` or a JSON-LD processor. Its decoder accepts the
+  submission's compacted shape only, plus
+  [ProvToolbox](https://lucmoreau.github.io/ProvToolbox/)'s `prov:`-prefixed spellings of
+  the type and special terms.
+- **PROV-N** is output only. `prov` has no PROV-N parser
+  ([#122](https://github.com/trungdong/prov/issues/122), planned for 3.2.0), so there is
+  nothing to round-trip. The column shows the keyword `get_provn()` emits.
 
-More caveats apply across many rows rather than to one:
+## Caveats that span several rows
 
-- **Two relations, same identifier, different `prov:time`** (RDF, permanent —
-  [#217](https://github.com/trungdong/prov/issues/217)): PROV-O represents a relation such as
-  `wasGeneratedBy` as one RDF node named by the relation's own identifier. If two asserted
-  relations share an identifier but differ only in `prov:time`, PROV-O has no way to keep their
-  `prov:atTime` values apart — both end up on the same node. This affects only that exact
-  construct: a normal document round-trips cleanly, and JSON, XML, PROV-N and the in-memory model
-  are unaffected. Decoding third-party RDF shaped this way raises `prov.model.ProvException`
-  naming the limitation. This is a permanent limitation, not an open bug — minting a synthetic
-  IRI or guessing at attribute values on decode were both considered and rejected. Plain
-  serialization of such documents remains legal (`prov` never enforces structural constraints at
-  assertion time, [#257](https://github.com/trungdong/prov/issues/257)); `unified()` does detect
-  the conflict, as part of PROV-CONSTRAINTS support (see {doc}`../upgrading-3.0`).
-- **No `mentionOf` term in PROV-JSONLD** (JSON-LD, permanent —
-  [#248](https://github.com/trungdong/prov/issues/248)): the PROV-JSONLD submission defines no
-  term for PROV-DM's Mention relation, so there's no shape `prov` could encode it in.
-  Serializing or deserializing a document containing a
-  {py:class}`~prov.model.ProvMention` record raises
-  `prov.serializers.provjsonld.ProvJSONLDException`. Every other relation and element round-trips
-  through PROV-JSONLD cleanly, including the same-identifier/differing-time cases above — PROV-O
-  is the one that has trouble there, not PROV-JSONLD.
-- **RDF's `json-ld` output is not PROV-JSONLD**: `rdf_format="json-ld"` runs the PROV-O graph
-  through rdflib's generic RDF→JSON-LD writer, not the PROV-JSONLD submission's compacted shape
-  — the two just share a name, and it inherits every PROV-O limitation above. For actual
-  PROV-JSONLD, use `format="jsonld"` instead.
-- **XML escapes illegal attribute names** (XML, permanent convention —
-  [#289](https://github.com/trungdong/prov/issues/289)): an attribute name is written as a
-  PROV-XML child element tag, but its local part isn't guaranteed to be a legal XML NCName — it
-  may start with a digit or contain characters such as `' ( ) , : ; [ ] =`. `prov` escapes each
-  illegal character using the `_xHHHH_` convention (the same one OpenXML/SQL Server use for this
-  problem) and reverses it on read, so such names round-trip losslessly; already-legal names are
-  emitted unchanged. One caveat: a third-party document that already contains a literal
-  `_xHHHH_`-shaped attribute name will be unescaped on read, since the convention can't tell an
-  intentional escape from one that merely looks like one.
-- **Some attribute keys can fail to round-trip through RDF** (RDF, open bug —
-  [#341](https://github.com/trungdong/prov/issues/341)): an attribute key whose local part *ends*
-  in one of `= ' , : ; [ ]` can fail to decode from PROV-O, because rdflib can't split that IRI
-  into namespace + local part without some other identifier in the same namespace having already
-  registered it during decoding. So the failure is order-dependent rather than universal — the
-  same key round-trips fine whenever a clean sibling in its namespace happens to decode first.
-  Attribute *values* aren't affected, and PROV-N, PROV-JSON and PROV-XML all round-trip these
-  keys correctly — PROV-O is the odd one out, as with the same-identifier limitation above.
-  Unlike that one, this is not a decided permanent limitation — it remains open for a fix. See
-  the issue for the exact conditions and affected code paths.
+### Two relations with the same identifier and different `prov:time` (RDF, permanent)
 
-## Component 1 — Entities and Activities
+PROV-O represents a relation such as `wasGeneratedBy` as one RDF node named by the
+relation's identifier. If two asserted relations share an identifier and differ only in
+`prov:time`, PROV-O has nowhere to keep the two `prov:atTime` values apart. Both land on
+the same node. Only that exact construct is affected. A normal document round-trips
+cleanly, and JSON, XML, PROV-N and the in-memory model are unaffected. Decoding
+third-party RDF shaped this way raises `prov.model.ProvException` naming the limitation.
+
+This is a permanent limitation, not an open bug
+([#217](https://github.com/trungdong/prov/issues/217)). Minting a synthetic IRI and
+guessing attribute values on decode were both considered and rejected. Serializing such a
+document stays legal, because `prov` never enforces structural constraints at assertion
+time ([#257](https://github.com/trungdong/prov/issues/257)). `unified()` does detect the
+conflict, as part of its PROV-CONSTRAINTS support (see {doc}`../upgrading-3.0`).
+
+### No `mentionOf` term in PROV-JSONLD (JSON-LD, permanent)
+
+The PROV-JSONLD submission defines no term for PROV-DM's Mention relation, so there is no
+shape `prov` could encode it in ([#248](https://github.com/trungdong/prov/issues/248)).
+Serializing or deserializing a document containing a {py:class}`~prov.model.ProvMention`
+record raises `prov.serializers.provjsonld.ProvJSONLDException`. Every other relation and
+element round-trips through PROV-JSONLD, including the same-identifier cases above, which
+trouble PROV-O only.
+
+### RDF's `json-ld` output is not PROV-JSONLD
+
+`rdf_format="json-ld"` runs the PROV-O graph through rdflib's generic JSON-LD writer. The
+result is not the PROV-JSONLD submission's compacted shape, and it inherits every PROV-O
+limitation above. Use `format="jsonld"` for PROV-JSONLD.
+
+### XML escapes illegal attribute names (XML, permanent convention)
+
+An attribute name is written as a PROV-XML child element tag, but its local part need not
+be a legal XML NCName. It may start with a digit or contain characters such as
+`' ( ) , : ; [ ] =`. `prov` escapes each illegal character with the `_xHHHH_` convention,
+the same one OpenXML and SQL Server use, and reverses it on read, so such names round-trip
+([#289](https://github.com/trungdong/prov/issues/289)). Legal names are written unchanged.
+One consequence is that a third-party document whose attribute name already looks like an
+`_xHHHH_` escape is unescaped on read.
+
+### Some attribute keys can fail to round-trip through RDF (RDF, open bug)
+
+An attribute key whose local part ends in one of `= ' , : ; [ ]` can fail to decode from
+PROV-O ([#341](https://github.com/trungdong/prov/issues/341)). rdflib cannot split such an
+IRI into namespace and local part unless another identifier in the same namespace has
+already registered it during decoding, so the failure depends on decode order rather than
+being universal. Attribute values are unaffected, and PROV-N, PROV-JSON and PROV-XML
+round-trip these keys. Unlike the same-identifier limitation, this one remains open for a
+fix. The issue lists the exact conditions.
+
+## Component 1: Entities and Activities
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Entity §5.1.1 | {py:class}`~prov.model.ProvEntity` | `entity()` | `entity` | ✓ | ✓ | ✓ | ✓ |
 | Activity §5.1.2 | {py:class}`~prov.model.ProvActivity` | `activity()` | `activity` | ✓ | ✓ | ✓ | ✓ |
-| Generation §5.1.3 | {py:class}`~prov.model.ProvGeneration` | `generation()` / `wasGeneratedBy()` | `wasGeneratedBy` | ✓ | ✓ | ✓ (permanent PROV-O limitation for the 2 same-id/differing-time cases — see above) | ✓ |
-| Usage §5.1.4 | {py:class}`~prov.model.ProvUsage` | `usage()` / `used()` | `used` | ✓ | ✓ | ✓ (permanent PROV-O limitation for the 2 same-id/differing-time cases — see above) | ✓ |
+| Generation §5.1.3 | {py:class}`~prov.model.ProvGeneration` | `generation()` / `wasGeneratedBy()` | `wasGeneratedBy` | ✓ | ✓ | ✓ (same-identifier caveat: 2 cases) | ✓ |
+| Usage §5.1.4 | {py:class}`~prov.model.ProvUsage` | `usage()` / `used()` | `used` | ✓ | ✓ | ✓ (same-identifier caveat: 2 cases) | ✓ |
 | Communication §5.1.5 | {py:class}`~prov.model.ProvCommunication` | `communication()` / `wasInformedBy()` | `wasInformedBy` | ✓ | ✓ | ✓ | ✓ |
-| Start §5.1.6 | {py:class}`~prov.model.ProvStart` | `start()` / `wasStartedBy()` | `wasStartedBy` | ✓ | ✓ | ✓ (permanent PROV-O limitation for the 4 same-id/differing-time cases — see above) | ✓ |
-| End §5.1.7 | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` | `wasEndedBy` | ✓ | ✓ | ✓ (permanent PROV-O limitation for the 4 same-id/differing-time cases — see above) | ✓ |
-| Invalidation §5.1.8 | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` | `wasInvalidatedBy` | ✓ | ✓ | ✓ (permanent PROV-O limitation for the 2 same-id/differing-time cases — see above) | ✓ |
+| Start §5.1.6 | {py:class}`~prov.model.ProvStart` | `start()` / `wasStartedBy()` | `wasStartedBy` | ✓ | ✓ | ✓ (same-identifier caveat: 4 cases) | ✓ |
+| End §5.1.7 | {py:class}`~prov.model.ProvEnd` | `end()` / `wasEndedBy()` | `wasEndedBy` | ✓ | ✓ | ✓ (same-identifier caveat: 4 cases) | ✓ |
+| Invalidation §5.1.8 | {py:class}`~prov.model.ProvInvalidation` | `invalidation()` / `wasInvalidatedBy()` | `wasInvalidatedBy` | ✓ | ✓ | ✓ (same-identifier caveat: 2 cases) | ✓ |
 
-{py:class}`~prov.model.ProvEntity` additionally exposes `wasGeneratedBy()`/`wasInvalidatedBy()`
-and {py:class}`~prov.model.ProvActivity` exposes
-`used()`/`wasInformedBy()`/`wasStartedBy()`/`wasEndedBy()` as self-as-subject chaining
-methods — the table above lists the `ProvBundle` factories, which every relation also has.
+The table lists the {py:class}`~prov.model.ProvBundle` factories, which every relation
+has. {py:class}`~prov.model.ProvEntity` also exposes `wasGeneratedBy()` and
+`wasInvalidatedBy()`, and {py:class}`~prov.model.ProvActivity` exposes `used()`,
+`wasInformedBy()`, `wasStartedBy()` and `wasEndedBy()`, as chaining methods with the
+record itself as subject.
 
-## Component 2 — Derivations
+## Component 2: Derivations
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -95,92 +103,94 @@ methods — the table above lists the `ProvBundle` factories, which every relati
 | Quotation §5.2.3 | {py:class}`~prov.model.ProvDerivation` + `prov:Quotation` type | `quotation()` / `wasQuotedFrom()` | `wasDerivedFrom` (plus `[prov:type='prov:Quotation']`) | ✓ | ✓ | ✓ | ✓ |
 | Primary Source §5.2.4 | {py:class}`~prov.model.ProvDerivation` + `prov:PrimarySource` type | `primary_source()` / `hadPrimarySource()` | `wasDerivedFrom` (plus `[prov:type='prov:PrimarySource']`) | ✓ | ✓ | ✓ | ✓ |
 
-Revision, quotation, and primary source are PROV-DM *subtypes* of derivation, not separate PROV-N
-records: `prov` implements all four with the single {py:class}`~prov.model.ProvDerivation` class,
-and the three subtype factories call `derivation()` then add the corresponding `prov:type` —
-`get_provn()` on a `revision()` record emits `wasDerivedFrom(..., [prov:type='prov:Revision'])`,
-not a `wasRevisionOf(...)` keyword. `ADDITIONAL_N_MAP` does carry a
-`wasRevisionOf`/`wasQuotedFrom`/`hadPrimarySource` keyword mapping for contexts (such as
-PROV-XML) that treat these as top-level types, but PROV-N output from this library always uses
-the base `wasDerivedFrom` form.
+Revision, quotation and primary source are PROV-DM subtypes of derivation, not separate
+PROV-N records. `prov` implements all four with the single
+{py:class}`~prov.model.ProvDerivation` class. The three subtype factories call
+`derivation()` and add the corresponding `prov:type`, so `get_provn()` on a `revision()`
+record emits `wasDerivedFrom(..., [prov:type='prov:Revision'])` rather than a
+`wasRevisionOf(...)` keyword. `ADDITIONAL_N_MAP` carries the `wasRevisionOf`,
+`wasQuotedFrom` and `hadPrimarySource` keywords for contexts such as PROV-XML that treat
+these as top-level types, but PROV-N output from this library always uses
+`wasDerivedFrom`.
 
-## Component 3 — Agents, Responsibility, and Influence
+## Component 3: Agents, Responsibility and Influence
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Agent §5.3.1 | {py:class}`~prov.model.ProvAgent` | `agent()` | `agent` | ✓ | ✓ | ✓ | ✓ |
-| Person / Organization / SoftwareAgent §5.3.1 | via `prov:type` on {py:class}`~prov.model.ProvAgent` | none — see finding below | `person` / `organization` / `softwareAgent` (`ADDITIONAL_N_MAP`, not emitted directly by this library) | ✓ | ✓ | ✓ | ✓ |
+| Person / Organization / SoftwareAgent §5.3.1 | `prov:type` on {py:class}`~prov.model.ProvAgent` | none (see below) | `person` / `organization` / `softwareAgent` (`ADDITIONAL_N_MAP`, not emitted by this library) | ✓ | ✓ | ✓ | ✓ |
 | Attribution §5.3.2 | {py:class}`~prov.model.ProvAttribution` | `attribution()` / `wasAttributedTo()` | `wasAttributedTo` | ✓ | ✓ | ✓ | ✓ |
 | Association §5.3.3 | {py:class}`~prov.model.ProvAssociation` | `association()` / `wasAssociatedWith()` | `wasAssociatedWith` | ✓ | ✓ | ✓ | ✓ |
-| Plan §5.3.3 | via `association(plan=...)` | — | — (plan is an ordinary entity referenced by the association's `plan` formal attribute) | ✓ | ✓ | ✓ | ✓ |
+| Plan §5.3.3 | `association(plan=...)` | none | none (the plan is an ordinary entity referenced by the association's `plan` formal attribute) | ✓ | ✓ | ✓ | ✓ |
 | Delegation §5.3.4 | {py:class}`~prov.model.ProvDelegation` | `delegation()` / `actedOnBehalfOf()` | `actedOnBehalfOf` | ✓ | ✓ | ✓ | ✓ |
 | Influence §5.3.5 | {py:class}`~prov.model.ProvInfluence` | `influence()` / `wasInfluencedBy()` | `wasInfluencedBy` | ✓ | ✓ | ✓ | ✓ |
 
-**Finding:** PROV-DM defines Person, Organization, and SoftwareAgent as agent subtypes, and Plan
-as an entity subtype used with associations. `prov` has no dedicated classes for the agent
-subtypes — express them with `agent("ag", {PROV_TYPE: PROV["Person"]})` — and Plan needs no
-special handling at all, since it's just an entity passed as the `plan=` argument to
-`association()`. This is an intentional design choice, not a defect (see
-{doc}`../explanation/prov-dm`). Convenience factories for the three agent subtypes, together
-with `EmptyCollection` (see Component 6), are tracked as
-[#260](https://github.com/trungdong/prov/issues/260).
+PROV-DM defines Person, Organization and SoftwareAgent as agent subtypes, and Plan as an
+entity subtype used with associations. `prov` has no dedicated classes for the agent
+subtypes. Express them with `agent("ag", {PROV_TYPE: PROV["Person"]})`. Plan needs no
+special handling, because it is an entity passed as the `plan=` argument to
+`association()`. This is a design choice, explained in {doc}`../explanation/prov-dm`.
+Convenience factories for the three agent subtypes and for `EmptyCollection` (Component 6)
+are tracked as [#260](https://github.com/trungdong/prov/issues/260).
 
-## Component 4 — Bundles
+## Component 4: Bundles
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Bundle constructor §5.4.1 | {py:class}`~prov.model.ProvBundle` | `ProvDocument.bundle()` / `add_bundle()` | `bundle <id> ... endBundle` (structural, hand-emitted by `get_provn()`) | ✓ | ✓ | ✓ | ✓ |
-| Bundle type §5.4.2 | not implemented — see finding below | — | — | — | — | — | — |
+| Bundle constructor §5.4.1 | {py:class}`~prov.model.ProvBundle` | `ProvDocument.bundle()` / `add_bundle()` | `bundle <id> ... endBundle` (structural, emitted by `get_provn()`) | ✓ | ✓ | ✓ | ✓ |
+| Bundle type §5.4.2 | not implemented (see below) | | | | | | |
 
-**Finding:** PROV-DM §5.4.1 defines bundle *containment* — a named, nestable set of records —
-which `prov` fully implements via `ProvDocument.bundle()`/`add_bundle()`; only a
-{py:class}`~prov.model.ProvDocument` may contain named bundles. §5.4.2 additionally lets a
-bundle's identifier denote a first-class entity of type `prov:Bundle`, so that
-provenance-of-provenance (e.g. "who asserted this bundle") can itself be expressed in PROV. That
-second half is **not implemented**: no serializer or {py:class}`~prov.model.ProvBundle` method
-ever produces a `prov:Bundle`-typed entity, so there is currently no supported way to attribute a
-bundle to an agent as a first-class PROV statement. Tracked as
-[#261](https://github.com/trungdong/prov/issues/261).
+PROV-DM §5.4.1 defines bundle containment, a named and nestable set of records, which
+`prov` implements through `ProvDocument.bundle()` and `add_bundle()`. Only a
+{py:class}`~prov.model.ProvDocument` may contain named bundles. §5.4.2 also lets a
+bundle's identifier denote a first-class entity of type `prov:Bundle`, so that the
+provenance of the bundle itself can be expressed in PROV. That second half is not
+implemented. No serializer or {py:class}`~prov.model.ProvBundle` method produces a
+`prov:Bundle`-typed entity, so there is no supported way to attribute a bundle to an agent
+as a PROV statement. Tracked as [#261](https://github.com/trungdong/prov/issues/261).
 
-## Component 5 — Alternate Entities
+## Component 5: Alternate Entities
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Specialization §5.5.1 | {py:class}`~prov.model.ProvSpecialization` | `specialization()` / `specializationOf()` | `specializationOf` | ✓ | ✓ | ✓ | ✓ |
-| Alternate §5.5.2 | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` | `alternateOf` | ✓ | ✓ | ✓ (`alternate(alt1, alt2)` emits `alt1 prov:alternateOf alt2`, matching PROV-DM's argument order: [#258](https://github.com/trungdong/prov/issues/258)) | ✓ |
-| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` (emitted as a bare keyword rather than the `prov:`-prefixed form the PROV-Links grammar technically requires — a deliberate deviation matching the de-facto output of reference implementations, so `provconvert` still parses it: [#248](https://github.com/trungdong/prov/issues/248)) | ✓ | ✓ | ✓ | ✗ (permanent PROV-JSONLD Mention gap — see above) |
+| Alternate §5.5.2 | {py:class}`~prov.model.ProvAlternate` | `alternate()` / `alternateOf()` | `alternateOf` | ✓ | ✓ | ✓ (`alternate(alt1, alt2)` emits `alt1 prov:alternateOf alt2`, PROV-DM's argument order: [#258](https://github.com/trungdong/prov/issues/258)) | ✓ |
+| Mention (PROV-LINKS) | {py:class}`~prov.model.ProvMention` (subclass of {py:class}`~prov.model.ProvSpecialization`) | `mention()` / `mentionOf()` | `mentionOf` (see below) | ✓ | ✓ | ✓ | ✗ (no Mention term, see above) |
 
-## Component 6 — Collections
+PROV-N output emits Mention as the bare keyword `mentionOf` rather than the
+`prov:mentionOf` form the PROV-LINKS grammar requires. This is a deliberate deviation
+matching the reference implementations, so `provconvert` still parses it
+([#248](https://github.com/trungdong/prov/issues/248)).
+
+## Component 6: Collections
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Collection §5.6 | {py:class}`~prov.model.ProvEntity` + `prov:Collection` type | `collection()` | `entity` (plus `[prov:type='prov:Collection']`) | ✓ | ✓ | ✓ | ✓ |
-| EmptyCollection §5.6 | {py:class}`~prov.model.ProvEntity` + `prov:EmptyCollection` type — no dedicated factory | none — see finding below | `entity` (plus `[prov:type='prov:EmptyCollection']`, keyword `emptyCollection` in `ADDITIONAL_N_MAP`, not emitted directly) | ✓ | ✓ | ✓ | ✓ |
+| EmptyCollection §5.6 | {py:class}`~prov.model.ProvEntity` + `prov:EmptyCollection` type | none (see below) | `entity` (plus `[prov:type='prov:EmptyCollection']`; the `emptyCollection` keyword in `ADDITIONAL_N_MAP` is not emitted) | ✓ | ✓ | ✓ | ✓ |
 | Membership §5.6 | {py:class}`~prov.model.ProvMembership` | `membership()` / `hadMember()` | `hadMember` | ✓ | ✓ | ✓ | ✓ |
 
-**Finding:** like collections, `EmptyCollection` is a real PROV-DM type that the round-trip
-machinery understands, but there's no `empty_collection()` factory or `empty=` flag on
-`collection()` to set the type for you — you'd add `prov:type: PROV["EmptyCollection"]` by hand
-via `other_attributes`. Tracked (together with the agent-subtype factories, see Component 3) as
-[#260](https://github.com/trungdong/prov/issues/260).
+`EmptyCollection` is a PROV-DM type the round-trip machinery understands, but there is no
+`empty_collection()` factory or `empty=` flag on `collection()`. Add
+`prov:type: PROV["EmptyCollection"]` through `other_attributes`. Tracked, together with
+the agent-subtype factories, as [#260](https://github.com/trungdong/prov/issues/260).
 
 ## Additional attributes
 
-Five PROV-DM attributes are usable on (almost) any record and are exercised directly by the
-shared attribute test matrix:
+Five PROV-DM attributes are usable on almost any record. The shared attribute test matrix
+exercises each directly.
 
 | Attribute | Constant (`prov.constants`) | Round-trip notes |
 | --- | --- | --- |
 | `prov:label` | `PROV_LABEL` | ✓ JSON/XML/RDF/JSON-LD, including language-tagged literals and multiple values on one record. |
 | `prov:location` | `PROV_LOCATION` | ✓ JSON/XML/RDF/JSON-LD across the full datatype corpus. |
-| `prov:role` | `PROV_ROLE` | ✓ JSON/XML/RDF/JSON-LD; used throughout the qualified-relation tests (association, usage, generation, ...). |
+| `prov:role` | `PROV_ROLE` | ✓ JSON/XML/RDF/JSON-LD; used throughout the qualified-relation tests. |
 | `prov:type` | `PROV_TYPE` | ✓ JSON/XML/RDF/JSON-LD, including mixed multi-datatype attribute sets on one record. |
 | `prov:value` | `PROV_VALUE` | ✓ JSON/XML/RDF/JSON-LD. |
 
-## Maintenance
+## Related pages
 
-This page should be revisited at each release as serializers change or issues close. For
-merge-time conformance (PROV-CONSTRAINTS unification, not covered by the round-trip tables
-above), see {doc}`../explanation/unification-flattening`. For conceptual background on each
-component, see {doc}`../explanation/prov-dm`, and for the full class/method API reference, see
-{doc}`model`.
+{doc}`../explanation/unification-flattening` covers merge-time conformance
+(PROV-CONSTRAINTS unification), which the round-trip tables above do not.
+{doc}`../explanation/prov-dm` gives the background for each component, and {doc}`model`
+is the class and method reference.

--- a/docs/reference/constants.md
+++ b/docs/reference/constants.md
@@ -1,13 +1,13 @@
 # prov.constants
 
-`prov.constants` defines the PROV-DM/PROV-O vocabulary as module-level data: one
-{py:class}`~prov.identifier.QualifiedName` constant per record type and per formal attribute
-(`PROV_ENTITY`, `PROV_ACTIVITY`, `PROV_ATTR_TIME`, ...), plus the lookup tables used to
-translate between them and the Python classes — `PROV_N_MAP` (record type to PROV-N keyword),
-`PROV_BASE_CLS` (record type to base class), and the various `PROV_ATTRIBUTE*`/`PROV_RECORD*`
-sets and dicts consulted while parsing and serializing. `prov.model` imports this module with
-`from prov.constants import *`, so these names are also available as `prov.model.PROV_*`; they
-are documented here, once, to avoid duplicate entries.
+`prov.constants` defines the PROV-DM and PROV-O vocabulary as module-level data. There is
+one {py:class}`~prov.identifier.QualifiedName` constant per record type and per formal
+attribute (`PROV_ENTITY`, `PROV_ACTIVITY`, `PROV_ATTR_TIME` and so on), plus the lookup
+tables that translate between them and the Python classes. `PROV_N_MAP` maps a record type
+to its PROV-N keyword and `PROV_BASE_CLS` to its base class. The `PROV_ATTRIBUTE*` and
+`PROV_RECORD*` sets and dicts are consulted while parsing and serializing. `prov.model`
+re-exports all of these, so they are also available as `prov.model.PROV_*`. They are
+documented here once.
 
 ```{eval-rst}
 .. automodule:: prov.constants

--- a/docs/reference/dot.md
+++ b/docs/reference/dot.md
@@ -1,9 +1,10 @@
 # prov.dot
 
-`prov.dot` renders a {py:class}`~prov.model.ProvBundle`/{py:class}`~prov.model.ProvDocument`
-as a [pydot](https://pypi.org/project/pydot/) `Dot` graph, which can then be written out as
-PNG, SVG, or PDF via a local [Graphviz](https://graphviz.org/) install. See
-{doc}`../howto/graphics` for the Graphviz setup notes and end-to-end examples.
+`prov.dot` renders a {py:class}`~prov.model.ProvBundle` or
+{py:class}`~prov.model.ProvDocument` as a [pydot](https://pypi.org/project/pydot/) `Dot`
+graph, which a local [Graphviz](https://graphviz.org/) install writes out as PNG, SVG or
+PDF. It needs the `dot` extra. {doc}`../howto/graphics` covers the Graphviz setup and
+worked examples.
 
 ```{eval-rst}
 .. autofunction:: prov.dot.prov_to_dot

--- a/docs/reference/graph.md
+++ b/docs/reference/graph.md
@@ -1,10 +1,9 @@
 # prov.graph
 
 `prov.graph` converts between a {py:class}`~prov.model.ProvDocument` and a
-[NetworkX](https://networkx.org/) `MultiDiGraph`, one node per element (entity, activity,
-agent) and one edge per relation, so graph algorithms NetworkX provides (and `prov` does
-not implement) can run directly over a provenance graph. See {doc}`../howto/networkx` for
-worked examples.
+[NetworkX](https://networkx.org/) `MultiDiGraph`, with one node per element (entity,
+activity, agent) and one edge per relation, so NetworkX's graph algorithms can run over a
+provenance graph. It needs the `graph` extra. {doc}`../howto/networkx` has worked examples.
 
 ```{eval-rst}
 .. autofunction:: prov.graph.prov_to_graph

--- a/docs/reference/identifier.md
+++ b/docs/reference/identifier.md
@@ -1,12 +1,12 @@
 # prov.identifier
 
-`prov.identifier` implements PROV's namespaced identifiers: a {py:class}`~prov.identifier.Namespace`
-groups identifiers under a URI and an optional prefix, and a
-{py:class}`~prov.identifier.QualifiedName` combines a namespace with a local part to name
-entities, activities, agents, and attributes. {py:class}`~prov.identifier.Identifier` is the
-common base, also used directly to represent `xsd:anyURI` values. `prov.model.NamespaceManager`
-(see {doc}`model`) tracks the namespaces registered on a bundle and resolves prefixes during
-parsing and serialization.
+`prov.identifier` implements PROV's namespaced identifiers. A
+{py:class}`~prov.identifier.Namespace` groups identifiers under a URI and an optional
+prefix. A {py:class}`~prov.identifier.QualifiedName` combines a namespace with a local
+part to name entities, activities, agents and attributes.
+{py:class}`~prov.identifier.Identifier` is the common base class, and is also used on its
+own for `xsd:anyURI` values. `prov.model.NamespaceManager` (see {doc}`model`) tracks the
+namespaces registered on a bundle and resolves prefixes during parsing and serialization.
 
 ```{eval-rst}
 .. autoclass:: prov.identifier.Identifier

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,14 +1,13 @@
 # API reference
 
 This section documents every public class and function in `prov`, module by module, with
-their type hints as shipped in the source (`prov` ships inline types via `py.typed`). It is
-organised by concept rather than alphabetically — start with {doc}`model` for the core object
-model, then follow the links below for identifiers, the PROV vocabulary, serializers, and the
-graph/graphics interop modules, plus the {doc}`conformance` matrix mapping every PROV-DM concept
-to its `prov` class, factory method, and serializer round-trip status. For task-oriented
-walkthroughs, see the {doc}`../tutorial/getting-started`
-and the {doc}`../howto/provjson`/{doc}`../howto/provjsonld` (and their sibling how-to pages)
-instead.
+the type hints shipped in the source. Start with {doc}`model` for the core object model.
+The other pages cover identifiers, the PROV vocabulary, serializers and the graph and
+graphics modules. {doc}`conformance` maps every PROV-DM concept to its class, factory
+method and round-trip status per format.
+
+For task-oriented guidance see the {doc}`../tutorial/getting-started` and the how-to
+guides.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -1,13 +1,13 @@
 # prov.model
 
-`prov.model` is the core of the library: the in-memory object model for
-[PROV-DM](https://www.w3.org/TR/prov-dm/) documents. A {py:class}`~prov.model.ProvDocument`
-contains {py:class}`~prov.model.ProvBundle`\ s of records — elements (entities, activities,
-agents) and relations between them — plus the namespace machinery used to build and resolve
-their identifiers. See the {doc}`../tutorial/getting-started` for a walk-through of building
-a document with this API, and the
-[PROV-DM Primer](https://www.w3.org/TR/prov-primer/) for the concepts behind the classes
-below.
+`prov.model` is the in-memory object model for [PROV-DM](https://www.w3.org/TR/prov-dm/)
+documents. A {py:class}`~prov.model.ProvDocument` contains
+{py:class}`~prov.model.ProvBundle` objects, which hold records. Records are elements
+(entities, activities, agents) and the relations between them. The namespace machinery
+that builds and resolves their identifiers lives here too. The
+{doc}`../tutorial/getting-started` walks through building a document with this API, and
+the [PROV-DM Primer](https://www.w3.org/TR/prov-primer/) covers the concepts behind the
+classes.
 
 ## Documents and bundles
 

--- a/docs/reference/serializers.md
+++ b/docs/reference/serializers.md
@@ -1,13 +1,13 @@
 # prov.serializers
 
-`prov.serializers` defines the pluggable serializer interface used by
+`prov.serializers` defines the serializer interface behind
 {py:meth}`ProvDocument.serialize() <prov.model.ProvDocument.serialize>` and
-{py:meth}`ProvDocument.deserialize() <prov.model.ProvDocument.deserialize>`, and the registry
-that looks up the serializer class for a given format string (`"json"`, `"xml"`, `"rdf"`,
-`"provn"`, `"jsonld"`). For how to use each format, see the {doc}`../howto/provjson`,
-{doc}`../howto/provxml`, {doc}`../howto/provo-rdf`, {doc}`../howto/provn`, and
-{doc}`../howto/provjsonld` how-to guides; this page documents the underlying interface and
-registry only.
+{py:meth}`ProvDocument.deserialize() <prov.model.ProvDocument.deserialize>`, and the
+registry that maps a format name (`"json"`, `"xml"`, `"rdf"`, `"provn"`, `"jsonld"`) to
+its serializer class. The how-to guides ({doc}`../howto/provjson`,
+{doc}`../howto/provxml`, {doc}`../howto/provo-rdf`, {doc}`../howto/provn`,
+{doc}`../howto/provjsonld`) show how to use each format. This page documents the interface
+and the registry only.
 
 ```{eval-rst}
 .. autoclass:: prov.serializers.Serializer
@@ -26,8 +26,9 @@ registry only.
 
 ## Reading documents
 
-{py:func}`prov.read` auto-detects the format of a source by trying each registered
-deserializer in turn; see {doc}`../howto/provjson` for its caveats around error reporting.
+{py:func}`prov.read` detects the format of a source by trying each registered
+deserializer in turn. The {doc}`../howto/provjson` guide describes the order and
+the error behaviour.
 
 ```{eval-rst}
 .. autofunction:: prov.read

--- a/docs/reference/serializers.md
+++ b/docs/reference/serializers.md
@@ -3,7 +3,7 @@
 `prov.serializers` defines the serializer interface behind
 {py:meth}`ProvDocument.serialize() <prov.model.ProvDocument.serialize>` and
 {py:meth}`ProvDocument.deserialize() <prov.model.ProvDocument.deserialize>`, and the
-registry that maps a format name (`"json"`, `"xml"`, `"rdf"`, `"provn"`, `"jsonld"`) to
+registry that maps a format name (`"json"`, `"rdf"`, `"provn"`, `"xml"`, `"jsonld"`) to
 its serializer class. The how-to guides ({doc}`../howto/provjson`,
 {doc}`../howto/provxml`, {doc}`../howto/provo-rdf`, {doc}`../howto/provn`,
 {doc}`../howto/provjsonld`) show how to use each format. This page documents the interface
@@ -27,8 +27,9 @@ and the registry only.
 ## Reading documents
 
 {py:func}`prov.read` detects the format of a source by trying each registered
-deserializer in turn. The {doc}`../howto/provjson` guide describes the order and
-the error behaviour.
+deserializer in registry order, `json`, `rdf`, `provn`, `xml`, `jsonld`, and returning the
+first non-empty document. The order matters for a non-seekable stream, which only the
+first attempt can read. The {doc}`../howto/provjson` guide describes the error behaviour.
 
 ```{eval-rst}
 .. autofunction:: prov.read


### PR DESCRIPTION
Third of four PRs from the documentation review (ledger in PR #424).

The conformance matrix keeps every cell and issue reference. Its cross-row caveats become headed subsections, the RDF cells point at the same-identifier caveat instead of repeating it, and narration and em dashes are gone.

The reference index and module intros are shorter and name the extra each module needs. The PROV-DM and unification pages import prov.model as pm like the rest of the site, and the roadmap link uses the main branch.

Verified: sphinx-build -W is clean, every Python block in the explanation pages runs and prints the output shown, codacy-analysis reports 0 issues on the changed files.