### PR TITLE
docs: update the project pages, copyright year and CLI help text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,98 +1,76 @@
 # Contributing
 
-Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given.
+Contributions are welcome. Every little bit helps, and credit is always given.
 
-You can contribute in many ways:
+## Ways to contribute
 
-## Types of Contributions
+### Report bugs
 
-### Report Bugs
+Report bugs at <https://github.com/trungdong/prov/issues>. Include your operating system
+and version, any details about your local setup that might help, and the steps to
+reproduce the bug.
 
-Report bugs at <https://github.com/trungdong/prov/issues>.
+### Fix bugs or implement features
 
-If you are reporting a bug, please include:
+Look through the [issues](https://github.com/trungdong/prov/issues). Anything tagged
+"bug" or "feature" is open to whoever wants to work on it.
 
-- Your operating system name and version.
-- Any details about your local setup that might be helpful in troubleshooting.
-- Detailed steps to reproduce the bug.
+### Write documentation
 
-### Fix Bugs
+More documentation is always useful, whether in the official docs, in docstrings, or as
+blog posts and articles elsewhere.
 
-Look through the GitHub [issues](https://github.com/trungdong/prov/issues) for bugs.
-Anything tagged with "bug" is open to whoever wants to implement it.
+### Propose a feature
 
-### Implement Features
+File an issue at <https://github.com/trungdong/prov/issues>. Explain how the feature would
+work and keep the scope as narrow as possible, so that it is easier to implement. This is
+a volunteer-driven project.
 
-Look through the GitHub [issues](https://github.com/trungdong/prov/issues)
-for features. Anything tagged with "feature" is open to whoever wants to implement it.
+## Set up for development
 
-### Write Documentation
-
-We could always use more documentation, whether as part of the
-official prov docs, in docstrings, or even on the web in blog posts,
-articles, and such.
-
-### Submit Feedback
-
-The best way to send feedback is to file an issue at <https://github.com/trungdong/prov/issues>.
-
-If you are proposing a feature:
-
-- Explain in detail how it would work.
-- Keep the scope as narrow as possible, to make it easier to implement.
-- Remember that this is a volunteer-driven project, and that contributions
-  are welcome :)
-
-## Get Started
-
-Ready to contribute? Here's how to set up `prov` for local development.
-
-1. Fork the `prov` repo on GitHub.
-2. Clone your fork locally:
+1. Fork the `prov` repository on GitHub.
+2. Clone your fork:
 
    ```bash
    git clone git@github.com:your_name_here/prov.git
    ```
 
-3. Set up the development environment with [uv](https://docs.astral.sh/uv/), which creates and manages the project virtualenv for you:
+3. Create the development environment with [uv](https://docs.astral.sh/uv/), which
+   manages the project virtualenv for you:
 
    ```bash
    cd prov/
    uv sync --extra rdf --extra xml --extra dot --extra graph
    ```
 
-   The `rdf`, `xml`, `dot`, and `graph` extras are required for the full test
-   suite to pass. See `docs/dependencies.md` for what each dependency is for.
+   The full test suite needs all four extras.
+   [docs/dependencies.md](https://github.com/trungdong/prov/blob/main/docs/dependencies.md)
+   explains what each dependency is for.
 
-4. Set up pre-commit hooks to ensure code quality checks run automatically:
+4. Install the pre-commit hooks:
 
    ```bash
    uv run pre-commit install
    ```
 
-   This installs the pre-commit framework hooks that will run ruff (linting and
-   formatting) and hygiene checks (trailing whitespace, end-of-file newlines,
-   YAML/TOML validation) on every commit, catching issues before they're pushed.
+   The hooks run ruff (lint and format) and hygiene checks (trailing whitespace,
+   end-of-file newlines, YAML and TOML validation) on every commit.
 
-5. Create a branch for local development:
+5. Create a branch:
 
    ```bash
    git checkout -b name-of-your-bugfix-or-feature
    ```
 
-   Now you can make your changes locally.
-
-6. When you're done making changes, check that your changes pass the tests, including testing other supported Python versions via uv:
+6. Make your changes, then run the tests on every supported interpreter:
 
    ```bash
    for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest || break; done
    ```
 
-   The first run downloads any interpreter you don't already have cached, so
-   expect some network traffic.
+   The first run downloads any interpreter you do not already have cached.
 
-7. Commit your changes and push your branch to GitHub:
+7. Commit and push your branch:
 
    ```bash
    git add .
@@ -100,23 +78,19 @@ Ready to contribute? Here's how to set up `prov` for local development.
    git push origin name-of-your-bugfix-or-feature
    ```
 
-8. Submit a pull request through the GitHub website.
+8. Open a pull request on GitHub.
 
-## Pull Request Guidelines
+## Pull request guidelines
 
-Before you submit a pull request, check that it meets these guidelines:
-
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.md.
-3. The pull request should work for Python 3.10+ and for PyPy3.
-   Look for the automated checks at the bottom of your pull request and make sure that
-   the tests pass for all supported Python versions.
+1. Include tests.
+2. If the pull request adds functionality, update the docs. Give new functions a docstring
+   and add the feature to the list in README.md.
+3. The pull request must pass on Python 3.10 and later and on PyPy. The automated checks
+   at the bottom of the pull request run the full matrix.
 
 ## Licensing
 
 `prov` is released under the MIT licence (see `LICENSE`). By submitting a contribution you
-agree that it is licensed under the same terms, with no additional restrictions: the
+agree that it is licensed under the same terms, with no additional restrictions. The
 licence that applies to your contribution inbound is the licence the project applies
 outbound. There is no contributor licence agreement to sign.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,8 @@ a volunteer-driven project.
 1. Include tests.
 2. If the pull request adds functionality, update the docs. Give new functions a docstring
    and add the feature to the list in README.md.
-3. The pull request must pass on Python 3.10 and later and on PyPy. The automated checks
-   at the bottom of the pull request run the full matrix.
+3. The pull request must pass on CPython 3.10 to 3.14 and on PyPy 3.11. The automated
+   checks at the bottom of the pull request run the full matrix.
 
 ## Licensing
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018-2025 Trung Dong Huynh
+Copyright (c) 2018–2026 Trung Dong Huynh
 Copyright (c) 2014–2017 University of Southampton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,9 +9,9 @@
 | < 2.0   | :x:                | None                |
 
 The latest 3.x release receives all fixes. The most recent 2.x release receives security
-fixes only. The back-port programme that followed the 3.0.0 release closed with 2.5.3, so
-bug fixes are no longer back-ported to 2.x. New features and behaviour-breaking corrections
-were never back-ported and stay on 3.x. Releases before 2.0 are no longer supported.
+fixes only; 2.5.3 was the last release to carry bug fixes back-ported from 3.x. New
+features and behaviour-breaking corrections were never back-ported and stay on 3.x.
+Releases before 2.0 receive no fixes.
 
 Both supported lines require Python 3.10 or later. 3.x has required it from the outset
 and 2.x from 2.3.0 onwards. Earlier 2.x releases support Python 3.9 and later. The

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,37 +1,33 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-The latest `3.x` release is actively maintained and receives all fixes.
-The most recent `2.x` release receives security fixes only. `1.x` and
-earlier are no longer supported.
+| Version | Supported          | Fixes               |
+| ------- | ------------------ | ------------------- |
+| 3.x     | :white_check_mark: | All fixes           |
+| 2.x     | :white_check_mark: | Security fixes only |
+| < 2.0   | :x:                | None                |
 
-| Version | Supported          | Fixes                                       |
-| ------- | ------------------ | ------------------------------------------- |
-| 3.x     | :white_check_mark: | All fixes                                   |
-| 2.x     | :white_check_mark: | Security fixes only                         |
-| < 2.0   | :x:                | None                                        |
+The latest 3.x release receives all fixes. The most recent 2.x release receives security
+fixes only. The back-port programme that followed the 3.0.0 release closed with 2.5.3, so
+bug fixes are no longer back-ported to 2.x. New features and behaviour-breaking corrections
+were never back-ported and stay on 3.x. Releases before 2.0 are no longer supported.
 
-Bug fixes are no longer back-ported to `2.x`: the back-port programme that
-followed the 3.0.0 release closed with `2.5.3`. New features and
-behaviour-breaking corrections were never back-ported and stay on `3.x`.
+Both supported lines require Python 3.10 or later. 3.x has required it from the outset
+and 2.x from 2.3.0 onwards. Earlier 2.x releases support Python 3.9 and later. The
+`classifiers` in a release's `pyproject.toml` or `setup.py` list its exact supported
+Python versions.
 
-Both supported lines require Python 3.10 or later: `3.x` from the outset,
-and `2.x` from `2.3.0` onwards. Earlier `2.x` releases support Python 3.9+;
-consult the `classifiers` in a given release's `pyproject.toml`/`setup.py`
-for its exact supported Python versions.
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+Report security vulnerabilities privately through
+[GitHub's private vulnerability reporting](https://github.com/trungdong/prov/security/advisories/new)
+for this repository, not as a public issue.
 
-Please report security vulnerabilities privately, using [GitHub's private
-vulnerability reporting](https://github.com/trungdong/prov/security/advisories/new)
-for this repository, rather than opening a public issue.
+Include as much detail as you can. The affected versions, the vulnerable code path, and
+steps to reproduce or a proof of concept all help.
 
-Include as much detail as you can: affected version(s), the vulnerable
-code path, and steps to reproduce or a proof of concept.
-
-We aim to acknowledge new reports within 5 business days and to provide
-an initial assessment (validity, severity, and expected timeline for a
-fix) within 14 days. Confirmed vulnerabilities will be fixed in a
-patch release and disclosed via a GitHub security advisory once a fix
-is available.
+We aim to acknowledge new reports within 5 business days and to give an initial assessment
+(validity, severity and expected timeline for a fix) within 14 days. Confirmed
+vulnerabilities are fixed in a patch release and disclosed through a GitHub security
+advisory once a fix is available.

--- a/docs/changelog-archive.md
+++ b/docs/changelog-archive.md
@@ -1,6 +1,6 @@
 # Changelog archive (1.5.3 and earlier)
 
-Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://github.com/trungdong/prov/blob/master/HISTORY.md).
+Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://github.com/trungdong/prov/blob/main/HISTORY.md).
 
 ## 1.5.3 (2018-11-20)
 
@@ -25,7 +25,7 @@ Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://
 
 - Added: Support for [PROV-O](http://www.w3.org/TR/prov-o/) (RDF) serialization and deserialization
 - Added: `direction` option for {py:meth}`prov.dot.prov_to_dot`
-- Added: {py:meth}`prov.graph.graph_to_prov` to convert a [MultiDiGraph](https://networkx.readthedocs.io/en/stable/reference/classes.multigraph.html) back to a {py:class}`~prov.model.ProvDocument`
+- Added: {py:meth}`prov.graph.graph_to_prov` to convert a [MultiDiGraph](https://networkx.org/documentation/stable/reference/classes/multidigraph.html) back to a {py:class}`~prov.model.ProvDocument`
 - Testing with Python 3.5
 - Various minor bug fixes and improvements
 
@@ -56,7 +56,7 @@ Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://
 
 ## 1.2.0 (2014-12-19)
 
-- Added: {py:meth}`prov.graph.prov_to_graph` to convert a {py:class}`~prov.model.ProvDocument` to a [MultiDiGraph](https://networkx.readthedocs.io/en/stable/reference/classes.multigraph.html)
+- Added: {py:meth}`prov.graph.prov_to_graph` to convert a {py:class}`~prov.model.ProvDocument` to a [MultiDiGraph](https://networkx.org/documentation/stable/reference/classes/multidigraph.html)
 - Added: PROV-N serializer
 - Fixed: None values for empty formal attributes in PROV-N output (issue #60)
 - Fixed: PROV-N representation for xsd:dateTime (issue #58)

--- a/docs/changelog-archive.md
+++ b/docs/changelog-archive.md
@@ -23,7 +23,7 @@ Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://
 
 ## 1.5.0 (2016-10-19)
 
-- Added: Support for [PROV-O](http://www.w3.org/TR/prov-o/) (RDF) serialization and deserialization
+- Added: Support for [PROV-O](https://www.w3.org/TR/prov-o/) (RDF) serialization and deserialization
 - Added: `direction` option for {py:meth}`prov.dot.prov_to_dot`
 - Added: {py:meth}`prov.graph.graph_to_prov` to convert a [MultiDiGraph](https://networkx.org/documentation/stable/reference/classes/multidigraph.html) back to a {py:class}`~prov.model.ProvDocument`
 - Testing with Python 3.5
@@ -66,7 +66,7 @@ Releases before 2.0.0. For 2.0.0 and later, see the [current changelog](https://
 
 ## 1.1.0 (2014-08-21)
 
-- Added: Support for [PROV-XML](http://www.w3.org/TR/prov-xml/) serialization and deserialization
+- Added: Support for [PROV-XML](https://www.w3.org/TR/prov-xml/) serialization and deserialization
 - A {py:class}`~prov.model.ProvRecord` instance can now be used as the value of an attributes
 - Added: convenient assertions methods for {py:class}`~prov.model.ProvEntity`, {py:class}`~prov.model.ProvActivity`, and {py:class}`~prov.model.ProvAgent`
 - Added: {py:meth}`prov.model.ProvDocument.update` and {py:meth}`prov.model.ProvBundle.update`

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -1,126 +1,128 @@
 # Upgrading to 3.0
 
-## TL;DR
+## Summary
 
 3.0 is the only release in the `prov` roadmap allowed to break compatibility. Every change
-below was signposted in 2.4.0 with a runtime warning, so **if your test suite ran clean under
+below was signposted in 2.4.0 with a runtime warning. **If your test suite ran clean under
 2.4.0 with `-W error::DeprecationWarning -W error::FutureWarning`, upgrading needs no code
 changes.**
 
-The two changes that matter for most users:
+Two changes matter for most users:
 
-1. **`prov.dot` and `prov.graph` need extras now.** Install `prov[dot]` and/or `prov[graph]`
-   if your code imports either module, or calls `prov_to_dot()`/`prov_to_graph()`/
+1. **`prov.dot` and `prov.graph` need extras.** Install `prov[dot]` or `prov[graph]` if
+   your code imports either module, or calls `prov_to_dot()`, `prov_to_graph()` or
    `graph_to_prov()`.
-2. **`unified()` now raises instead of silently merging.** `ProvBundle.unified()`/
+2. **`unified()` raises instead of silently merging.** `ProvBundle.unified()` and
    `ProvDocument.unified()` raise `prov.model.ProvUnificationError` when records sharing an
-   identifier disagree on a formal attribute or have incompatible types.
-   `prov_to_dot()`/`prov_to_graph()` call `unified()` internally, so they can raise too.
+   identifier disagree on a formal attribute or have incompatible types. `prov_to_dot()`
+   and `prov_to_graph()` call `unified()` internally, so they can raise too.
 
-Everything else is a set of narrow bug fixes (mostly affecting serializer output for edge
-cases, listed below) and one renamed type alias. If neither change above applies to your code,
-skip straight to [what's removed](#removed).
+Everything else is a set of narrow bug fixes, mostly to serializer output for edge cases,
+and one renamed type alias. If neither change above applies to your code, skip to
+[what's removed](#removed).
 
-See [ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) for the
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) has the
 release-by-release plan and the
 [modernisation roadmap design](https://github.com/trungdong/prov/blob/main/planning/specs/2026-07-03-modernisation-roadmap-design.md)
-for the full rationale.
+the full rationale.
 
 ## Install the extras you need
 
 | If your code uses | Install |
 |---|---|
 | `prov.dot`, `prov_to_dot()` | `prov[dot]` |
-| `prov.graph`, `prov_to_graph()`/`graph_to_prov()` | `prov[graph]` |
-| `ProvBundle.plot()`/`ProvDocument.plot()`'s interactive display | `prov[dot]` (pulls in `graph` too) |
+| `prov.graph`, `prov_to_graph()`, `graph_to_prov()` | `prov[graph]` |
+| The interactive display in `ProvBundle.plot()` or `ProvDocument.plot()` | `prov[plot]` |
 
-A plain `pip install prov` still gives you the core data model and the PROV-JSON/PROV-N/
-PROV-JSONLD serializers with no extras. Extras combine, e.g. `pip install "prov[rdf,xml,dot,graph]"`.
+A plain `pip install prov` still gives you the core data model and the PROV-JSON, PROV-N
+and PROV-JSONLD serializers. Extras combine, for example
+`pip install "prov[rdf,xml,dot,graph]"`. See {doc}`installation`.
 
 ## Dependency changes
 
 - **`python-dateutil` is dropped** in favour of the standard library's
-  `datetime.fromisoformat()`. Typical ISO-8601 timestamps are unaffected. Non-standard strings
-  dateutil parsed permissively (e.g. `"Nov 7, 2011"`, or a bare `xsd:date` like
-  `"2011-11-16"`) are no longer accepted; an unparseable `time=`/`startTime=`/`endTime=`
-  factory argument now raises `prov.model.ProvException` instead of a raw `dateutil` error.
+  `datetime.fromisoformat()`. Typical ISO 8601 timestamps are unaffected. Non-standard
+  strings that dateutil parsed permissively, such as `"Nov 7, 2011"` or a bare `xsd:date`
+  like `"2011-11-16"`, are no longer accepted. An unparseable `time=`, `startTime=` or
+  `endTime=` factory argument now raises `prov.model.ProvException` instead of a raw
+  `dateutil` error.
 - **`rdflib` floor raised to 7.0.0.** Upgrade if you pin rdflib 6.x alongside `prov[rdf]`.
   Output differences are limited to those rdflib 7 already introduced under 2.x.
 
 ## Bug fixes that change output or equality
 
-These fix real bugs, but each one changes output bytes or equality semantics for inputs that
-work without error today — that's why they waited for 3.0 rather than shipping in 2.x. Skim
-the "Action" column; most users are unaffected by most rows.
+Each of these fixes a real bug, but each also changes output bytes or equality semantics
+for inputs that worked without error before, which is why they waited for 3.0. Skim the
+"Action" column. Most users are unaffected by most rows.
 
 | Issue | What changed | Action |
 |---|---|---|
-| [#89](https://github.com/trungdong/prov/issues/89) | RDF no longer decorates a plain string value with `^^xsd:string`. | Only matters if you byte-compare RDF output — semantic equality is unaffected. |
-| [#34](https://github.com/trungdong/prov/issues/34) | Attribute sets used to silently drop Python-equal-but-differently-typed values (e.g. `2`/`2.0`, `1`/`True`); all distinct values are now kept. `get_attribute()`/`get_asserted_types()`/`.value` keep their 2.x behaviour. | Recheck code that reads attributes via `attributes`/`extra_attributes`/equality/serialization and relied on the old collapsing, or that mutated a `get_asserted_types()` result in place (no longer writes through). |
-| [#77](https://github.com/trungdong/prov/issues/77) | `xsd:decimal` literals now compare/hash by value, not lexical form (`10` and `10.00` are now equal). | Recheck code relying on differently-formatted decimals comparing unequal. |
-| [#259](https://github.com/trungdong/prov/issues/259) | Language tags now compare/hash case-insensitively; serialized output keeps its original casing. | Recheck code relying on differently-cased tags comparing unequal. |
-| [#168](https://github.com/trungdong/prov/issues/168) | PROV-JSON now emits `xsd:QName` (not the non-standard `prov:QUALIFIED_NAME`) for qualified-name values; both still decode. | Accept `xsd:QName` if you hand-parse this type yourself. |
+| [#89](https://github.com/trungdong/prov/issues/89) | RDF no longer decorates a plain string value with `^^xsd:string`. | Only matters if you byte-compare RDF output. Semantic equality is unaffected. |
+| [#34](https://github.com/trungdong/prov/issues/34) | Attribute sets used to silently drop Python-equal but differently typed values (`2` and `2.0`, `1` and `True`). All distinct values are now kept. `get_attribute()`, `get_asserted_types()` and `.value` keep their 2.x behaviour. | Recheck code that reads attributes through `attributes`, `extra_attributes`, equality or serialization and relied on the old collapsing, or that mutated a `get_asserted_types()` result in place, which no longer writes through. |
+| [#77](https://github.com/trungdong/prov/issues/77) | `xsd:decimal` literals now compare and hash by value, not lexical form. `10` and `10.00` are now equal. | Recheck code relying on differently formatted decimals comparing unequal. |
+| [#259](https://github.com/trungdong/prov/issues/259) | Language tags now compare and hash case-insensitively. Serialized output keeps the original casing. | Recheck code relying on differently cased tags comparing unequal. |
+| [#168](https://github.com/trungdong/prov/issues/168) | PROV-JSON now emits `xsd:QName` for qualified-name values instead of the non-standard `prov:QUALIFIED_NAME`. Both still decode. | Accept `xsd:QName` if you hand-parse this type yourself. |
 | [#238](https://github.com/trungdong/prov/issues/238) | A `prov:QUALIFIED_NAME`-typed `Literal` now resolves to a `QualifiedName` on assertion, restoring round-trip equality. | Recheck code that inspected the raw `Literal` type. |
-| [#235](https://github.com/trungdong/prov/issues/235)/[#249](https://github.com/trungdong/prov/issues/249)/[#251](https://github.com/trungdong/prov/issues/251) | A typed integer literal keeps its asserted datatype instead of silently re-typing to `xsd:int`; PROV-N types plain numbers by magnitude instead of truncating. | Recheck byte-comparisons of PROV-N output. |
-| [#244](https://github.com/trungdong/prov/issues/244)/[#246](https://github.com/trungdong/prov/issues/246)/[#256](https://github.com/trungdong/prov/issues/256) | Plain ints are typed by magnitude (not always `xsd:int`) in JSON/XML/RDF output; PROV-JSON's typed-literal value is always a JSON string. | Recheck code that parses PROV-JSON's `$` as a JSON number. |
-| [#218](https://github.com/trungdong/prov/issues/218)/[#225](https://github.com/trungdong/prov/issues/225) | RDF decoding preserves the original lexical form for datatypes Python can't losslessly round-trip; `xsd:double` values are emitted at full precision. | Recheck byte-comparisons of RDF/turtle output. |
+| [#235](https://github.com/trungdong/prov/issues/235), [#249](https://github.com/trungdong/prov/issues/249), [#251](https://github.com/trungdong/prov/issues/251) | A typed integer literal keeps its asserted datatype instead of silently re-typing to `xsd:int`. PROV-N types plain numbers by magnitude instead of truncating. | Recheck byte comparisons of PROV-N output. |
+| [#244](https://github.com/trungdong/prov/issues/244), [#246](https://github.com/trungdong/prov/issues/246), [#256](https://github.com/trungdong/prov/issues/256) | Plain ints are typed by magnitude, not always `xsd:int`, in JSON, XML and RDF output. PROV-JSON's typed-literal value is always a JSON string. | Recheck code that parses PROV-JSON's `$` as a JSON number. |
+| [#218](https://github.com/trungdong/prov/issues/218), [#225](https://github.com/trungdong/prov/issues/225) | RDF decoding preserves the original lexical form for datatypes Python cannot round-trip losslessly. `xsd:double` values are emitted at full precision. | Recheck byte comparisons of RDF output. |
 | [#223](https://github.com/trungdong/prov/issues/223) | PROV-N now escapes metacharacters in identifiers and backslashes in string literals. | Recheck any hand-parsing of PROV-N output. |
-| [#250](https://github.com/trungdong/prov/issues/250)/[#226](https://github.com/trungdong/prov/issues/226) | Anonymous qualified relations (Communication/Attribution/Delegation/Influence) now always carry their influencer property in PROV-O. | Recheck dedup logic keyed on the old (incomplete) triple shape. |
-| [#258](https://github.com/trungdong/prov/issues/258) | `alternate()` now emits PROV-O in the correct (untransposed) subject/object order. | Only matters if you byte-compare output — `alternateOf` is symmetric, so semantic equality is unaffected. |
+| [#250](https://github.com/trungdong/prov/issues/250), [#226](https://github.com/trungdong/prov/issues/226) | Anonymous qualified relations (Communication, Attribution, Delegation, Influence) now always carry their influencer property in PROV-O. | Recheck dedup logic keyed on the old, incomplete triple shape. |
+| [#258](https://github.com/trungdong/prov/issues/258) | `alternate()` now emits PROV-O in the correct, untransposed subject and object order. | Only matters if you byte-compare output. `alternateOf` is symmetric, so semantic equality is unaffected. |
 | [#288](https://github.com/trungdong/prov/issues/288) | `xsd:base64Binary` RDF values decode to their base64 text, not a Python bytes repr. | Recheck code that processes this attribute type. |
-| [#299](https://github.com/trungdong/prov/issues/299) | A qualified Start/End node's binary `prov:startedAtTime`/`endedAtTime` predicate now populates the relation's formal `prov:time`, instead of landing as an extra attribute. | Recheck code reading the old extra attribute. |
-| [#303](https://github.com/trungdong/prov/issues/303) | Anonymous Communication/Attribution/Influence relations with extra attributes no longer decode into two duplicate records. | None — this only fixes a round-trip bug. |
-| [#294](https://github.com/trungdong/prov/issues/294) | A qualified name ending in a PROV-N metacharacter now round-trips through PROV-O instead of raising `ValueError`. | None — this only fixes a round-trip bug. |
-| [#96](https://github.com/trungdong/prov/issues/96) | Bundle-local and default namespace prefixes are now bound in RDF output instead of falling back to an rdflib-minted prefix. | Recheck byte-comparisons of turtle/TriG prefixes. |
-| [#217](https://github.com/trungdong/prov/issues/217) | **Documented limitation, not a fix:** two same-identifier relations that disagree on a formal attribute still can't round-trip through PROV-O. Decoding now raises a clear, chained error pointing at {doc}`reference/conformance` instead of a raw one. | Give such relations distinct identifiers if you need them to survive an RDF round trip. |
-| [#224](https://github.com/trungdong/prov/issues/224) | Empty-string attribute values now survive a PROV-XML round trip (previously dropped). | None — this only fixes a round-trip bug. |
-| [#289](https://github.com/trungdong/prov/issues/289) | An attribute name that isn't a legal XML NCName is now escaped instead of raising `ValueError`; see {doc}`reference/conformance` for the escaping rules. | None for already-legal names. Drop any workaround you had for the old `ValueError`. |
-| [#228](https://github.com/trungdong/prov/issues/228) | Malformed PROV-JSON now raises `prov.serializers.provjson.ProvJSONException` instead of a raw `KeyError`/`AttributeError`/`TypeError`. | **Update exception handlers**: catch `ProvJSONException` instead of the raw types around PROV-JSON deserialization. |
-| [#273](https://github.com/trungdong/prov/issues/273) | PROV-XML parsing now uses a hardened parser; external DTD entities no longer resolve (affected values come back empty instead of expanded). | If you need to *detect* rather than just neutralise entity use, reject documents containing `<!DOCTYPE` before deserializing. |
+| [#299](https://github.com/trungdong/prov/issues/299) | A qualified Start or End node's `prov:startedAtTime` or `prov:endedAtTime` predicate now populates the relation's formal `prov:time` instead of landing as an extra attribute. | Recheck code reading the old extra attribute. |
+| [#303](https://github.com/trungdong/prov/issues/303) | Anonymous Communication, Attribution and Influence relations with extra attributes no longer decode into two duplicate records. | None. This only fixes a round-trip bug. |
+| [#294](https://github.com/trungdong/prov/issues/294) | A qualified name ending in a PROV-N metacharacter now round-trips through PROV-O instead of raising `ValueError`. | None. This only fixes a round-trip bug. |
+| [#96](https://github.com/trungdong/prov/issues/96) | Bundle-local and default namespace prefixes are now bound in RDF output instead of falling back to an rdflib-minted prefix. | Recheck byte comparisons of Turtle and TriG prefixes. |
+| [#217](https://github.com/trungdong/prov/issues/217) | **Documented limitation, not a fix.** Two same-identifier relations that disagree on a formal attribute still cannot round-trip through PROV-O. Decoding now raises a clear, chained error pointing at {doc}`reference/conformance`. | Give such relations distinct identifiers if they must survive an RDF round trip. |
+| [#224](https://github.com/trungdong/prov/issues/224) | Empty-string attribute values now survive a PROV-XML round trip. They were dropped before. | None. This only fixes a round-trip bug. |
+| [#289](https://github.com/trungdong/prov/issues/289) | An attribute name that is not a legal XML NCName is now escaped instead of raising `ValueError`. {doc}`reference/conformance` has the escaping rules. | None for already-legal names. Drop any workaround you had for the old `ValueError`. |
+| [#228](https://github.com/trungdong/prov/issues/228) | Malformed PROV-JSON now raises `prov.serializers.provjson.ProvJSONException` instead of a raw `KeyError`, `AttributeError` or `TypeError`. | **Update exception handlers.** Catch `ProvJSONException` instead of the raw types around PROV-JSON deserialization. |
+| [#273](https://github.com/trungdong/prov/issues/273) | PROV-XML parsing now uses a hardened parser. External DTD entities no longer resolve, and affected values come back empty instead of expanded. | If you need to detect rather than neutralise entity use, reject documents containing `<!DOCTYPE` before deserializing. |
 
 ## `unified()` now enforces PROV-CONSTRAINTS
 
 Before 3.0, `unified()` merged same-identifier records by unioning their attributes with no
-conflict detection. 3.0 replaces this with real
-[PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) merging — see the
-[unification and flattening explanation](explanation/unification-flattening.md) for the full
-model. In short:
+conflict detection. 3.0 replaces this with
+[PROV-CONSTRAINTS](https://www.w3.org/TR/prov-constraints/) merging. The
+[unification and flattening explanation](explanation/unification-flattening.md) has the
+full model. In short:
 
-- Records sharing an identifier are merged by unifying formal attributes position-by-position.
-  **Two different concrete values for the same formal attribute now raise
-  `prov.model.ProvUnificationError`** instead of merging silently. A missing attribute still
-  unifies with any concrete value, as before.
-- Records sharing an identifier but of **incompatible types** (e.g. an entity and an activity)
-  now raise the same error, naming both types, instead of merging into whichever record was
-  asserted first. Overlaps the spec permits (e.g. an agent that's also an entity) still merge
-  as separate, per-type records.
-- Each bundle unifies independently — nothing merges across a bundle boundary.
-- Non-formal ("extra") attributes still keep their set-union behaviour.
-- Out of scope: uniqueness constraints not keyed on the record identifier (Constraints 24–29)
-  belong to the separate, opt-in validation engine tracked as
+- Records sharing an identifier are merged by unifying formal attributes position by
+  position. **Two different concrete values for the same formal attribute now raise
+  `prov.model.ProvUnificationError`** instead of merging silently. A missing attribute
+  still unifies with any concrete value, as before.
+- Records sharing an identifier but of **incompatible types**, such as an entity and an
+  activity, raise the same error, naming both types, instead of merging into whichever
+  record was asserted first. Overlaps the specification permits, such as an agent that is
+  also an entity, still merge as separate, per-type records.
+- Each bundle unifies independently. Nothing merges across a bundle boundary.
+- Non-formal ("extra") attributes keep their set-union behaviour.
+- Uniqueness constraints not keyed on the record identifier (Constraints 24 to 29) are out
+  of scope. They belong to the separate, opt-in validation engine tracked as
   [#62](https://github.com/trungdong/prov/issues/62).
 
 `ProvUnificationError` subclasses `ProvException`, so an existing `except ProvException`
-handler around `unified()` keeps working. `prov_to_dot()` catches the error and falls back to
-rendering the non-unified bundle; `prov_to_graph()` lets it propagate. Building and
-serializing a document with these conflicts is still legal in 3.0 — `prov` performs no
-structural validation at assertion/serialization time by design
-([#257](https://github.com/trungdong/prov/issues/257)) — only calling `unified()` on one (or
-decoding its RDF form) raises.
+handler around `unified()` keeps working. `prov_to_dot()` catches the error and falls back
+to rendering the non-unified bundle. `prov_to_graph()` lets it propagate. Building and
+serializing a document with these conflicts is still legal in 3.0, because `prov` performs
+no structural validation at assertion or serialization time by design
+([#257](https://github.com/trungdong/prov/issues/257)). Only calling `unified()` on such a
+document, or decoding its RDF form, raises.
 
-**Action:** if you call `unified()` — directly, or via `prov_to_dot()`/`prov_to_graph()` — on
-documents where same-identifier records might disagree on a formal attribute or type, catch
-`ProvUnificationError` or fix the document to avoid the conflict.
+**Action:** if you call `unified()`, directly or through `prov_to_dot()` or
+`prov_to_graph()`, on documents where same-identifier records might disagree on a formal
+attribute or type, catch `ProvUnificationError` or fix the document to avoid the conflict.
 
 ## Removed
 
-3.0 removes everything 2.4.0 marked deprecated — nothing else is scheduled for removal:
+3.0 removes everything 2.4.0 marked deprecated. Nothing else is scheduled for removal.
 
-- The unconditional `pydot`/`networkx` dependencies — superseded by the `dot`/`graph` extras
-  above. `import prov.dot`/`import prov.graph` now raises `ModuleNotFoundError` naming the
-  extra to install.
+- The unconditional `pydot` and `networkx` dependencies, superseded by the `dot` and
+  `graph` extras above. `import prov.dot` and `import prov.graph` now raise
+  `ModuleNotFoundError` naming the extra to install.
 - `python-dateutil` as a runtime dependency, and the incidental `prov.model.dateutil`
   re-export that came from importing it.
-- `prov.model.GenrationRef` — the misspelled type alias used in `wasDerivedFrom`/
-  `wasRevisionOf`/`wasQuotedFrom`/`hadPrimarySource`'s `generation` parameter — is renamed
-  `GenerationRef`, with no alias kept for the old spelling.
+- `prov.model.GenrationRef`, the misspelled type alias used for the `generation` parameter
+  of `wasDerivedFrom()`, `wasRevisionOf()`, `wasQuotedFrom()` and `hadPrimarySource()`. It
+  is renamed `GenerationRef`, with no alias kept for the old spelling.

--- a/docs/upgrading-3.0.md
+++ b/docs/upgrading-3.0.md
@@ -2,24 +2,26 @@
 
 ## Summary
 
-3.0 is the only release in the `prov` roadmap allowed to break compatibility. Every change
-below was signposted in 2.4.0 with a runtime warning. **If your test suite ran clean under
-2.4.0 with `-W error::DeprecationWarning -W error::FutureWarning`, upgrading needs no code
-changes.**
-
-Two changes matter for most users:
+3.0 is the only release in the `prov` roadmap allowed to break compatibility. Two changes
+matter for most users:
 
 1. **`prov.dot` and `prov.graph` need extras.** Install `prov[dot]` or `prov[graph]` if
    your code imports either module, or calls `prov_to_dot()`, `prov_to_graph()` or
    `graph_to_prov()`.
 2. **`unified()` raises instead of silently merging.** `ProvBundle.unified()` and
    `ProvDocument.unified()` raise `prov.model.ProvUnificationError` when records sharing an
-   identifier disagree on a formal attribute or have incompatible types. `prov_to_dot()`
-   and `prov_to_graph()` call `unified()` internally, so they can raise too.
+   identifier disagree on a formal attribute or have incompatible types. `prov_to_graph()`
+   calls `unified()` internally, so it can raise too. `prov_to_dot()` catches the error and
+   renders the document without unifying it.
+
+Both were signposted from 2.4.0 with a runtime warning, which every later 2.x release also
+carries. **If your test suite ran clean under 2.4.0 or later with
+`-W error::DeprecationWarning -W error::FutureWarning`, neither change affects your code.**
 
 Everything else is a set of narrow bug fixes, mostly to serializer output for edge cases,
-and one renamed type alias. If neither change above applies to your code, skip to
-[what's removed](#removed).
+and one renamed type alias. Those could not be signposted by a warning, because they
+change the result of calls that already succeeded. Skim the table below for the ones that
+touch your code, or skip to [what's removed](#removed).
 
 [ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) has the
 release-by-release plan and the
@@ -110,9 +112,9 @@ no structural validation at assertion or serialization time by design
 ([#257](https://github.com/trungdong/prov/issues/257)). Only calling `unified()` on such a
 document, or decoding its RDF form, raises.
 
-**Action:** if you call `unified()`, directly or through `prov_to_dot()` or
-`prov_to_graph()`, on documents where same-identifier records might disagree on a formal
-attribute or type, catch `ProvUnificationError` or fix the document to avoid the conflict.
+**Action:** if you call `unified()`, directly or through `prov_to_graph()`, on documents
+where same-identifier records might disagree on a formal attribute or type, catch
+`ProvUnificationError` or fix the document to avoid the conflict.
 
 ## Removed
 

--- a/docs/whats-new-3.md
+++ b/docs/whats-new-3.md
@@ -6,70 +6,70 @@ the 3.x line changed, what it costs to move, and why the pin can go.
 ## Nothing to install that you do not use
 
 3.0.0 removed every unconditional runtime dependency. `pip install prov` installs the
-library alone; each format or capability that needs a third-party package is an extra:
+library alone. Each capability that needs a third-party package is an extra:
 
-| Extra | Enables | Pulls in |
+| Extra | Enables | Installs |
 |---|---|---|
 | `rdf` | PROV-O (RDF) serializer and deserializer | `rdflib` |
 | `xml` | PROV-XML serializer and deserializer | `lxml` |
-| `graph` | NetworkX conversion (`prov.graph`) | `networkx` |
-| `dot` | Graphviz export (`prov.dot`) | `pydot`, `networkx` |
-| `plot` | `ProvBundle.plot()` | `matplotlib`, `pydot`, `networkx` |
+| `dot` | Graphviz export through `prov.dot` | `pydot`, `networkx` |
+| `graph` | NetworkX conversion through `prov.graph` | `networkx` |
+| `plot` | The interactive display in `ProvBundle.plot()` | `matplotlib`, `pydot`, `networkx` |
 
 PROV-JSON, PROV-N and PROV-JSONLD need no extra. See {doc}`installation`.
 
 ## Standards conformance, audited
 
-Before 3.0.0 the library was audited against W3C PROV-DM, PROV-CONSTRAINTS, PROV-O,
-PROV-XML and PROV-JSON. The {doc}`reference/conformance` page records, concept by concept,
-how each serializer round-trips it and which gaps are permanent limitations of a format
-rather than defects. The audit's fixes shipped in 3.0.0, each with tests showing the old and
-new behaviour.
+Before 3.0.0 the library was audited against W3C PROV-DM, PROV-N, PROV-CONSTRAINTS,
+PROV-O, PROV-XML and PROV-JSON. The {doc}`reference/conformance` page records, concept by
+concept, how each serializer round-trips it and which gaps are permanent limitations of a
+format rather than defects. The audit's fixes shipped in 3.0.0, each with tests showing the
+old and new behaviour.
 
 ## Unification follows PROV-CONSTRAINTS
 
-`unified()` implements the PROV-CONSTRAINTS key constraints: records sharing an identifier
-are merged by term unification of their formal attributes, and records that cannot be
-merged (different concrete values for the same formal attribute, or incompatible types)
-raise `ProvUnificationError` instead of being silently combined. Bundles unify
-independently. See {doc}`explanation/unification-flattening`.
+`unified()` implements the PROV-CONSTRAINTS key constraints. Records sharing an identifier
+are merged by term unification of their formal attributes. Records that cannot be merged,
+because they hold different concrete values for the same formal attribute or have
+incompatible types, raise `ProvUnificationError` instead of being silently combined.
+Bundles unify independently. See {doc}`explanation/unification-flattening`.
 
 ## PROV-JSONLD
 
 3.1.0 added a serializer and deserializer for
 [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), selected with
-`format="jsonld"`, implemented with the standard library alone. It joins PROV-JSON,
+`format="jsonld"` and implemented with the standard library alone. It joins PROV-JSON,
 PROV-XML and PROV-O in the shared round-trip test matrix and in `prov.read()`'s format
 auto-detection. See {doc}`howto/provjsonld`.
 
 ## Typed and documented
 
-Every public name carries type hints and the package ships `py.typed`, so type checkers see
-the API. The documentation is organised as tutorial, how-to guides, reference and
+Every public name carries type hints and the package ships `py.typed`, so type checkers
+see the API. The documentation is organised as tutorial, how-to guides, reference and
 explanation, and the API reference is generated from the docstrings.
 
 ## Moving from 2.x
 
-For most code the upgrade needs no change. The two things that can need attention are the
-extras above (install the ones you use) and `unified()` raising on records it previously
-merged silently. {doc}`upgrading-3.0` lists every change, what triggers it, and what to do.
+For most code the upgrade needs no change. Two things can need attention. Install the
+extras your code uses, and expect `unified()` to raise on records it previously merged
+silently. {doc}`upgrading-3.0` lists every change, what triggers it, and what to do.
 
 ## The 2.x line
 
-The most recent 2.x release receives security fixes only; 2.5.3 was the last release to
+The most recent 2.x release receives security fixes only. 2.5.3 was the last release to
 carry bug fixes back-ported from 3.x. See
 [SECURITY.md](https://github.com/trungdong/prov/blob/main/SECURITY.md).
 
 ## If you pin `prov==2.1.1` or `prov==1.5.1`
 
-Those pins predate the 3.x work. Both are outside the current support policy. 1.5.1
-predates the 2.x line and 2.1.1 is an early 2.x release from before the modernisation
-work. Lift the pin to `prov>=3` and add the extras your code uses.
-Please open an issue if anything in the upgrade guide does not cover your case.
+Both pins predate the 3.x work and fall outside the current support policy. 1.5.1
+predates the 2.x line, and 2.1.1 is an early 2.x release from before the modernisation
+work. Lift the pin to `prov>=3` and add the extras your code uses. Open an issue if the
+upgrade guide does not cover your case.
 
 ## What comes next
 
-[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) has the ordered list
-of planned releases. Next is a PROV-N parser (3.2.0), making the notation readable as well
-as writable. Python 3.10 support ends in the first release after its end of life on
+[ROADMAP.md](https://github.com/trungdong/prov/blob/main/ROADMAP.md) lists the planned
+releases in order. Next is 3.2.0 with a PROV-N parser, making the notation readable as
+well as writable. Python 3.10 support ends in the first release after its end of life on
 2026-10-31.

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 """
-prov-compare -- Compare two PROV-JSON, PROV-XML, or RDF (PROV-O) files for equivalence
+prov-compare -- Compare two PROV documents (PROV-JSON, PROV-XML, PROV-O or PROV-JSONLD) for equivalence
 
 @author:     Trung Dong Huynh
 
-@copyright:  2025 Trung Dong Huynh
+@copyright:  2026 Trung Dong Huynh
 
 @license:    MIT Licence
 
 @contact:    trungdong@donggiang.com
-@deffield    updated: 2025-06-07
+@deffield    updated: 2026-09-10
 """
 
 import logging
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 __all__: list[str] = []
 __version__ = 0.1
 __date__ = "2015-06-16"
-__updated__ = "2025-06-07"
+__updated__ = "2026-09-10"
 
 DEBUG = 0
 TESTRUN = 0
@@ -77,10 +77,10 @@ def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     program_shortdesc = __doc__.split("\n")[1]
     program_license = f"""{program_shortdesc}
 
-  Copyright 2025 Trung Dong Huynh.
+  Copyright 2026 Trung Dong Huynh.
 
   Licensed under the MIT License
-  https://github.com/trungdong/prov/blob/master/LICENSE
+  https://github.com/trungdong/prov/blob/main/LICENSE
 
   Distributed on an "AS IS" basis without warranties
   or conditions of any kind, either express or implied.
@@ -101,7 +101,7 @@ USAGE
             dest="format1",
             action="store",
             default="json",
-            help="File 1's format: json or xml",
+            help="File 1's format: json, xml, rdf or jsonld",
         )
         parser.add_argument(
             "-F",
@@ -109,7 +109,7 @@ USAGE
             dest="format2",
             action="store",
             default="json",
-            help="File 2's format: json or xml",
+            help="File 2's format: json, xml, rdf or jsonld",
         )
         parser.add_argument(
             "-V", "--version", action="version", version=program_version_message

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -4,12 +4,12 @@ convert -- Convert PROV-JSON to RDF, PROV-N, PROV-XML, or graphical formats (SVG
 
 @author:     Trung Dong Huynh
 
-@copyright:  2025 Trung Dong Huynh
+@copyright:  2026 Trung Dong Huynh
 
 @license:    MIT License
 
 @contact:    trungdong@donggiang.com
-@deffield    updated: 2025-06-07
+@deffield    updated: 2026-09-10
 """
 
 import io
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 __all__: list[str] = []
 __version__ = 0.1
 __date__ = "2014-03-14"
-__updated__ = "2025-06-07"
+__updated__ = "2026-09-10"
 
 DEBUG = 0
 TESTRUN = 0
@@ -87,8 +87,8 @@ class CLIError(Exception):
 def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> None:
     """Read a PROV document from ``infile`` and write it to ``outfile`` in ``output_format``.
 
-    ``infile`` is auto-detected across all registered deserialization
-    formats (see :meth:`~prov.model.ProvDocument.deserialize`). For
+    ``infile`` is always read as PROV-JSON, the default format of
+    :meth:`~prov.model.ProvDocument.deserialize`. For
     ``output_format``, ``"provn"`` is written directly via
     :meth:`~prov.model.ProvDocument.get_provn`, a name in
     :data:`GRAPHVIZ_SUPPORTED_FORMATS` is rendered through
@@ -100,7 +100,7 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
         outfile: File-like object (opened in binary mode) to write the
             converted output to.
         output_format: Target format name (e.g. ``"json"``, ``"xml"``,
-            ``"rdf"``, ``"provn"``, or a Graphviz output format such as
+            ``"rdf"``, ``"jsonld"``, ``"provn"``, or a Graphviz output format such as
             ``"svg"``/``"pdf"``/``"png"``).
 
     Raises:
@@ -161,10 +161,10 @@ def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     program_shortdesc = __doc__.split("\n")[1]
     program_license = f"""{program_shortdesc}
 
-  Copyright 2025 Trung Dong Huynh.
+  Copyright 2026 Trung Dong Huynh.
 
   Licensed under the MIT License
-  https://github.com/trungdong/prov/blob/master/LICENSE
+  https://github.com/trungdong/prov/blob/main/LICENSE
 
   Distributed on an "AS IS" basis without warranties
   or conditions of any kind, either express or implied.
@@ -183,7 +183,7 @@ USAGE
             dest="format",
             action="store",
             default="json",
-            help="output format: json, xml, provn, or one supported by GraphViz (e.g. svg, pdf)",
+            help="output format: json, xml, rdf, jsonld, provn, or a Graphviz output format (e.g. svg, pdf, png)",
         )
         parser.add_argument("infile", nargs="?", type=FileType("r"), default=sys.stdin)
         parser.add_argument(

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1663,7 +1663,7 @@ class ProvRDFSerializer(Serializer):
                     "same-identifier relations that disagree on a formal "
                     "attribute (e.g. two prov:atTime values) cannot both be "
                     "represented. See "
-                    "https://github.com/trungdong/prov/blob/master/docs/reference/conformance.md "
+                    "https://github.com/trungdong/prov/blob/main/docs/reference/conformance.md "
                     "for details."
                 ) from exc
 


### PR DESCRIPTION
Last of four PRs from the documentation review (ledger in PR #424).

Fixes: copyright year 2026 in LICENSE and both CLI script headers, with matching dashes in the LICENSE year ranges; prov-convert's help text now lists rdf and jsonld among its output formats and prov-compare's lists every format it reads; the convert_file docstring says the input is always PROV-JSON, which is what the code does; the upgrading guide said plot() needs prov[dot] where it needs prov[plot]; the what's new audit list gains PROV-N; the changelog archive's networkx link was dead and its HISTORY link used the master branch.

Readability: CONTRIBUTING, SECURITY, the what's new page and the upgrading guide lose narration and em dashes. HISTORY.md is unchanged.

Verified: full pytest matrix on 3.10 to 3.14 and PyPy 3.11 (1672 passed, 26 skipped, matching main), mypy strict and ruff clean, sphinx-build -W clean, codacy-analysis reports 0 issues on the changed files.