### PR TITLE
docs: audit the dependencies page, unify HISTORY.md style, drop ProvStore from comments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -106,7 +106,7 @@ citation files for the repository. No API, dependency or Python-floor changes.
   `prov.serializers.provjsonld.ProvJSONLDException` for any document
   containing a `ProvMention` record, and the deserializer raises the same
   exception on an input statement typed `"Mention"`. This is a permanent
-  limitation of the submission, not a `prov` defect — see
+  limitation of the submission, not a `prov` defect. See
   `docs/reference/conformance.md`
 
 ## 3.0.0 (2026-07-27)
@@ -126,132 +126,132 @@ for what changed and what to do about it.
   hold different concrete values now raise the new documented
   `prov.model.ProvUnificationError` instead of silently unioning; absent
   formal attributes unify with concrete values; extra attributes keep
-  set-union semantics; bundles unify independently (#253)
+  set-union semantics; bundles unify independently ([#253](https://github.com/trungdong/prov/issues/253))
 - `unified()` rejects same-identifier records of incompatible types
-  (entity vs activity, distinct relation kinds — PROV-CONSTRAINTS 53/54/55)
+  (entity vs activity, distinct relation kinds, PROV-CONSTRAINTS 53/54/55)
   with `ProvUnificationError` instead of merging them order-dependently
   into the first record's type; spec-permitted overlaps (an agent that is
-  also an entity or activity) are kept as separate records (#253)
+  also an entity or activity) are kept as separate records ([#253](https://github.com/trungdong/prov/issues/253))
 - Attribute values that are Python-equal but differently typed (`2` vs
   `2.0`, `1` vs `True`) are all retained on a record instead of
-  collapsing to whichever was asserted first — visible in attribute
+  collapsing to whichever was asserted first. This is visible in attribute
   iteration, record equality and hashing, and serialization. Attributes now
   iterate in assertion order rather than an arbitrary hash order, which makes
   `args`, `formal_attributes`, `get_startTime()` and `get_endTime()`
   deterministic. `ProvRecord.get_attribute()`, `get_asserted_types()` and
   the `value` property still return a plain `set`, but it is now built
   fresh on every call, so mutating it no longer writes through to the record:
-  `record.get_asserted_types().add(qn)` now silently does nothing (#34)
+  `record.get_asserted_types().add(qn)` now silently does nothing ([#34](https://github.com/trungdong/prov/issues/34))
 - `pydot` and `networkx` are no longer unconditional runtime
   dependencies. `import prov.dot` now requires the `dot` extra
   (`pip install "prov[dot]"`) and `import prov.graph` the `graph`
   extra; without them the import raises `ModuleNotFoundError` naming the
   extra to install. The `plot` extra now pulls in `pydot`/`networkx`
   as well, since `plot()` renders through `prov.dot`. See
-  `docs/upgrading-3.0.md`.
+  `docs/upgrading-3.0.md`
 - The `rdf` extra now requires `rdflib>=7.0.0` (previously `>=6.0.0`);
   round-trip behaviour is unchanged
-- `python-dateutil` dropped — `prov` now has no unconditional
+- `python-dateutil` dropped. `prov` now has no unconditional
   runtime dependencies. Datetime strings are parsed as `xsd:dateTime`
   (ISO 8601 plus the hour-24 end-of-day form) via the standard library;
   factory `time=`/`startTime=`/`endTime=` parameters raise
   `ProvException` on invalid input instead of leaking a raw dateutil
   error, and non-ISO forms previously tolerated by dateutil (e.g.
-  `"Nov 7, 2011"`) are no longer accepted (#237)
+  `"Nov 7, 2011"`) are no longer accepted ([#237](https://github.com/trungdong/prov/issues/237))
 - The misspelled `prov.model.GenrationRef` type alias is renamed
   `GenerationRef`; the old spelling is removed rather than kept as a
   deprecated alias
 
 ### Conformance and correctness fixes
 
-- When an attribute is asserted twice with an equal value of equal type — e.g.
-  `Literal("10", XSD_DECIMAL)` and `Literal("10.00", XSD_DECIMAL)` (#77),
+- When an attribute is asserted twice with an equal value of equal type, e.g.
+  `Literal("10", XSD_DECIMAL)` and `Literal("10.00", XSD_DECIMAL)` ([#77](https://github.com/trungdong/prov/issues/77)),
   or `Literal("hi", langtag="en")` and `Literal("hi", langtag="EN")`
-  (#259) — the record retains the first value asserted, as in 2.x (#34)
+  ([#259](https://github.com/trungdong/prov/issues/259)), the record retains the first value asserted, as in 2.x ([#34](https://github.com/trungdong/prov/issues/34))
 - Numeric datatype fidelity: `Literal` values typed `xsd:long` (and the
   rest of the XSD integer family) keep their asserted datatype instead of
-  being silently re-typed `xsd:int` (#235); PROV-N output types plain
+  being silently re-typed `xsd:int` ([#235](https://github.com/trungdong/prov/issues/235)); PROV-N output types plain
   integers by magnitude (`xsd:int`/`xsd:long`/`xsd:integer`) so
   out-of-int32 values are no longer emitted as invalid bare int literals
-  (#249), and plain floats as full-precision `xsd:double` instead of
-  `%g`-truncated `xsd:float` (#251)
+  ([#249](https://github.com/trungdong/prov/issues/249)), and plain floats as full-precision `xsd:double` instead of
+  `%g`-truncated `xsd:float` ([#251](https://github.com/trungdong/prov/issues/251))
 - Literal semantics: string literals have one canonical serialized form (RDF
-  output no longer decorates plain strings with `^^xsd:string`) (#89);
-  `xsd:decimal` literals compare and hash in value space (#77); language
+  output no longer decorates plain strings with `^^xsd:string`) ([#89](https://github.com/trungdong/prov/issues/89));
+  `xsd:decimal` literals compare and hash in value space ([#77](https://github.com/trungdong/prov/issues/77)); language
   tags compare case-insensitively per RDF 1.1 while preserving their
-  original case in output (#259)
+  original case in output ([#259](https://github.com/trungdong/prov/issues/259))
 - PROV-XML round trip preserves attributes whose value is the empty string;
-  previously they were silently dropped on deserialization (#224)
+  previously they were silently dropped on deserialization ([#224](https://github.com/trungdong/prov/issues/224))
 - PROV-XML serializes attribute names containing characters illegal in an
   XML NCName using the reversible `_xHHHH_` escaping convention instead
   of raising `ValueError`; the deserializer applies the inverse, so such
-  names round-trip (#289)
+  names round-trip ([#289](https://github.com/trungdong/prov/issues/289))
 - The PROV-JSON deserializer raises `ProvJSONException` on structurally
   malformed input instead of leaking raw `KeyError`/`AttributeError`
-  (#228)
+  ([#228](https://github.com/trungdong/prov/issues/228))
 - PROV-JSON typed literals always encode `$` as a string, and plain
   integers are typed by magnitude across PROV-JSON/PROV-XML/PROV-O output
   (`xsd:int`/`xsd:long`/`xsd:integer`), fixing schema-invalid output
-  for out-of-int32 values (#244, #246, #256)
+  for out-of-int32 values ([#244](https://github.com/trungdong/prov/issues/244), [#246](https://github.com/trungdong/prov/issues/246), [#256](https://github.com/trungdong/prov/issues/256))
 - PROV-JSON encodes QualifiedName attribute values as `xsd:QName` typed
   literals per the PROV-JSON submission (previously the non-standard
-  `prov:QUALIFIED_NAME`, which remains accepted on input) (#168), and
+  `prov:QUALIFIED_NAME`, which remains accepted on input) ([#168](https://github.com/trungdong/prov/issues/168)), and
   `prov:QUALIFIED_NAME`-typed `Literal` values are resolved to
-  QualifiedNames at assertion time, restoring round-trip equality (#238)
+  QualifiedNames at assertion time, restoring round-trip equality ([#238](https://github.com/trungdong/prov/issues/238))
 - PROV-O: documents containing multiple same-identifier relations with
   differing formal attributes ("scruffy" statements) are documented as a
-  PROV-O representational limitation — they serialize but do not round-trip
+  PROV-O representational limitation. They serialize but do not round-trip
   through RDF, and deserializing such RDF now raises an error naming the
-  limitation; all other formats are unaffected (#217)
-- PROV-O: a related gap is recorded, not fixed — an attribute key whose local
-  part ends in a PROV-N metacharacter (#223) can fail to round-trip through
+  limitation; all other formats are unaffected ([#217](https://github.com/trungdong/prov/issues/217))
+- PROV-O: a related gap is recorded, not fixed. An attribute key whose local
+  part ends in a PROV-N metacharacter ([#223](https://github.com/trungdong/prov/issues/223)) can fail to round-trip through
   RDF when its namespace has not already been registered by another qualified
   name; `docs/reference/conformance.md` documents it as an open defect
-  (#341)
+  ([#341](https://github.com/trungdong/prov/issues/341))
 - PROV-O (RDF) round-trip fidelity: mixed XSD-datatype attribute sets
-  survive deserialization with their asserted datatypes intact (#218), and
+  survive deserialization with their asserted datatypes intact ([#218](https://github.com/trungdong/prov/issues/218)), and
   `xsd:double` values are emitted at full precision instead of rdflib's
-  6-significant-digit canonical form (#225)
+  6-significant-digit canonical form ([#225](https://github.com/trungdong/prov/issues/225))
 - PROV-O output: anonymous qualified Communication/Attribution/Delegation/
   Influence nodes now carry their influencer property (`prov:activity`/
   `prov:agent`/`prov:agent`/`prov:influencer`) as the PROV-O
   qualification tables require, and the RDF round trip no longer collapses
   distinct anonymous delegations sharing a (delegate, activity) pair
-  (#250, #226)
+  ([#250](https://github.com/trungdong/prov/issues/250), [#226](https://github.com/trungdong/prov/issues/226))
 - PROV-O output emits `alternateOf` with the PROV-DM argument order
   (`alt1 prov:alternateOf alt2`); previously subject and object were
-  transposed on both write and read (#258)
+  transposed on both write and read ([#258](https://github.com/trungdong/prov/issues/258))
 - PROV-O (RDF) deserialization returns `xsd:base64Binary` literals as
   their base64 text; previously the value was wrapped in a Python bytes
-  repr (`b'…'`), corrupting the round trip (#288)
+  repr (`b'…'`), corrupting the round trip ([#288](https://github.com/trungdong/prov/issues/288))
 - PROV-O (RDF) deserialization reconciles `prov:startedAtTime`/
   `prov:endedAtTime` asserted directly on a qualified `prov:Start`/
   `prov:End` node into the relation's formal `prov:time` attribute;
   previously the formal attribute was left `None` and the value misfiled as
-  an extra attribute (#299)
+  an extra attribute ([#299](https://github.com/trungdong/prov/issues/299))
 - PROV-O (RDF) round trip: an anonymous Communication/Attribution/Influence
   relation carrying extra attributes now deserializes back into a single
-  record instead of two (#303)
+  record instead of two ([#303](https://github.com/trungdong/prov/issues/303))
 - PROV-O (RDF) round trip: a qualified name whose local part ends in a PROV-N
   metacharacter (`= ' , : ; [ ]`) now deserializes instead of raising
-  `ValueError: Can't split ...`; serialized output is unchanged (#294)
+  `ValueError: Can't split ...`; serialized output is unchanged ([#294](https://github.com/trungdong/prov/issues/294))
 - PROV-N output escapes qualified-name local parts per the grammar's
   `PN_CHARS_ESC` production, so identifiers containing `' ( ) , : ; [ ]
-  =` no longer produce invalid PROV-N (#223)
-- PROV-N continues to emit Mention as bare `mentionOf(...)` — the
-  de-facto syntax of the reference implementations for the last decade —
+  =` no longer produce invalid PROV-N ([#223](https://github.com/trungdong/prov/issues/223))
+- PROV-N continues to emit Mention as bare `mentionOf(...)`, the
+  de-facto syntax of the reference implementations for the last decade,
   rather than the `prov:mentionOf` form derivable from the PROV-Links
-  note; now documented as a deliberate deviation (#248)
+  note; now documented as a deliberate deviation ([#248](https://github.com/trungdong/prov/issues/248))
 
 ### Improvements
 
 - Bundle-local and default namespace prefixes are now bound into RDF
   serialization alongside document-level ones, so turtle/TriG output uses
   the declared prefixes instead of auto-minted `ns1:`-style fallbacks
-  (#96)
+  ([#96](https://github.com/trungdong/prov/issues/96))
 - Security: PROV-XML parsing no longer resolves DTD entities and never
   touches the network (`resolve_entities=False`, `no_network=True`),
-  closing an XXE surface on untrusted input (#273)
+  closing an XXE surface on untrusted input ([#273](https://github.com/trungdong/prov/issues/273))
 - New public type aliases in `prov.model`, joining the existing
   `NameValuePair`: `AttributePair` (an attribute name/value pair before
   qualified-name resolution), `InfluencerRef` (the `influencer` parameter
@@ -262,19 +262,19 @@ for what changed and what to do about it.
 ### Internal
 
 - The PROV-O (RDF) serializer's encode/decode container functions were
-  decomposed into per-record-type dispatch, with byte-identical output (#274)
+  decomposed into per-record-type dispatch, with byte-identical output ([#274](https://github.com/trungdong/prov/issues/274))
 - Functions across the model, the serializers and `prov.dot` were refactored
   below the project's complexity threshold, with byte-identical behaviour
-  (#275)
-- Code-quality passes across `src/prov/` — type-alias adoption, removal of a
+  ([#275](https://github.com/trungdong/prov/issues/275))
+- Code-quality passes across `src/prov/` (type-alias adoption, removal of a
   permanently-disabled branch in the PROV-O (RDF) encoder, and readability
-  clean-ups — with no change in behaviour
+  clean-ups) with no change in behaviour
 - Test infrastructure: the RDF fixture-comparison helper `find_diff()` now
-  detects single-triple differences, which it previously missed (#304)
+  detects single-triple differences, which it previously missed ([#304](https://github.com/trungdong/prov/issues/304))
 
 ## 2.5.1 (2026-07-13)
 
-- `prov.read()` polish following 2.5.0's #239: seekable streams are now
+- `prov.read()` polish following 2.5.0's [#239](https://github.com/trungdong/prov/issues/239): seekable streams are now
   rewound between auto-detection attempts (so e.g. a PROV-XML stream
   auto-detects instead of being consumed by the first candidate); rdflib's
   "does not look like a valid URI" logger noise from swallowed candidate
@@ -287,22 +287,22 @@ for what changed and what to do about it.
 
 ## 2.5.0 (2026-07-13)
 
-- New record-level chaining convenience methods (#154):
+- New record-level chaining convenience methods ([#154](https://github.com/trungdong/prov/issues/154)):
   `ProvEntity.wasRevisionOf()`, `.wasQuotedFrom()`, `.hadPrimarySource()`,
   `.mentionOf()`, and `.wasInfluencedBy()` on `ProvEntity`,
-  `ProvActivity` and `ProvAgent` — mirroring the existing
+  `ProvActivity` and `ProvAgent`, mirroring the existing
   `e1.wasDerivedFrom(e2)` style for the remaining relation types
 - The PROV-XML deserializer now raises `ProvXMLException` when a record's
   child element carries only unrecognised XML attributes, instead of leaking a
   raw `UnboundLocalError` or silently reusing the previous attribute's value
-  (#254)
+  ([#254](https://github.com/trungdong/prov/issues/254))
 - `ProvDocument.serialize()` and `deserialize()` now accept any writable/
   readable file-like object (e.g. `tempfile.NamedTemporaryFile`), instead of
   only `io.IOBase` instances; previously such destinations were silently
   treated as file paths, writing to a repr-named file in the working
   directory. The serializers' text/binary stream detection now also
-  recognises such wrapper objects as text streams (#240)
-- `prov.read()` fixes (#239): valid PROV-XML is now auto-detected (the RDF
+  recognises such wrapper objects as text streams ([#240](https://github.com/trungdong/prov/issues/240))
+- `prov.read()` fixes ([#239](https://github.com/trungdong/prov/issues/239)): valid PROV-XML is now auto-detected (the RDF
   parser's `BadSyntax` no longer aborts detection); a `str`/`bytes`
   source that is not an existing file path is parsed as raw content, as the
   documentation always advertised; and input that no deserializer can
@@ -311,31 +311,31 @@ for what changed and what to do about it.
 - Documentation: the agent-subtype idiom now correctly uses qualified names
   (`PROV["Person"]`) for `prov:type` values; the previously documented
   string form asserted a plain string, which does not denote the pre-defined
-  PROV type (#236)
+  PROV type ([#236](https://github.com/trungdong/prov/issues/236))
 
 ## 2.4.0 (2026-07-06)
 
 - **Documentation overhaul**: the documentation has been reorganised along the
   Diátaxis framework (tutorials, how-to guides, reference, explanations), with
   new furo/MyST/napoleon/intersphinx tooling behind the Sphinx build. Closes
-  #141 (graphics export how-to) and #83 (`prov-convert`/`prov-compare` CLI
-  tools how-to). (#210, #211, #212, #213, #214, #215, #216)
+  [#141](https://github.com/trungdong/prov/issues/141) (graphics export how-to) and [#83](https://github.com/trungdong/prov/issues/83) (`prov-convert`/`prov-compare` CLI
+  tools how-to). ([#210](https://github.com/trungdong/prov/issues/210), [#211](https://github.com/trungdong/prov/issues/211), [#212](https://github.com/trungdong/prov/issues/212), [#213](https://github.com/trungdong/prov/issues/213), [#214](https://github.com/trungdong/prov/issues/214), [#215](https://github.com/trungdong/prov/issues/215), [#216](https://github.com/trungdong/prov/issues/216))
 - **Test suite redesigned as pytest-native**: shared statement/attribute/qname
   coverage is now expressed once and parametrized across a document x format
   matrix (json/xml/rdf/model) instead of being copy-pasted per serializer;
   Hypothesis property-based round-trip tests generate documents across the
   full feature set; a malformed-input corpus exercises each deserializer's
-  error handling. (#219, #220, #221, #222, #227, #229)
+  error handling. ([#219](https://github.com/trungdong/prov/issues/219), [#220](https://github.com/trungdong/prov/issues/220), [#221](https://github.com/trungdong/prov/issues/221), [#222](https://github.com/trungdong/prov/issues/222), [#227](https://github.com/trungdong/prov/issues/227), [#229](https://github.com/trungdong/prov/issues/229))
 - **`prov.model` split into a package** (`prov.model.records`,
   `prov.model.namespaces`, `prov.model.bundle`) for maintainability, with
   no import-path changes: every historic `from prov.model import X` still
-  works identically. (#231)
-- Minor Makefile/CLAUDE.md cleanup for contributors. (#209)
+  works identically. ([#231](https://github.com/trungdong/prov/issues/231))
+- Minor Makefile/CLAUDE.md cleanup for contributors. ([#209](https://github.com/trungdong/prov/issues/209))
 - The serializer registry now degrades gracefully when the optional `rdf`
   (`rdflib`) or `xml` (`lxml`) extra is not installed: `import prov`
   and the JSON/PROV-N serializers work in a minimal install, and requesting
   the `rdf`/`xml` format raises an informative `DoNotExist` naming the
-  missing extra instead of a bare `ModuleNotFoundError`. (#230)
+  missing extra instead of a bare `ModuleNotFoundError`. ([#230](https://github.com/trungdong/prov/issues/230))
 - Deprecation warnings signposting planned 3.0 changes: importing
   `prov.dot`/`prov.graph` now emits a `DeprecationWarning` naming the
   future `prov[dot]`/`prov[graph]` extras those modules will require, and
@@ -344,41 +344,41 @@ for what changed and what to do about it.
   hidden by default (standard `DeprecationWarning`/`FutureWarning`
   semantics) and link to the new
   [Upgrading to 3.0](https://github.com/trungdong/prov/blob/main/docs/upgrading-3.0.md)
-  guide, which tables every planned 3.0 change and what to do about it.
+  guide, which tables every planned 3.0 change and what to do about it
 
 ## 2.3.0 (2026-07-05)
 
 - **Dropped Python 3.9 support; minimum is now Python 3.10** (security fixes
-  in transitive dependencies are only released for Python 3.10+) (#189)
+  in transitive dependencies are only released for Python 3.10+) ([#189](https://github.com/trungdong/prov/issues/189))
 - **Widened `rdflib` to `>=6.0.0,<8`** (was `>=4.2.1,<7`): rdflib 7 now
   supported; the floor rose because 4.2.1 no longer installs on supported
-  Pythons (#207)
+  Pythons ([#207](https://github.com/trungdong/prov/issues/207))
 - Diagnostic improvement: `DoNotExist` (serializer lookup) and the CLI's
   `CLIError` now set `__cause__` via exception chaining, so tracebacks
   show the original error; exception types and messages are unchanged, so
-  existing `except` blocks are unaffected (#200)
+  existing `except` blocks are unaffected ([#200](https://github.com/trungdong/prov/issues/200))
 - Whole package passes `mypy --strict`; ships a `py.typed` marker
-  (PEP 561) so downstream type-checkers see inline types (#192, #193, #194)
+  (PEP 561) so downstream type-checkers see inline types ([#192](https://github.com/trungdong/prov/issues/192), [#193](https://github.com/trungdong/prov/issues/193), [#194](https://github.com/trungdong/prov/issues/194))
 - Coverage raised to 97%, enforced in CI; new tests for the CLI scripts,
   `prov.read()` auto-detection, graph interop, and the serializer
-  registry (#201, #202, #203, #204)
+  registry ([#201](https://github.com/trungdong/prov/issues/201), [#202](https://github.com/trungdong/prov/issues/202), [#203](https://github.com/trungdong/prov/issues/203), [#204](https://github.com/trungdong/prov/issues/204))
 - Internal code quality: ruff rule families I/C4/SIM/RUF/UP045/UP031 enabled
-  and long-standing lint suppressions resolved (#195, #196, #197, #198,
-  #199, #200); dependency audit documented in `docs/dependencies.md`; tox
+  and long-standing lint suppressions resolved ([#195](https://github.com/trungdong/prov/issues/195), [#196](https://github.com/trungdong/prov/issues/196), [#197](https://github.com/trungdong/prov/issues/197), [#198](https://github.com/trungdong/prov/issues/198),
+  [#199](https://github.com/trungdong/prov/issues/199), [#200](https://github.com/trungdong/prov/issues/200)); dependency audit documented in `docs/dependencies.md`; tox
   removed (use `uv run --python 3.X pytest` for local multi-version
-  testing) (#205)
+  testing) ([#205](https://github.com/trungdong/prov/issues/205))
 - Security hygiene: `SECURITY.md`, Dependabot version updates, and a
-  documented support policy (#190)
-- Fixed ReadTheDocs build (Sphinx pinned `<9`) (#187)
+  documented support policy ([#190](https://github.com/trungdong/prov/issues/190))
+- Fixed ReadTheDocs build (Sphinx pinned `<9`) ([#187](https://github.com/trungdong/prov/issues/187))
 
 ## 2.2.0 (2026-07-03)
 
-- Fixed graphical output when a filename is supplied (#164)
-- Fixed PROV-XML deserialization when prov is the default namespace (#155)
-- New `plot` extra: `pip install prov[plot]` for matplotlib support (#166)
+- Fixed graphical output when a filename is supplied ([#164](https://github.com/trungdong/prov/issues/164))
+- Fixed PROV-XML deserialization when prov is the default namespace ([#155](https://github.com/trungdong/prov/issues/155))
+- New `plot` extra: `pip install prov[plot]` for matplotlib support ([#166](https://github.com/trungdong/prov/issues/166))
 - Marked as Production/Stable; added Python 3.14 to the test matrix
 - Tooling: ruff (lint+format), pytest runner, uv-based CI, automated PyPI
-  releases via Trusted Publishing. No public API changes.
+  releases via Trusted Publishing. No public API changes
 
 ## 2.1.1 (2025-06-24)
 
@@ -397,11 +397,11 @@ for what changed and what to do about it.
 ## 2.0.1 (2024-06-10)
 
 - Removed support for EOL Python 3.6 and 3.7
-- Minor documentation update (#153)
-- Stopped using deepcopy when duplicating Namespace (#158)
-- Restricting rdflib package version to "<7" (#156)
-- Raise an exception when an empty URI is registered as a namespace (#142)
-- Ensure rdflib 6+ returns bytes when serializing tests (fixed #151)
+- Minor documentation update ([#153](https://github.com/trungdong/prov/issues/153))
+- Stopped using deepcopy when duplicating Namespace ([#158](https://github.com/trungdong/prov/issues/158))
+- Restricting rdflib package version to "<7" ([#156](https://github.com/trungdong/prov/issues/156))
+- Raise an exception when an empty URI is registered as a namespace ([#142](https://github.com/trungdong/prov/issues/142))
+- Ensure rdflib 6+ returns bytes when serializing tests (fixed [#151](https://github.com/trungdong/prov/issues/151))
 - Removed fancy label output for bundle
 
 ## 2.0.0 (2020-11-01)

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,175 +1,125 @@
-# Dependency audit
+# Dependencies
 
-Audit date: 2026-07-05, against `master` @ `185c062` (Phase 2 dependency audit, T14).
-Pin rationales re-verified 2026-07-27, against `master` @ `970524f`, ahead of the 3.0.0
-release: every rationale below was re-read against `uv.lock`, and the Sphinx and numpy
-constraints were re-derived by actually re-resolving and re-running the tooling they
-guard (commands and outcomes recorded in their entries below), not by re-asserting the
-prior text.
+Why each runtime extra, dev-group and docs-group entry exists, and why it is pinned the
+way it is. Last checked 2026-09-10 against `pyproject.toml` and `uv.lock` at 3.1.1. Version
+numbers quoted here drift after that date, so check `pyproject.toml` before relying on
+them.
 
-Why every runtime dependency, extra, and dev/docs-group entry exists, and why it's pinned
-the way it is. Re-check pins against `pyproject.toml` before trusting the version numbers
-below — they drift after the audit date above.
+## Runtime dependencies
 
-## Runtime dependencies (`[project.dependencies]`)
+`prov` has no unconditional runtime dependencies. `pydot` and `networkx` moved behind the
+`dot` and `graph` extras in 3.0.0, and `python-dateutil` was dropped in the same release in
+favour of `prov.model.parse_xsd_datetime()`, an `xsd:dateTime` parser built on the standard
+library's `datetime.fromisoformat()`.
 
-`prov` has **no unconditional runtime dependencies** as of 3.0.0.dev0. `pydot` and
-`networkx` moved behind the `dot`/`graph` extras, and `python-dateutil` was dropped in
-3.0 — datetime strings are now parsed by `prov.model.parse_xsd_datetime()`, a stdlib
-`datetime.fromisoformat()`-based `xsd:dateTime` parser, resolving the long-standing
-`# TODO: is this really needed?` that used to sit next to the `python-dateutil` entry here.
+## Optional extras
 
-## Optional extras (`[project.optional-dependencies]`)
+Install with `prov[extra]`. A missing extra raises an error naming it when the capability is
+used, not at `import prov` time.
 
-Install with `prov[extra]`; omitting them makes the corresponding serializer/module raise
-`ModuleNotFoundError` when used, not at `import prov` time.
+| Extra | Packages | Backs |
+|---|---|---|
+| `rdf` | `rdflib>=7.0.0,<8` | `prov.serializers.provrdf`, PROV-O (RDF) |
+| `xml` | `lxml>=3.3.5` | `prov.serializers.provxml`, PROV-XML |
+| `dot` | `pydot>=1.2.0`, `networkx>=2.0` | `prov.dot`, Graphviz rendering |
+| `graph` | `networkx>=2.0` | `prov.graph`, NetworkX interop |
+| `plot` | `matplotlib>=3.6`, `pydot>=1.2.0`, `networkx>=2.0` | The interactive display in `ProvBundle.plot()` |
 
-- **`dot` → `pydot>=1.2.0`, `networkx>=2.0`** — backs `prov.dot` (`prov_to_dot()`),
-  rendering a document to a `pydot.Graph` for export via Graphviz (PDF/PNG/SVG). Requires
-  a *local* `graphviz` binary installed separately; `pydot` alone only builds the DOT
-  representation. `prov.dot` renders through `prov.graph` internally, so this extra
-  carries `networkx` too, not just `pydot`. `pydot` floor `1.2.0` predates this project's
-  use of it; `networkx` floor `2.0` is the first release with the API `prov.graph` relies
-  on. Both were unconditional runtime dependencies before 3.0.0.dev0 (see
-  `docs/upgrading-3.0.md`).
-- **`graph` → `networkx>=2.0`** — backs `prov.graph` (`prov_to_graph()`/
-  `graph_to_prov()`), the NetworkX `MultiDiGraph` interop. Same floor/rationale as the
-  `networkx` pin under `dot` above.
-- **`rdf` → `rdflib>=7.0.0,<8`** — backs `prov.serializers.provrdf` (PROV-O/RDF
-  serialization). Floor raised to `7.0.0` 2026-07-18 (roadmap step 35, 3.0.0.dev0): the
-  rdflib-6 accidental prefix-carrying behaviour described below is no longer supported,
-  and the serializer now depends on `rdflib.graph.Dataset`/`DATASET_DEFAULT_GRAPH_ID`,
-  which don't exist before rdflib 7. Internally, `provrdf.py` migrated off the deprecated
-  `ConjunctiveGraph` to `Dataset(default_union=True)` plus named `Graph`s — deferred from
-  2.x precisely because `Dataset`'s defaults (e.g. `default_union`) are not
-  behaviour-neutral, so the switch waited for a 3.0 breaking-change window.
-  `default_union=True` reproduces `ConjunctiveGraph`'s union-query semantics, and
-  round-trip behaviour (including the bundle-local-namespaces-as-full-IRIs point below)
-  is unchanged by the migration. The `rdflib-compat` CI job proves both bounds (`7.0.0`
-  floor and newest 7.x); the main matrix uses the locked version. Under rdflib 7,
-  bundle-local namespaces serialize as full IRIs instead of their original prefixes
-  (round-trips stay equivalent — `QualifiedName` equality is by IRI). Separately, from
-  rdflib 7.3.0 onward rdflib's own internals (`ConjunctiveGraph.add()`/`.parse()`, and
-  the TriG parser/serializer plugins) call their own now-deprecated `Dataset.contexts()`/
-  `Dataset.default_context` under the hood, so a `-W error::DeprecationWarning` run
-  against `test_rdf.py` fails on rdflib >=7.3 even though `provrdf.py` no longer
-  directly calls a deprecated rdflib name in the document-encoding path (confirmed
-  clean against the `7.0.0` floor); this is rdflib's own migration debt, slated for
-  cleanup by their 8.0. (`encode_container()` still accepts a caller-supplied `Dataset`
-  as its `container` argument for API-compatibility reasons; that path's own `.add()`
-  calls do re-trip rdflib's internal warning, since `Dataset` inherits `.add()` from the
-  deprecated `ConjunctiveGraph` unchanged — see the method's docstring.)
-- **`xml` → `lxml>=3.3.5`** — backs `prov.serializers.provxml` (PROV-XML). Floor predates
-  this project's adoption; no known upper-bound issue.
-- **`plot` → `matplotlib>=3.6`, `pydot>=1.2.0`, `networkx>=2.0`** — backs the
-  interactive-display path of `ProvBundle.plot()`/`ProvDocument.plot()` in
-  `src/prov/model/bundle.py`; `plot()` renders through `prov.dot` (lazily imported), so
-  this extra pulls in `pydot`/`networkx` alongside `matplotlib` rather than requiring
-  `prov[dot]` to be depended on separately. `matplotlib` floor `3.6` is a defensive modern
-  baseline rather than a verified minimum; not exercised in CI (no display backend in the
-  test environment), so this path is coverage-`defer`red (see
-  `planning/test-gap-checklist.md`).
+### `rdf`
 
-## Dev dependency group (`[dependency-groups] dev`)
+The floor rose from 6.0.0 to 7.0.0 in 3.0.0. The serializer uses `rdflib.graph.Dataset` and
+`DATASET_DEFAULT_GRAPH_ID`, which do not exist before rdflib 7, and rdflib 6's accidental
+prefix-carrying behaviour is no longer supported. `Dataset(default_union=True)` reproduces
+the union-query semantics of the deprecated `ConjunctiveGraph` it replaced, so round-trip
+behaviour is unchanged. Under rdflib 7, bundle-local namespaces serialize as full IRIs
+rather than their original prefixes; round trips stay equivalent because `QualifiedName`
+equality is by IRI.
 
-Tools needed to develop/test/lint/typecheck the package locally and in CI; never installed
-for end users.
+The `rdflib-compat` CI job runs the RDF tests against both bounds, `==7.0.0` and the newest
+7.x. The main matrix uses the locked version.
 
-- **`coverage>=7.6.10`** — measures branch coverage for the `fail_under` ratchet enforced
-  in CI (see `[tool.coverage]` in `pyproject.toml`).
-- **`hypothesis>=6.156.1`** — property-based testing; drives the round-trip strategies in
-  `src/prov/tests/strategies.py` exercised by `test_property_roundtrip.py` over
-  `ROUNDTRIP_FORMATS`. Added when that module was introduced (added to this audit
-  2026-07-27; the pin itself predates this note — it was missing from the dev-group list
-  above by omission, not by design).
-- **`jsonschema>=4`** — validates PROV-JSON output against the vendored member-submission
-  schema in `test_json_schema.py`, and PROV-JSONLD output against a second vendored schema
-  in `test_jsonld_schema.py` (both under `src/prov/tests/schemas/`). Same omission/backfill
-  as `hypothesis` above.
-- **`lxml-stubs>=0.5.1`** — type stubs for `lxml`, needed for `mypy --strict` to type-check
-  `provxml.py` without treating `lxml` as `Any`.
-- **`mypy>=1.19.1`** — the strict type checker (`[tool.mypy] strict = true`); floor is
-  whatever version this project first enforced strict mode + `py.typed` with.
-- **`pre-commit>=4.0.1`** — runs ruff (lint + format) and hygiene checks
-  (trailing-whitespace/EOF-newline/YAML-TOML validation) automatically at commit time; see
-  `CONTRIBUTING.md` step 4.
-- **`pyld>=2.0.4`** — reference JSON-LD processor used only by `test_jsonld_semantics.py`
-  to prove PROV-JSONLD output expands to the intended RDF terms. Test-time only: `prov`
-  itself never imports it, so it carries no runtime dependency. Floor `2.0.4` is a
-  defensive modern baseline (the resolved/locked version at introduction was `3.1.0`), not
-  a verified minimum.
-- **`pytest>=8.4.2`** — the test runner; collects the `unittest.TestCase`-style test suite
-  under `src/prov/tests/` natively.
-- **`pytest-cov>=7.1.0`** — pytest's coverage plugin, so `coverage` can attribute hits
-  correctly when tests run under pytest instead of `unittest`.
-- **`ruff>=0.15.20`** — combined linter (replacing the historic flake8) and formatter
-  (replacing the historic black); see `[tool.ruff]` for the enabled rule families.
-- **`types-networkx>=3.4.2.20250509`** — type stubs for `networkx`, needed for
-  `mypy --strict` on `graph.py`. Pulls in `numpy` transitively (see the `numpy<2.5`
-  constraint below).
+From rdflib 7.3.0 its own internals call deprecated `Dataset` members, so a
+`-W error::DeprecationWarning` run of the RDF tests fails on rdflib 7.3 and later even
+though `provrdf.py` calls no deprecated rdflib name in the encoding path. That is rdflib's
+migration debt, slated for its 8.0. The `own-warnings` CI job therefore counts only
+warnings attributed to `prov` modules. `encode_container()` still accepts a caller-supplied
+`Dataset` for API compatibility; that path's `.add()` calls trip the same rdflib warning.
 
-Previously in this group and removed by this audit: `bumpversion` (a release-time-only
-tool with no place in the routine dev loop — reintroduce as a dedicated group if release
-automation is scripted later), `setuptools`/`wheel` (build-backend concerns declared under
-`[build-system]`, not something a dev environment needs to import directly), `tox`
-(replaced by direct `uv run --python 3.X pytest` invocations across the supported
-interpreter matrix; CI already covers the matrix independently — see "Local multi-version
-testing" in `CLAUDE.md`), and `sphinx`/`sphinx-rtd-theme` (moved to the new `docs` group
-below, since building the documentation is a separate concern from running/lint/typecheck
-tests; at that point the RTD build still installed `docs/requirements.txt` directly, not
-the dev group — since T21/docs-tooling (2026-07-05) RTD installs the `docs` group directly
-via `uv sync`, see below).
+### `xml`
 
-## Docs dependency group (`[dependency-groups] docs`)
+The `lxml` floor predates this project's adoption. No known upper-bound issue. The
+deserializer passes its own hardened `XMLParser` at every parse site; see the comment in
+`provxml.py` for why the floor matters there.
 
-The single source of truth for docs build dependencies — both local builds
-(`uv sync --group docs --extra rdf --extra xml`) and ReadTheDocs (`.readthedocs.yml` runs
-`uv sync --frozen --no-dev --group docs --extra rdf --extra xml` directly) install from
-this group. `docs/requirements.txt` — a hand-maintained mirror of this list that RTD used
-before it could run `uv` in its build image — was deleted 2026-07-05 (T21) once RTD's
-`build.jobs.create_environment` could install `uv` itself via `asdf`; keeping two
-manually-synced dependency lists was a standing liability.
+### `dot`, `graph` and `plot`
 
-- **`sphinx>=8.1.3`** — the documentation generator. Was capped `<9` from 2026-07-04:
-  Sphinx 9's autodoc calls `repr()` on class bases while documenting
-  `prov.serializers.provrdf`, and rdflib's `DefinedNamespaceMeta.__repr__`
-  (`rdflib.namespace`) used to raise `AttributeError` on its abstract base class,
-  crashing the build; re-verified 2026-07-05 with the furo theme swap, the crash still
-  reproduced on 9.1.0. **Cap lifted 2026-07-27**: rdflib fixed it — the currently locked
-  rdflib (7.6.0) has `DefinedNamespaceMeta.__repr__` catch that `AttributeError` itself
-  and fall back to a placeholder string instead of propagating it (confirmed by reading
-  the method's source out of the installed package). Verified end to end by resolving
-  Sphinx unconstrained (`uv lock --upgrade-package sphinx`, which now locks 9.0.4 for
-  Python 3.11 and 9.1.0 for Python ≥3.12) and then building the docs against that lock
-  with `uv run --group docs --extra rdf --extra xml --extra dot --extra graph
-  sphinx-build -b html -W docs docs/_build/html`: build succeeds, 0 warnings. If a
-  similar autodoc crash resurfaces on a future Sphinx major, re-run that same build
-  with `-W` before assuming a new cap is needed.
-- **`furo`** — the HTML theme for the published docs, replacing `sphinx_rtd_theme`
-  2026-07-05 (T21): actively maintained, accessible defaults, and native light/dark mode
-  without extra configuration. No known version constraints yet.
-- **`myst-parser`** — lets `.md` sources (in addition to `.rst`) build as Sphinx pages,
-  via `source_suffix` in `conf.py`. Added T21 so future docs content (Diátaxis
-  restructure, tasks 3–6 of the modernisation roadmap) isn't forced into reStructuredText.
-  Enables the `colon_fence`/`deflist` MyST extensions only; no other extensions are
-  needed by the current page set.
-- **`sphinx-copybutton`** — adds a "copy" button to code blocks in the rendered HTML;
-  purely a UX nicety for the many shell/PROV-N/JSON snippets across the docs. Added T21.
+`prov.dot` renders through `prov.graph`, so the `dot` extra carries `networkx` as well as
+`pydot`. Rendering also needs a local Graphviz binary, which no extra installs. `plot()`
+renders through `prov.dot`, so the `plot` extra carries `pydot` and `networkx` alongside
+`matplotlib`. The `pydot` floor predates this project's use of it and the `networkx` floor
+is the first release with the API `prov.graph` relies on. The `matplotlib` floor is a
+defensive modern baseline, not a verified minimum. The interactive `plot()` path is not
+exercised in CI because the test environment has no display backend; it is annotated
+"defer" in `planning/test-gap-checklist.md`.
 
-Removed T21: `sphinx_rtd_theme` (superseded by `furo`, above).
+## Dev dependency group
 
-## `[tool.uv] constraint-dependencies`
+Tools for developing, testing, linting and type-checking the package locally and in CI.
+Never installed for end users.
 
-- **`numpy<2.5`** — numpy is never imported by `prov` itself; it arrives transitively via
-  `types-networkx` and `matplotlib`. numpy 2.5 switched its inline stubs to unconditional
-  PEP 695 `type` statements, which mypy refuses to parse once `[tool.mypy] python_version`
-  is below 3.12 (this project's `python_version = "3.10"`), regardless of the interpreter
-  actually running mypy. Capping numpy avoids that crash. **Re-checked 2026-07-27, still
-  needed**: numpy's current PyPI release is 2.5.1. Clearing the constraint and running
-  `uv lock --upgrade-package numpy` resolves numpy 2.5.1 for Python ≥3.12; `uv sync` that
-  lock and `uv run mypy src` immediately fails with `numpy/__init__.pyi: error: Type
-  statement is only supported in Python 3.12 and greater [syntax]`, reproducing the
-  original crash. Constraint restored and re-locked. If a Dependabot bump of
-  `matplotlib`/`types-networkx` ever fails to resolve because of this constraint, lift it,
-  run `uv run mypy src`, and keep the lift only if mypy stays green (e.g. once numpy gates
-  the new stub syntax on `python_version`, or this project's mypy floor rises to 3.12).
+| Package | Purpose |
+|---|---|
+| `coverage>=7.6.10` | Branch coverage for the `fail_under` ratchet in `[tool.coverage]`. |
+| `hypothesis>=6.156.1` | Property-based round-trip tests, `strategies.py` and `test_property_roundtrip.py`. |
+| `jsonschema>=4` | Validates PROV-JSON and PROV-JSONLD output against the vendored schemas under `src/prov/tests/schemas/`. |
+| `lxml-stubs>=0.5.1` | Type stubs so `mypy --strict` can check `provxml.py`. |
+| `mypy>=1.19.1` | Strict type checking; the floor is the version strict mode was first enforced with. |
+| `pre-commit>=4.0.1` | Runs ruff and the hygiene hooks at commit time; see `CONTRIBUTING.md`. |
+| `pyld>=2.0.4` | Reference JSON-LD processor used only by `test_jsonld_semantics.py`; `prov` never imports it. The floor is a defensive baseline, not a verified minimum. |
+| `pytest>=8.4.2` | The test runner. |
+| `pytest-cov>=7.1.0` | Coverage attribution under pytest. |
+| `ruff>=0.15.20` | Linter and formatter; `[tool.ruff]` lists the rule families. |
+| `types-networkx>=3.4.2.20250509` | Type stubs for `graph.py` under `mypy --strict`. Pulls in `numpy` transitively, see the constraint below. |
+
+Removed from this group in 2.3.0: `bumpversion`, `setuptools`, `wheel` and `tox`. Build
+backend requirements live under `[build-system]`, and the interpreter matrix is run with
+`uv run --python 3.X pytest`, as `CONTRIBUTING.md` shows. `sphinx` and `sphinx-rtd-theme`
+moved to the docs group below.
+
+## Docs dependency group
+
+The single source of truth for documentation builds. Local builds and Read the Docs both
+install it, with all four extras because autodoc imports the serializers, `prov.dot` and
+`prov.graph`:
+
+```bash
+uv sync --group docs --extra rdf --extra xml --extra dot --extra graph
+```
+
+`.readthedocs.yml` runs the same `uv sync` with `--frozen --no-dev`.
+
+| Package | Purpose |
+|---|---|
+| `sphinx>=8.1.3` | The documentation generator. |
+| `furo` | The HTML theme. Actively maintained, accessible defaults, native light and dark mode. |
+| `myst-parser` | Builds the `.md` sources; only the `colon_fence` and `deflist` extensions are enabled. |
+| `sphinx-copybutton` | A copy button on code blocks. |
+
+Sphinx was capped below 9 from 2.3.0 to 3.0.0 because Sphinx 9's autodoc called `repr()`
+on rdflib's `DefinedNamespaceMeta`, which raised `AttributeError` and crashed the build.
+rdflib 7.6.0 catches that error itself, so the cap was lifted for 3.0.0 after a clean
+`sphinx-build -W` against Sphinx 9. The lock file currently resolves Sphinx 8.1.3. If a
+similar autodoc crash appears on a future Sphinx major, rebuild with `-W` before assuming a
+new cap is needed.
+
+## `[tool.uv]` constraint
+
+`numpy<2.5`. `prov` never imports numpy; it arrives transitively through `types-networkx`
+and `matplotlib`. numpy 2.5 switched its inline stubs to unconditional PEP 695 `type`
+statements, which mypy refuses to parse while `[tool.mypy] python_version` is below 3.12,
+whatever interpreter runs mypy. Clearing the constraint and re-locking reproduces the crash
+(`numpy/__init__.pyi: error: Type statement is only supported in Python 3.12 and greater`).
+If a Dependabot bump of `matplotlib` or `types-networkx` fails to resolve because of this
+constraint, lift it, run `uv run mypy src`, and keep the lift only if mypy stays green.
+That becomes possible once numpy gates the new syntax on `python_version` or this
+project's mypy floor rises to 3.12.

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -51,8 +51,7 @@ XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 # a safe lxml release, any other library sharing the process can repoint the
 # *global* default parser via `etree.set_default_parser(...)`, which is what
 # a bare `etree.parse(...)` call (no `parser=`) silently inherits; and prov
-# is consumed by other applications (e.g. ProvStore) that may load such
-# libraries. Passing this parser explicitly at both parse sites closes all
+# is embedded in other applications that may load such libraries. Passing this parser explicitly at both parse sites closes all
 # three regardless of the installed lxml version or what else is loaded in
 # the process. `huge_tree` is left at its lxml default of `False`: raising it
 # disables libxml2's own hard limits on tree depth/text length/entity
@@ -63,8 +62,8 @@ XML_XSD_URI = "http://www.w3.org/2001/XMLSchema"
 # "is not harmful", only less efficient than per-thread instances under
 # heavy concurrent load (access is internally serialized). PROV-XML
 # deserialization is not expected to be a high-frequency, highly concurrent
-# hot path even in a web service such as ProvStore, so the simplicity of a
-# single shared parser wins over per-parse allocation; if profiling ever
+# hot path even in a web service, so the simplicity of a single shared
+# parser wins over per-parse allocation; if profiling ever
 # shows lock contention here, switch to constructing a parser per call.
 _XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True)
 

--- a/src/prov/tests/test_attribute_merging.py
+++ b/src/prov/tests/test_attribute_merging.py
@@ -13,8 +13,8 @@ attribute union.
 This module characterizes the fixed behaviour: both values are now retained
 on the record -- observable through ``attributes``/``extra_attributes``
 iteration, record equality/hashing, and serialization -- and the retained
-values survive serialization round trips. By maintainer decision (`prov` is
-a published dependency of ProvStore), the three narrowing accessors
+values survive serialization round trips. By maintainer decision (downstream
+projects depend on the 2.x return types), the three narrowing accessors
 (``get_attribute()``, ``get_asserted_types()``, ``.value``) deliberately keep
 their 2.x return type: a plain ``set`` built fresh from the record's own
 type-aware storage, which re-collapses a Python-equal-but-differently-typed
@@ -200,9 +200,8 @@ def test_mixed_typed_attribute_round_trips(fmt):
 #
 # get_attribute()/get_asserted_types()/.value deliberately keep returning a
 # plain `set` built fresh from the record's own type-aware storage, instead
-# of exposing that storage directly: `prov` is a published dependency of
-# ProvStore, so the narrow, 2.x-compatible return type was chosen over a new
-# public container type. The accepted consequence is that a Python-equal-
+# of exposing that storage directly: downstream projects depend on the 2.x
+# return type, so it was kept over a new public container type. The accepted consequence is that a Python-equal-
 # but-differently-typed pair retained on the record re-collapses in what
 # these three accessors return -- exactly the 2.x behaviour -- even though
 # the record's own storage, `attributes`/`extra_attributes`, equality/

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -690,8 +690,8 @@ def test_escape_unescape_ncname_localpart_is_inverse(local):
 #   public API. Both `etree.parse` call sites in provxml.py pass no
 #   `parser=` argument, so they silently inherit whatever
 #   `lxml.etree.set_default_parser()` last installed process-wide -- which
-#   any other library sharing the interpreter (prov is embedded in
-#   ProvStore, among others) is free to do. Measured directly:
+#   any other library sharing the interpreter is free to do, and prov is
+#   embedded in other applications. Measured directly:
 #
 #     pristine global default              -> XMLSyntaxError (safe)
 #     after set_default_parser(permissive) -> parsed, file contents leaked


### PR DESCRIPTION
Follow-up to the documentation review (PRs #424 to #427).

docs/dependencies.md is rewritten against pyproject.toml, uv.lock and CI as of 3.1.1. Wrong claims fixed: Read the Docs installs all four extras, not two; the lock resolves Sphinx 8.1.3, not 9; the test suite is pytest-native, not unittest-style; a CLAUDE.md section it cited no longer exists. Audit narration and plan-task references are gone; extras and dependency groups are tables.

HISTORY.md uses one style throughout: every issue reference is a link, as the 3.1.1 entry already did, and the em dashes and stray trailing full stops in older entries are gone. No entry's content changed.

Three source comments cited ProvStore, decommissioned in December 2024, as the downstream consumer behind a design choice. They now say downstream applications.

Verified: full pytest matrix on 3.10 to 3.14 and PyPy 3.11 (1672 passed, 26 skipped, matching main), mypy strict and ruff clean, sphinx-build -W clean. codacy-analysis reports 0 issues on the Markdown and test files; the two Semgrep findings on provxml.py are the pre-existing lxml.etree usage rule and are identical on main.