### PR TITLE
3.2.0 design spec, implementation plan and roadmap row

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # History
 
+## 3.2.0 (unreleased)
+
+### PROV-N
+
+### Performance
+
+### Fixes
+
+### Tests
+
+### Documentation
+
+### Project
+
 ## 3.1.1 (2026-09-10)
 
 3.1.1 is a point release: bug fixes, hardening of the graphical export, test

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,17 +37,17 @@ code changes.
 | **3.0.0** *(released 2026-07-27)* | Compatibility release | The one release allowed to break compatibility (see the explicit list below). |
 | **3.1.0** *(released 2026-08-07)* | PROV-JSONLD support | A new serializer and deserializer for [PROV-JSONLD](https://www.w3.org/submissions/prov-jsonld/), the W3C member submission for representing PROV-DM natively in JSON-LD. Purely additive. |
 | **3.1.1** *(released 2026-09-10)* | Point release | Bug fixes and hardening from the September 2026 audit: deterministic bundle namespace declarations ([#337](https://github.com/trungdong/prov/issues/337)), link and label hardening in `prov.dot`, `ProvWarning` on dropped `prov_to_graph()` relations, quieter PROV-O decoding, faster bundle equality and namespace lookup. Tests close [#130](https://github.com/trungdong/prov/issues/130) and [#338](https://github.com/trungdong/prov/issues/338); a non-blocking CI job answers [#340](https://github.com/trungdong/prov/issues/340). Documentation and repository scaffolding: "What's new in 3", an architecture overview, code of conduct, issue and PR templates, `CITATION.cff` and the first Zenodo DOI. |
-| **3.2.0** | Two-way PROV-N | A parser for [PROV-N](https://www.w3.org/TR/prov-n/), built from the specification's grammar, making the notation readable as well as writable (today `prov` can only write PROV-N). Purely additive. |
+| **3.2.0** | Two-way PROV-N and speed | A parser for [PROV-N](https://www.w3.org/TR/prov-n/), built from the specification's grammar with no new dependency, making the notation readable as well as writable ([#122](https://github.com/trungdong/prov/issues/122)); `strict`, `default` and `lenient` parsing profiles; a strict output option for the writer; `prov-convert` reads PROV-N. A benchmark suite with a non-blocking CI regression check, and measured speed-ups to record construction and deserialisation. Follow-ups from 3.1.1: a warning when `prov.dot` draws an unset endpoint, and colon-bearing local parts round-tripping through PROV-O ([#341](https://github.com/trungdong/prov/issues/341)). Purely additive. Targeted before 2026-10-31, so it keeps the Python 3.10 floor. |
 
 ### Python version support policy
 
 `prov` supports all non-EOL CPython versions and drops a version in the first release
-after it reaches end of life — the policy set when the 3.9 floor was dropped ahead of
+after it reaches end of life, the policy set when the 3.9 floor was dropped ahead of
 schedule in 2.3.0 (see "What changes in 3.0" below for the history). Python 3.10
-reaches EOL on 2026-10-31; under this policy, the Python floor rises to 3.11 in
-whichever release ships first after that date. 3.1.0 (PROV-JSONLD) is expected within
-about a month of 3.0.0 — well before 2026-10-31 — so 3.1.0 keeps the 3.10 floor; the
-drop lands in a later release, whichever one ships next after Python 3.10's EOL.
+reaches EOL on 2026-10-31. 3.2.0 is targeted before that date and keeps the 3.10 floor,
+so it is the last release to support Python 3.10; the floor rises to 3.11 in 3.3.0, the
+first release after Python 3.10's EOL. If 3.2.0 slips past 2026-10-31, the floor rises in
+3.2.0 instead, under the same policy.
 
 ## What changes in 3.0
 

--- a/planning/plans/2026-09-12-release-3.2.0.md
+++ b/planning/plans/2026-09-12-release-3.2.0.md
@@ -1,0 +1,3934 @@
+# Release 3.2.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship prov 3.2.0 with a PROV-N parser (two-way PROV-N, closes #122), a benchmark suite with an advisory CI gate, three measured performance improvements, and five follow-ups from 3.1.1, before 2026-10-31 and on the Python 3.10 floor.
+
+**Architecture:** The parser is two pure-Python modules under `src/prov/serializers/` (a tokeniser and a recursive-descent parser) that build records through `ProvBundle.new_record()` exactly as the PROV-JSON deserializer does, so typing, literals and namespaces behave identically across formats. A `profile` argument selects strict, default or lenient acceptance. The benchmark suite lives in a top-level `benchmarks/` directory outside the package and lands before any tuning, so every performance PR carries a before-and-after number. Each task group is one focused PR off `main`, merged on green CI after review.
+
+**Tech Stack:** Python 3.10+, `uv`, pytest, Hypothesis, pytest-benchmark, mypy `--strict`, ruff, lxml, rdflib, pydot, networkx, Sphinx/MyST, GitHub Actions, `gh` CLI, Codacy CLI.
+
+**Spec:** `planning/specs/2026-09-12-release-3.2.0-design.md`.
+
+## Global Constraints
+
+- **Branching and PRs.** Every task group branches from up-to-date `origin/main`, opens one PR with a body that says what and why, and merges only on green CI (`gh pr checks <n> --watch`). Merge with `gh pr merge <n> --merge --delete-branch` (merge commits, never squash). Codacy blocks on any finding, including markdownlint on Markdown; run `codacy-analysis analyze --files <changed files>` before pushing and expect "0 issues found". Coveralls "decreased" is advisory as long as `uv run coverage run -m pytest && uv run coverage report` exits 0 against the 97% floor.
+- **Review before merge.** No PR merges before its review completes. PR 3 (tokeniser) and PR 4 (parser) each get a `/code-review` round run by the coordinator, findings fixed in the same PR. PR 12 opens with a `/simplify` round over everything the release touched. A whole-release review runs after the release stamp and before the GitHub release is created.
+- **Suite invariant.** Baseline on `main` @ 112fb91 (3.1.1 plus two dependency bumps): **1672 passed, 26 skipped, 0 xfailed** from `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx`. Task 0 re-runs this and corrects the number here if it has moved. Each task states how the pass count moves; the skip count stays 26 and xfail 0 unless a task says otherwise. Any other movement is a regression.
+- **Quality gates per code PR.** `uv run mypy src`, `uv run ruff check src/ benchmarks/`, `uv run ruff format --check src/ benchmarks/`, full suite green on 3.12 locally, the CI matrix green on the PR.
+- **Every code task adds its `HISTORY.md` line** under the `## 3.2.0 (unreleased)` section that Task 0 creates, in the subsection the task names (PROV-N / Performance / Fixes / Tests / Documentation / Project). Task 18 dates the heading.
+- **Public API.** Every new public name is added where the task says and nowhere else. `prov.model` is frozen by `test_public_api.py`; nothing in this release adds to it. `ProvNSyntaxError` lives in `prov.serializers.provn`, as `ProvJSONException` lives in `prov.serializers.provjson`.
+- **PROV-N compatibility.** The writer's default output does not change byte for byte. Every document `get_provn()` writes today must parse under the `default` profile and round-trip to an equal document.
+- **Performance PRs (Tasks 11 to 13).** Each states before and after numbers from `uv run pytest benchmarks/ --benchmark-json=<file>` in its PR body. An improvement that does not move its target number does not merge. Public API, equality and hash semantics do not change.
+- **Commit and PR text.** No AI attribution lines. Paragraphs unwrapped (one line each). British English, no em dashes in commit, PR or documentation text. Shipped docs and `HISTORY.md` describe changes by release, never by plan task or PR sequence.
+- **Code comments.** Concise, present-state, no history of abandoned approaches. British English.
+- **Coordinator-run tasks.** Tasks 3, 6, 16 and 19 are run by the coordinator in the main session, not by an implementation subagent, because they invoke the `code-review` and `simplify` skills or publish.
+
+**User decisions (already made):**
+- 3.2.0 contains the PROV-N parser, the performance track with an advisory benchmark gate, and the small follow-ups. Approved 2026-09-12.
+- The parser is hand-written recursive descent with no dependency; no Lark, no extra.
+- Three parsing profiles: `strict` (Recommendation grammar only), `default` (plus the de-facto extensions), `lenient` (skip unparseable statements with a warning, resume at the next statement boundary, which is not the next line).
+- Benchmark gate is pytest-benchmark, non-blocking CI job, 20% mean regression threshold; tuning limited to the three named hotspots; 2x target on construction and JSON deserialisation.
+- The PROV-N writer is not rewritten. The parser becomes its test oracle. One addition: a `strict` option that writes `prov:mentionOf`.
+- `ROADMAP.md` is updated in the first PR, before any code, and stamped again at release.
+- `/code-review` rounds on the tokeniser and parser PRs; a `/simplify` round before the whole-release review.
+- Contribution licensing is settled (inbound equals outbound, no CLA); not revisited here.
+- The parser accepts expressions and bundles in any order inside a document in every profile; the profile distinction is vocabulary, not statement ordering.
+
+---
+
+## PR map
+
+| PR | Tasks | Branch | Closes |
+|---|---|---|---|
+| 1 | 0 | `release/3.2.0-spec` | none |
+| 2 | 1 | `bench/suite-and-gate` | benchmark-suite issue (Task 0 files it) |
+| 3 | 2, 3 | `provn/lexer` | none |
+| 4 | 4, 5, 6 | `provn/parser` | #122 |
+| 5 | 7, 8 | `provn/roundtrip-corpus` | none |
+| 6 | 9, 10 | `provn/strict-writer-cli-input` | none |
+| 7 | 11 | `perf/resolve-cache` | none |
+| 8 | 12 | `perf/slots-hash` | none |
+| 9 | 13 | `perf/literal-fast-path` | none |
+| 10 | 14 | `fix/dot-warning-provo-colon` | #341, prov.dot issue (Task 0 files it) |
+| 11 | 15 | `chore/citation-guard-precommit` | none |
+| 12 | 16, 17, 18 | `release/3.2.0` | none |
+| publish | 19 | none | milestone 3.2.0 |
+
+---
+
+### Task 0: Land the spec, this plan and the roadmap row
+
+**Goal:** PR 1 carries the approved spec, this plan, the `ROADMAP.md` edit and the changelog scaffold, and is merged so every later branch starts from a `main` that contains them.
+
+**Files:**
+- Create: `planning/plans/2026-09-12-release-3.2.0.md` (this file)
+- Create: `planning/plans/2026-09-12-release-3.2.0.md.tasks.json` (gitignored; never force-add)
+- Modify: `ROADMAP.md:39-50`
+- Modify: `HISTORY.md:1-3`
+
+**Acceptance Criteria:**
+- [ ] The suite baseline in Global Constraints matches a fresh run on `main`
+- [ ] `ROADMAP.md`'s 3.2.0 row names two-way PROV-N, the benchmark suite, the performance improvements and the follow-ups, states the pre-2026-10-31 target and the 3.10 floor, and carries no date
+- [ ] `ROADMAP.md`'s support-policy paragraph names 3.2.0 as the last release on the 3.10 floor and 3.3.0 as the first on 3.11
+- [ ] `HISTORY.md` opens with a `## 3.2.0 (unreleased)` section and its six empty subsections
+- [ ] Milestone 3.2.0 holds #122, #341 and two new issues (benchmark suite; `prov.dot` unset-endpoint warning)
+- [ ] PR 1 is merged
+
+**Verify:** `gh issue list --milestone 3.2.0 --state open` shows four issues; `git log --oneline -1 origin/main` shows the merge commit.
+
+**Steps:**
+
+- [ ] **Step 1: Confirm the baseline**
+
+```bash
+git checkout main && git pull --ff-only
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx 2>&1 | tail -3
+```
+
+Expected: `1672 passed, 26 skipped`. If the numbers differ, edit the Suite invariant line in Global Constraints to the observed values and mention the change in the PR body.
+
+- [ ] **Step 2: Edit the 3.2.0 row in `ROADMAP.md`**
+
+Replace the existing 3.2.0 row (the last row of the "Planned releases" table) with:
+
+```markdown
+| **3.2.0** | Two-way PROV-N and speed | A parser for [PROV-N](https://www.w3.org/TR/prov-n/), built from the specification's grammar with no new dependency, making the notation readable as well as writable ([#122](https://github.com/trungdong/prov/issues/122)); `strict`, `default` and `lenient` parsing profiles; a strict output option for the writer; `prov-convert` reads PROV-N. A benchmark suite with a non-blocking CI regression check, and measured speed-ups to record construction and deserialisation. Follow-ups from 3.1.1: a warning when `prov.dot` draws an unset endpoint, and colon-bearing local parts round-tripping through PROV-O ([#341](https://github.com/trungdong/prov/issues/341)). Purely additive. Targeted before 2026-10-31, so it keeps the Python 3.10 floor. |
+```
+
+- [ ] **Step 3: Rewrite the support-policy paragraph**
+
+Replace the paragraph under `### Python version support policy` with:
+
+```markdown
+`prov` supports all non-EOL CPython versions and drops a version in the first release
+after it reaches end of life, the policy set when the 3.9 floor was dropped ahead of
+schedule in 2.3.0 (see "What changes in 3.0" below for the history). Python 3.10
+reaches EOL on 2026-10-31. 3.2.0 is targeted before that date and keeps the 3.10 floor,
+so it is the last release to support Python 3.10; the floor rises to 3.11 in 3.3.0, the
+first release after Python 3.10's EOL. If 3.2.0 slips past 2026-10-31, the floor rises in
+3.2.0 instead, under the same policy.
+```
+
+- [ ] **Step 4: Scaffold the changelog**
+
+Insert after the `# History` heading and its blank line in `HISTORY.md`:
+
+```markdown
+## 3.2.0 (unreleased)
+
+### PROV-N
+
+### Performance
+
+### Fixes
+
+### Tests
+
+### Documentation
+
+### Project
+
+```
+
+- [ ] **Step 5: File the two new issues and populate the milestone**
+
+```bash
+gh issue create --title "Benchmark suite with a non-blocking CI regression check" --label enhancement --milestone 3.2.0 --body "A pytest-benchmark suite under benchmarks/ covering construction, serialisation and deserialisation per format, unified() and prov_to_graph(), with a committed baseline and a non-blocking CI job that fails on a 20% mean regression. Design: planning/specs/2026-09-12-release-3.2.0-design.md, section 4."
+gh issue create --title "prov.dot draws an unset relation endpoint to a blank node without warning" --label "bug" --milestone 3.2.0 --body "_add_relation routes a relation whose formal endpoint is unset to a blank node silently. prov_to_graph() gained a ProvWarning for the same situation in 3.1.1; prov.dot should warn the same way, naming the relation and the missing endpoint. Rendering does not change."
+gh issue edit 122 --milestone 3.2.0
+gh issue edit 341 --milestone 3.2.0
+```
+
+Record the two new issue numbers in the PR map above (replace the placeholders in the Closes column) before committing.
+
+- [ ] **Step 6: Generate the tasks file, run the gates, open the PR**
+
+```bash
+uv run python - <<'PY'
+# Regenerates the gitignored tasks file from this plan; see the script in the
+# plan's appendix (Task 0, step 6) if it is ever lost.
+import json, re, datetime, pathlib
+plan = pathlib.Path("planning/plans/2026-09-12-release-3.2.0.md")
+text = plan.read_text()
+sections = re.split(r"^### Task (\d+): (.+)$", text, flags=re.M)
+tasks = []
+for i in range(1, len(sections), 3):
+    num, title, body = int(sections[i]), sections[i + 1].strip(), sections[i + 2]
+    body = body.split("\n**Steps:**")[0].strip()
+    m = re.search(r"```json:metadata\n(.*?)\n```", sections[i + 2], re.S)
+    desc = body + ("\n\n```json:metadata\n" + m.group(1) + "\n```" if m else "")
+    tasks.append({"id": num, "subject": f"Task {num}: {title}", "status": "pending", "description": desc})
+for t in tasks:
+    if t["id"] > 0:
+        t["blockedBy"] = [t["id"] - 1]
+pathlib.Path(str(plan) + ".tasks.json").write_text(json.dumps({"planPath": str(plan), "tasks": tasks, "lastUpdated": datetime.datetime.now(datetime.timezone.utc).isoformat()}, indent=2) + "\n")
+print(len(tasks), "tasks")
+PY
+codacy-analysis analyze --files ROADMAP.md HISTORY.md planning/plans/2026-09-12-release-3.2.0.md planning/specs/2026-09-12-release-3.2.0-design.md
+git add ROADMAP.md HISTORY.md planning/plans/2026-09-12-release-3.2.0.md
+git commit -m "docs: add the 3.2.0 plan, roadmap row and changelog scaffold"
+git push -u origin release/3.2.0-spec
+gh pr create --title "3.2.0 design spec, implementation plan and roadmap row" --body "Adds the approved design spec and implementation plan for 3.2.0 (two-way PROV-N, benchmark suite and performance improvements, 3.1.1 follow-ups), updates the 3.2.0 row and the Python support paragraph in ROADMAP.md before any code lands, and scaffolds the 3.2.0 changelog section.
+
+The roadmap row is written first so that the community-facing statement matches the release being built; it is stamped with the date at release time."
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+```json:metadata
+{"files": ["ROADMAP.md", "HISTORY.md", "planning/plans/2026-09-12-release-3.2.0.md"], "verifyCommand": "gh issue list --milestone 3.2.0 --state open", "acceptanceCriteria": ["Suite baseline confirmed", "ROADMAP.md 3.2.0 row and support paragraph updated", "HISTORY.md 3.2.0 section scaffolded", "Milestone holds #122, #341 and two new issues", "PR 1 merged"], "modelTier": "mechanical"}
+```
+
+---
+
+### Task 1: Benchmark suite, baseline and non-blocking CI job
+
+**Goal:** A `benchmarks/` suite that measures the operations the spec names, a committed baseline, a comparison script that fails on a 20% mean regression, and a `continue-on-error` CI job that runs it, so every later performance PR has a number.
+
+**Files:**
+- Create: `benchmarks/__init__.py` (empty)
+- Create: `benchmarks/conftest.py`
+- Create: `benchmarks/test_bench.py`
+- Create: `benchmarks/compare.py`
+- Create: `benchmarks/baseline.json`
+- Create: `benchmarks/README.md`
+- Modify: `pyproject.toml:92-110` (new `bench` dependency group)
+- Modify: `.github/workflows/CI.yml:108-137` (new job after `own-warnings`)
+- Modify: `docs/releasing.md:20-40` (one paragraph)
+- Modify: `CLAUDE.md` ("Gates every PR must pass" section)
+- Modify: `HISTORY.md` (Project subsection)
+
+**Acceptance Criteria:**
+- [ ] `uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json` runs eleven benchmarks in under three minutes at N=10000
+- [ ] `uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json` exits 0 on a fresh run and exits 1 when a mean exceeds the baseline by more than 20%
+- [ ] `uv run pytest` (default test paths) does not collect `benchmarks/`
+- [ ] CI shows a `benchmark (non-blocking)` job that passes and is `continue-on-error`
+- [ ] `PROV_BENCH_N=100000 uv run pytest benchmarks/ -k construct` runs the larger size
+- [ ] `docs/releasing.md` and `CLAUDE.md` name the benchmark command
+- [ ] Suite counts unchanged (1672 / 26 / 0)
+
+**Verify:** `uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q && uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json` → prints a per-benchmark table and `OK`.
+
+**Steps:**
+
+- [ ] **Step 1: Add the dependency group**
+
+In `pyproject.toml`, after the `dev` group inside `[dependency-groups]`, add:
+
+```toml
+bench = [
+    "pytest-benchmark>=5.1.0",
+]
+```
+
+Run `uv sync --extra rdf --extra xml --extra dot --extra graph --group dev --group bench` and confirm `uv.lock` changes are committed.
+
+- [ ] **Step 2: Write the document generator**
+
+`benchmarks/conftest.py`:
+
+```python
+"""Shared document generator for the benchmark suite.
+
+``PROV_BENCH_N`` sets the record count (default 10000, which keeps the CI
+job under three minutes; use 100000 for local profiling).
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+
+import pytest
+
+from prov.model import ProvDocument
+
+N = int(os.environ.get("PROV_BENCH_N", "10000"))
+
+
+def build_document(n: int = N) -> ProvDocument:
+    """Return a document with roughly ``n`` records in a realistic mix.
+
+    Every fifth block of records lands in one of five named bundles, so
+    bundle handling is exercised without dominating the numbers.
+    """
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.add_namespace("dc", "http://purl.org/dc/terms/")
+    bundles = [doc.bundle(f"ex:bundle{i}") for i in range(5)]
+    base_time = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    per_block = 8  # records created per loop iteration
+    for i in range(max(1, n // per_block)):
+        target = bundles[i % 5] if i % 5 == 0 else doc
+        e_in = target.entity(f"ex:input{i}", {"dc:title": f"Input {i}", "ex:size": i})
+        e_out = target.entity(
+            f"ex:output{i}", {"dc:title": f"Output {i}", "ex:score": i / 7.0}
+        )
+        act = target.activity(
+            f"ex:run{i}",
+            base_time + datetime.timedelta(seconds=i),
+            base_time + datetime.timedelta(seconds=i + 1),
+            {"ex:status": "ok"},
+        )
+        agent = target.agent(f"ex:agent{i % 50}", {"prov:type": "prov:SoftwareAgent"})
+        target.used(act, e_in, base_time + datetime.timedelta(seconds=i))
+        target.wasGeneratedBy(e_out, act, base_time + datetime.timedelta(seconds=i + 1))
+        target.wasAssociatedWith(act, agent)
+        target.wasDerivedFrom(e_out, e_in, act)
+    return doc
+
+
+@pytest.fixture(scope="session")
+def document() -> ProvDocument:
+    return build_document()
+
+
+def serialized(doc: ProvDocument, fmt: str) -> str | bytes:
+    return doc.serialize(format=fmt)
+```
+
+- [ ] **Step 3: Write the benchmarks**
+
+`benchmarks/test_bench.py`:
+
+```python
+"""Benchmarks for the operations the 3.2.0 performance track measures.
+
+Run with ``uv run pytest benchmarks/ --benchmark-json=<file>`` and compare
+against ``benchmarks/baseline.json`` with ``benchmarks/compare.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prov.model import ProvDocument
+
+from .conftest import N, build_document, serialized
+
+FORMATS = ("json", "xml", "rdf", "provn", "jsonld")
+
+
+def test_construct(benchmark):
+    benchmark(build_document, N)
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_serialize(benchmark, document, fmt):
+    benchmark(serialized, document, fmt)
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_deserialize(benchmark, document, fmt):
+    content = serialized(document, fmt)
+    if fmt == "provn":
+        try:
+            ProvDocument.deserialize(content=content, format=fmt)
+        except NotImplementedError:
+            pytest.skip("PROV-N parser not yet available")
+    benchmark(ProvDocument.deserialize, content=content, format=fmt)
+
+
+def test_unified(benchmark, document):
+    benchmark(document.unified)
+
+
+def test_prov_to_graph(benchmark, document):
+    from prov.graph import prov_to_graph
+
+    benchmark(prov_to_graph, document)
+
+
+def test_equality(benchmark, document):
+    other = build_document(N)
+    benchmark(lambda: document == other)
+```
+
+The `provn` deserialise case skips until Task 5 lands; Task 5 removes the `try` block and refreshes the baseline.
+
+- [ ] **Step 4: Write the comparison script**
+
+`benchmarks/compare.py`:
+
+```python
+"""Compare a pytest-benchmark JSON run against a committed baseline.
+
+Usage: ``python benchmarks/compare.py BASELINE CURRENT [--max-regression 0.20]``
+
+Exits 1 if any benchmark's mean is slower than the baseline mean by more
+than the threshold. Benchmarks present on only one side are reported and
+ignored, so adding a benchmark never fails the gate on its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load(path: Path) -> dict[str, float]:
+    data = json.loads(path.read_text())
+    return {b["fullname"]: b["stats"]["mean"] for b in data["benchmarks"]}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("current", type=Path)
+    parser.add_argument("--max-regression", type=float, default=0.20)
+    args = parser.parse_args(argv)
+
+    base, cur = load(args.baseline), load(args.current)
+    failed = False
+    print(f"{'benchmark':60} {'baseline':>10} {'current':>10} {'change':>8}")
+    for name in sorted(base.keys() | cur.keys()):
+        if name not in base or name not in cur:
+            side = "baseline" if name in base else "current"
+            print(f"{name:60} only in {side}")
+            continue
+        change = (cur[name] - base[name]) / base[name]
+        flag = ""
+        if change > args.max_regression:
+            failed = True
+            flag = "  REGRESSION"
+        print(f"{name:60} {base[name]:10.4f} {cur[name]:10.4f} {change:+7.1%}{flag}")
+    print("REGRESSION" if failed else "OK")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run the suite and produce the first baseline**
+
+```bash
+uv run pytest benchmarks/ --benchmark-json=benchmarks/baseline.json -q
+uv run python benchmarks/compare.py benchmarks/baseline.json benchmarks/baseline.json
+```
+
+Expected: eleven benchmarks (ten plus one skipped provn deserialise), table printed, `OK`. This local baseline is a placeholder; step 8 replaces it with one from the CI runner.
+
+- [ ] **Step 6: Add the CI job**
+
+In `.github/workflows/CI.yml`, after the `own-warnings` job and before `typecheck`, add:
+
+```yaml
+  benchmark:
+    # Non-blocking regression check. Compares this run against the committed
+    # benchmarks/baseline.json and fails on a 20% mean regression. Runner
+    # noise is why it never blocks a merge; a red run is a prompt to look.
+    # Refresh the baseline with a workflow_dispatch run and the
+    # save-baseline input, then commit the downloaded artifact.
+    name: benchmark (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          python-version: "3.12"
+      - name: Run the benchmarks
+        run: |
+          uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev --group bench
+          uv run --no-sync pytest benchmarks/ --benchmark-json=bench.json -q
+      - name: Compare against the baseline
+        run: uv run --no-sync python benchmarks/compare.py benchmarks/baseline.json bench.json
+      - name: Upload this run as a baseline candidate
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline
+          path: bench.json
+```
+
+Pin `actions/upload-artifact` to a commit SHA the way the other actions are pinned; look the current v4 SHA up with `gh api repos/actions/upload-artifact/git/ref/tags/v4 --jq .object.sha` and append the `# v4` comment.
+
+- [ ] **Step 7: Document the suite**
+
+`benchmarks/README.md`:
+
+````markdown
+# Benchmarks
+
+Timing suite for the operations the library's performance work tracks. It is
+not part of the test suite and is not shipped.
+
+```bash
+uv sync --extra rdf --extra xml --extra dot --extra graph --group dev --group bench
+uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json
+uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json
+```
+
+`PROV_BENCH_N` sets the record count (default 10000). CI runs the suite on
+every push as a non-blocking job and fails it on a 20% mean regression against
+`baseline.json`.
+
+## Refreshing the baseline
+
+Do this whenever a change is meant to alter speed. Run the CI workflow by hand
+so the baseline comes from the runner type CI compares on:
+
+```bash
+gh workflow run CI.yml
+gh run watch
+gh run download --name benchmark-baseline --dir /tmp/bench
+cp /tmp/bench/bench.json benchmarks/baseline.json
+```
+
+Commit the new baseline in the same PR as the change that motivated it.
+````
+
+In `docs/releasing.md`, after the pre-flight code block and before "Compare the suite's pass, skip and xfail counts", add:
+
+````markdown
+Run the benchmark suite and compare it with the committed baseline; a regression
+here is advisory, but a release should not ship one unexplained:
+
+```bash
+uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q
+uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json
+```
+````
+
+In `CLAUDE.md`, in the "Gates every PR must pass" code block, after the `ruff format --check` line, add `uv run ruff check benchmarks/` to the ruff line (so it reads `uv run ruff check src/ benchmarks/`) and add after the block:
+
+```markdown
+Performance changes also run `uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json`
+and `uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json`; the
+CI job is non-blocking. `benchmarks/README.md` says how to refresh the baseline.
+```
+
+- [ ] **Step 8: Open the PR, then take the baseline from CI**
+
+```bash
+uv run ruff check src/ benchmarks/ && uv run ruff format src/ benchmarks/
+codacy-analysis analyze --files benchmarks/README.md docs/releasing.md CLAUDE.md .github/workflows/CI.yml pyproject.toml benchmarks/compare.py benchmarks/conftest.py benchmarks/test_bench.py
+git add benchmarks pyproject.toml uv.lock .github/workflows/CI.yml docs/releasing.md CLAUDE.md HISTORY.md
+git commit -m "bench: add the benchmark suite and a non-blocking CI regression check"
+git push -u origin bench/suite-and-gate
+gh pr create --fill
+```
+
+Once the PR's CI is green, run `gh workflow run CI.yml --ref bench/suite-and-gate`, download the artifact as the README describes, commit it as `benchmarks/baseline.json`, and push. Add to `HISTORY.md` under Project: `- A benchmark suite under `benchmarks/` with a non-blocking CI job that fails on a 20% regression against a committed baseline`.
+
+```json:metadata
+{"files": ["benchmarks/conftest.py", "benchmarks/test_bench.py", "benchmarks/compare.py", "benchmarks/baseline.json", "benchmarks/README.md", "pyproject.toml", ".github/workflows/CI.yml", "docs/releasing.md", "CLAUDE.md", "HISTORY.md"], "verifyCommand": "uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q && uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json", "acceptanceCriteria": ["Suite runs eleven benchmarks under three minutes", "compare.py exits 0 on fresh run and 1 on >20% regression", "Default pytest does not collect benchmarks/", "CI job benchmark (non-blocking) present and continue-on-error", "PROV_BENCH_N honoured", "releasing.md and CLAUDE.md updated", "Suite counts unchanged"], "modelTier": "standard"}
+```
+
+---
+### Task 2: PROV-N tokeniser
+
+**Goal:** `prov.serializers.provn_lexer` turns PROV-N text into a token stream with line and column, handling every lexical production the Recommendation defines, with table-driven tests that pin each token class and each awkward boundary.
+
+**Files:**
+- Create: `src/prov/serializers/provn_lexer.py`
+- Create: `src/prov/tests/test_provn_lexer.py`
+- Modify: `HISTORY.md` (PROV-N subsection; the line is written in Task 5 when the parser lands, nothing here)
+
+**Acceptance Criteria:**
+- [ ] `tokenize()` yields the token kinds listed in the module for every construct in the Recommendation's lexical grammar (qualified names with escapes and percent-encoding, IRIs, short and long strings with escapes, integers, `xsd:dateTime` literals, `%%`, language tags, the `-` marker, punctuation) and skips both comment styles
+- [ ] Every malformed input raises `ProvNSyntaxError` whose `line` and `column` point at the offending character
+- [ ] A local part's trailing `.` is left for the next token; an escaped `\.` is kept
+- [ ] `@` after a string is a language tag; `@` inside a name is part of the name
+- [ ] `-5` is an integer; `-` alone is the marker; `2011-11-16T16:00:00` is a dateTime, not three integers
+- [ ] `uv run mypy src` passes; coverage of `provn_lexer.py` is 100%
+- [ ] Suite counts move to 1672 + the new lexer tests passed, 26 skipped, 0 xfailed
+
+**Verify:** `uv run pytest src/prov/tests/test_provn_lexer.py -q` → all pass; `uv run coverage run -m pytest src/prov/tests/test_provn_lexer.py && uv run coverage report --include='*/provn_lexer.py'` → 100%.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/prov/tests/test_provn_lexer.py`:
+
+```python
+"""Tokeniser tests for PROV-N (W3C PROV-N Recommendation, section 3.8
+lexical productions). Table-driven: one case per token class and one per
+boundary that a hand-written lexer gets wrong."""
+
+import pytest
+
+from prov.serializers.provn_lexer import ProvNSyntaxError, TokenKind, tokenize
+
+
+def kinds(text):
+    return [t.kind for t in tokenize(text) if t.kind is not TokenKind.EOF]
+
+
+def values(text):
+    return [t.value for t in tokenize(text) if t.kind is not TokenKind.EOF]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("entity", [TokenKind.NAME]),
+        ("ex:e1", [TokenKind.NAME]),
+        ("<http://example.org/>", [TokenKind.IRI]),
+        ('"hello"', [TokenKind.STRING]),
+        ('"""multi\nline"""', [TokenKind.STRING]),
+        ("42", [TokenKind.INT]),
+        ("-42", [TokenKind.INT]),
+        ("2011-11-16T16:00:00", [TokenKind.DATETIME]),
+        ("2011-11-16T16:00:00.123Z", [TokenKind.DATETIME]),
+        ("2011-11-16T16:00:00+01:00", [TokenKind.DATETIME]),
+        ("%%", [TokenKind.TYPED]),
+        ("-", [TokenKind.MARKER]),
+        ("'ex:abc'", [TokenKind.QNAME_LITERAL]),
+        ("( ) [ ] , ; =", [
+            TokenKind.LPAREN, TokenKind.RPAREN, TokenKind.LBRACKET,
+            TokenKind.RBRACKET, TokenKind.COMMA, TokenKind.SEMICOLON,
+            TokenKind.EQUALS,
+        ]),
+    ],
+)
+def test_token_kinds(text, expected):
+    assert kinds(text) == expected
+
+
+def test_comments_are_skipped():
+    text = "entity // trailing\n/* block\ncomment */ agent"
+    assert values(text) == [("", "entity"), ("", "agent")]
+
+
+@pytest.mark.parametrize("ch", list("='(),:;[]"))
+def test_escaped_metachar_in_local_part(ch):
+    tokens = list(tokenize(f"ex:na\\{ch}me"))
+    assert tokens[0].kind is TokenKind.NAME
+    assert tokens[0].value == ("ex", f"na{ch}me")
+
+
+def test_percent_encoding_is_kept_verbatim():
+    assert values("ex:a%20b") == [("ex", "a%20b")]
+
+
+def test_stray_dot_raises_with_position():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("ex:abc."))
+    assert (ctx.value.line, ctx.value.column) == (1, 7)
+
+
+def test_escaped_dot_is_kept():
+    assert values(r"ex:abc\.") == [("ex", "abc.")]
+
+
+def test_inner_dot_is_part_of_the_name():
+    assert values("ex:a.b") == [("ex", "a.b")]
+
+
+def test_langtag_only_after_a_string():
+    assert kinds('"a place"@en') == [TokenKind.STRING, TokenKind.LANGTAG]
+    assert values('"a place"@en')[1] == "en"
+    assert kinds("ex:a@b") == [TokenKind.NAME]
+    assert values("ex:a@b") == [("ex", "a@b")]
+
+
+def test_typed_literal_marker_vs_percent_in_name():
+    assert kinds('"1" %% xsd:int') == [TokenKind.STRING, TokenKind.TYPED, TokenKind.NAME]
+    assert kinds("ex:%41b") == [TokenKind.NAME]
+
+
+def test_marker_vs_negative_int():
+    assert kinds("-, -5, - 5") == [
+        TokenKind.MARKER, TokenKind.COMMA, TokenKind.INT, TokenKind.COMMA,
+        TokenKind.MARKER, TokenKind.INT,
+    ]
+    assert values("-5")[0] == -5
+
+
+def test_string_escapes_are_decoded():
+    assert values(r'"back\\slash and \"quote\""')[0] == 'back\\slash and "quote"'
+    assert values('"""a "quoted" word\nline two"""')[0] == 'a "quoted" word\nline two'
+    assert values(r'"tab\there"')[0] == "tab\there"
+
+
+def test_qname_literal_with_escape():
+    assert values(r"'ex:we\'ird'")[0] == ("ex", "we'ird")
+
+
+def test_bare_local_name_has_empty_prefix():
+    assert values("e1") == [("", "e1")]
+
+
+def test_line_and_column_tracking():
+    tokens = list(tokenize("entity(\n  ex:e1)"))
+    assert (tokens[0].line, tokens[0].column) == (1, 1)
+    assert (tokens[2].line, tokens[2].column) == (2, 3)
+    assert tokens[-1].kind is TokenKind.EOF
+
+
+@pytest.mark.parametrize(
+    ("text", "line", "column"),
+    [
+        ('"unterminated', 1, 1),
+        ('"""never closed', 1, 1),
+        ("<http://no-close", 1, 1),
+        ("'ex:open", 1, 1),
+        ("entity(\n  ex:e1, ^)", 2, 10),
+        ("ex:a:b", 1, 5),
+        ('"x" %', 1, 5),
+        ("ex:a\\zb", 1, 5),
+    ],
+)
+def test_malformed_input_reports_position(text, line, column):
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize(text))
+    assert (ctx.value.line, ctx.value.column) == (line, column)
+    assert f"line {line}, column {column}" in str(ctx.value)
+
+
+def test_unicode_names_and_strings():
+    assert values("ex:café") == [("ex", "café")]
+    assert values('"日本語"') == ["日本語"]
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `uv run pytest src/prov/tests/test_provn_lexer.py -q`
+Expected: collection error, `ModuleNotFoundError: No module named 'prov.serializers.provn_lexer'`.
+
+- [ ] **Step 3: Write the tokeniser**
+
+`src/prov/serializers/provn_lexer.py`:
+
+```python
+"""Tokeniser for PROV-N (https://www.w3.org/TR/prov-n/, section 3.8).
+
+Produces a flat token stream with line and column positions. Keywords are
+not distinguished here: every bare or prefixed name is a ``NAME`` token, and
+the parser decides whether a name at statement start is a keyword. The one
+context-sensitive rule is the language tag, which only follows a string.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from prov.model import ProvException
+
+__all__ = ["ProvNSyntaxError", "Token", "TokenKind", "tokenize"]
+
+
+class ProvNSyntaxError(ProvException):
+    """A PROV-N document could not be tokenised or parsed.
+
+    Attributes:
+        message: What was expected and what was found.
+        line: 1-based line of the offending token.
+        column: 1-based column of the offending token.
+    """
+
+    def __init__(self, message: str, line: int, column: int):
+        super().__init__(f"line {line}, column {column}: {message}")
+        self.message = message
+        self.line = line
+        self.column = column
+
+
+class TokenKind(Enum):
+    """Token classes; the names follow the Recommendation's productions."""
+
+    NAME = "name"  # QUALIFIED_NAME [51], value (prefix, local)
+    QNAME_LITERAL = "qualified name literal"  # 'prefix:local', value (prefix, local)
+    IRI = "IRI"  # IRI_REF [56], value the IRI text
+    STRING = "string"  # STRING_LITERAL [60], value the unescaped text
+    INT = "integer"  # INT_LITERAL [61], value an int
+    DATETIME = "dateTime"  # DATETIME [62], value the lexical form
+    LANGTAG = "language tag"  # LANGTAG [63], value the tag
+    TYPED = "%%"
+    MARKER = "-"
+    LPAREN = "("
+    RPAREN = ")"
+    LBRACKET = "["
+    RBRACKET = "]"
+    COMMA = ","
+    SEMICOLON = ";"
+    EQUALS = "="
+    EOF = "end of input"
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: TokenKind
+    text: str
+    value: Any
+    line: int
+    column: int
+
+
+# Character classes from the Recommendation ([53] to [55]); '.' and '-' are
+# handled in the local-part patterns because their placement rules differ.
+_PN_CHARS_BASE = (
+    r"A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF"
+    r"\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF"
+    r"\uFDF0-\uFFFD\U00010000-\U000EFFFF"
+)
+_PN_CHARS_U = _PN_CHARS_BASE + "_"
+_PN_CHARS = _PN_CHARS_U + r"\-0-9\u00B7\u0300-\u036F\u203F-\u2040"
+_PN_OTHERS = r"/@~&+*?#$!"
+_PERCENT = r"%[0-9A-Fa-f]{2}"
+_ESC = r"\\[=',\-:;\[\]().]"
+_LOCAL_START = rf"[{_PN_CHARS_U}0-9{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
+_LOCAL_CONT = rf"[{_PN_CHARS}.{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
+_PN_LOCAL = rf"(?:{_LOCAL_START})(?:{_LOCAL_CONT})*"
+_PN_PREFIX = rf"[{_PN_CHARS_BASE}][{_PN_CHARS}.]*"
+
+_QNAME = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})")
+_QNAME_FULL = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})\Z")
+_DATETIME = re.compile(
+    r"-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?"
+)
+_INT = re.compile(r"-?\d+")
+_IRI = re.compile(r"<([^<>\"{}|^`\\\s]*)>")
+_LANGTAG = re.compile(r"@([A-Za-z]+(?:-[A-Za-z0-9]+)*)")
+_SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n])*)"')
+_LONG_STRING = re.compile(r'"""((?:\\.|"(?!"")|[^"\\])*)"""', re.S)
+_QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n])*)'")
+_SKIP = re.compile(r"(?:\s+|//[^\n]*|/\*.*?\*/)+", re.S)
+_UNESCAPE_LOCAL = re.compile(r"\\(.)")
+_STRING_ESCAPES = {
+    "t": "\t", "b": "\b", "n": "\n", "r": "\r", "f": "\f",
+    '"': '"', "'": "'", "\\": "\\",
+}
+
+_PUNCTUATION = {
+    "(": TokenKind.LPAREN, ")": TokenKind.RPAREN,
+    "[": TokenKind.LBRACKET, "]": TokenKind.RBRACKET,
+    ",": TokenKind.COMMA, ";": TokenKind.SEMICOLON, "=": TokenKind.EQUALS,
+}
+
+
+def _unescape_string(raw: str, line: int, column: int) -> str:
+    def replace(match: re.Match[str]) -> str:
+        char = match.group(1)
+        if char not in _STRING_ESCAPES:
+            raise ProvNSyntaxError(f"unknown string escape '\\{char}'", line, column)
+        return _STRING_ESCAPES[char]
+
+    return re.sub(r"\\(.)", replace, raw, flags=re.S)
+
+
+def _split_qname(raw: str, line: int, column: int) -> tuple[str, str]:
+    match = _QNAME_FULL.match(raw)
+    if match is None:
+        raise ProvNSyntaxError(f"invalid qualified name '{raw}'", line, column)
+    prefix, local = match.group(1) or "", match.group(2)
+    return prefix, _UNESCAPE_LOCAL.sub(r"\1", local)
+
+
+class _Lexer:
+    def __init__(self, text: str):
+        self.text = text
+        self.pos = 0
+        self.line = 1
+        self.line_start = 0
+        self.previous: TokenKind | None = None
+
+    @property
+    def column(self) -> int:
+        return self.pos - self.line_start + 1
+
+    def advance(self, length: int) -> None:
+        chunk = self.text[self.pos : self.pos + length]
+        newlines = chunk.count("\n")
+        if newlines:
+            self.line += newlines
+            self.line_start = self.pos + chunk.rfind("\n") + 1
+        self.pos += length
+
+    def error(self, message: str) -> ProvNSyntaxError:
+        return ProvNSyntaxError(message, self.line, self.column)
+
+    def emit(self, kind: TokenKind, text: str, value: Any) -> Token:
+        token = Token(kind, text, value, self.line, self.column)
+        self.advance(len(text))
+        self.previous = kind
+        return token
+
+    def tokens(self) -> Iterator[Token]:
+        text = self.text
+        while True:
+            skip = _SKIP.match(text, self.pos)
+            if skip:
+                self.advance(skip.end() - self.pos)
+            if self.pos >= len(text):
+                yield Token(TokenKind.EOF, "", None, self.line, self.column)
+                return
+            yield self.next_token()
+
+    def next_token(self) -> Token:  # noqa: C901 -- one branch per token class
+        text, pos = self.text, self.pos
+        char = text[pos]
+        if char in _PUNCTUATION:
+            return self.emit(_PUNCTUATION[char], char, char)
+        if char == "<":
+            match = _IRI.match(text, pos)
+            if match is None:
+                raise self.error("unterminated IRI")
+            return self.emit(TokenKind.IRI, match.group(0), match.group(1))
+        if char == '"':
+            return self.string_token()
+        if char == "'":
+            match = _QNAME_LITERAL.match(text, pos)
+            if match is None:
+                raise self.error("unterminated qualified name literal")
+            value = _split_qname(match.group(1), self.line, self.column)
+            return self.emit(TokenKind.QNAME_LITERAL, match.group(0), value)
+        if char == "@" and self.previous is TokenKind.STRING:
+            match = _LANGTAG.match(text, pos)
+            if match is None:
+                raise self.error("invalid language tag")
+            return self.emit(TokenKind.LANGTAG, match.group(0), match.group(1))
+        if text.startswith("%%", pos):
+            return self.emit(TokenKind.TYPED, "%%", "%%")
+        datetime_match = _DATETIME.match(text, pos)
+        if datetime_match:
+            raw = datetime_match.group(0)
+            return self.emit(TokenKind.DATETIME, raw, raw)
+        int_match = _INT.match(text, pos)
+        name_match = _QNAME.match(text, pos)
+        if int_match and (name_match is None or name_match.end() <= int_match.end()):
+            raw = int_match.group(0)
+            return self.emit(TokenKind.INT, raw, int(raw))
+        if name_match:
+            return self.name_token(name_match)
+        if char == "-":
+            return self.emit(TokenKind.MARKER, "-", "-")
+        raise self.error(f"unexpected character {char!r}")
+
+    def name_token(self, match: re.Match[str]) -> Token:
+        raw = match.group(0)
+        # PN_LOCAL may contain '.' but not end with one ([54]); an escaped
+        # '\.' is a regular character, so only a bare trailing dot backs off.
+        while raw.endswith(".") and not raw.endswith("\\."):
+            raw = raw[:-1]
+        if not raw or raw.endswith(":"):
+            raise self.error("expected a local name after ':'")
+        value = _split_qname(raw, self.line, self.column)
+        token = self.emit(TokenKind.NAME, raw, value)
+        if self.pos < len(self.text) and self.text[self.pos] == ":":
+            raise self.error("unexpected ':' inside a qualified name")
+        return token
+
+    def string_token(self) -> Token:
+        text, pos = self.text, self.pos
+        if text.startswith('"""', pos):
+            match = _LONG_STRING.match(text, pos)
+            if match is None:
+                raise self.error("unterminated long string")
+        else:
+            match = _SHORT_STRING.match(text, pos)
+            if match is None:
+                raise self.error("unterminated string")
+        value = _unescape_string(match.group(1), self.line, self.column)
+        return self.emit(TokenKind.STRING, match.group(0), value)
+
+
+def tokenize(text: str) -> Iterator[Token]:
+    """Yield the tokens of ``text``, ending with an ``EOF`` token.
+
+    Raises:
+        ProvNSyntaxError: On the first character that starts no valid token,
+            with the line and column of that character.
+    """
+    return _Lexer(text).tokens()
+```
+
+- [ ] **Step 4: Run the tests until they pass**
+
+Run: `uv run pytest src/prov/tests/test_provn_lexer.py -q`
+Expected: all pass. If a position assertion fails by one column, the error was raised after `emit()` advanced; raise before emitting.
+
+Two cases to check by hand while iterating, because the regex order decides them:
+
+- `ex:a:b` must raise at column 5 (the second colon). `name_token()` raises after emitting `ex:a`; the raise happens with `self.pos` on the colon, so the column is 5.
+- `"x" %` must raise at column 5 with "unexpected character '%'", because `%` alone matches neither `%%` nor `_PERCENT`.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+uv run coverage run -m pytest src/prov/tests/test_provn_lexer.py -q && uv run coverage report --include='*/provn_lexer.py'
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+codacy-analysis analyze --files src/prov/serializers/provn_lexer.py src/prov/tests/test_provn_lexer.py
+git add src/prov/serializers/provn_lexer.py src/prov/tests/test_provn_lexer.py
+git commit -m "feat(provn): add the PROV-N tokeniser"
+git push -u origin provn/lexer
+gh pr create --title "PROV-N tokeniser" --body "Adds prov.serializers.provn_lexer, a hand-written tokeniser for PROV-N covering every lexical production of the Recommendation, with line and column tracking and table-driven tests for each token class and boundary case. First half of the PROV-N parser (#122); the parser itself follows in the next PR.
+
+No public API change yet: ProvNSyntaxError becomes public with the parser."
+```
+
+Do not merge. Task 3 reviews this PR first.
+
+```json:metadata
+{"files": ["src/prov/serializers/provn_lexer.py", "src/prov/tests/test_provn_lexer.py"], "verifyCommand": "uv run pytest src/prov/tests/test_provn_lexer.py -q", "acceptanceCriteria": ["All token kinds recognised, comments skipped", "Malformed input raises ProvNSyntaxError with correct line and column", "Trailing dot handling", "Langtag only after string", "Marker vs negative int vs dateTime", "mypy passes, lexer coverage 100%", "Suite counts: new tests added, 26 skipped, 0 xfailed"], "modelTier": "standard"}
+```
+
+---
+
+### Task 3: Code-review round on the tokeniser PR
+
+**Goal:** PR 3 has passed a `/code-review` round, every confirmed finding is fixed in the same PR, and the PR is merged.
+
+**Files:**
+- Modify: `src/prov/serializers/provn_lexer.py` (as findings require)
+- Modify: `src/prov/tests/test_provn_lexer.py` (as findings require)
+
+**Acceptance Criteria:**
+- [ ] The coordinator invoked the `code-review` skill on PR 3 at level `high`
+- [ ] Every CONFIRMED finding is fixed with a test that pins it, or dismissed in the PR with the reason
+- [ ] CI green after the fixes; PR 3 merged with `--merge --delete-branch`
+
+**Verify:** `gh pr view <PR 3> --json state,mergedAt` → `MERGED`.
+
+**Steps:**
+
+- [ ] **Step 1: Run the review (coordinator, main session)**
+
+Invoke the `code-review` skill with arguments `<PR 3 number> high`. The review targets a lexer, so ask it to weigh: regex catastrophic backtracking on adversarial input (long runs of `%` or `\`), column arithmetic after multi-line long strings and block comments, Unicode astral-plane characters in names, and any token class the Recommendation defines that the tests never exercise.
+
+- [ ] **Step 2: Fix confirmed findings in the PR branch**
+
+For each confirmed finding, add a test to `test_provn_lexer.py` that fails before the fix, fix `provn_lexer.py`, and commit as `fix(provn): <finding>`. Dismissed findings get a one-line reply in the PR.
+
+- [ ] **Step 3: Merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+```json:metadata
+{"files": ["src/prov/serializers/provn_lexer.py", "src/prov/tests/test_provn_lexer.py"], "verifyCommand": "gh pr view --json state", "acceptanceCriteria": ["code-review skill run at level high on PR 3", "Confirmed findings fixed with pinning tests or dismissed with reasons", "PR 3 merged"], "modelTier": "frontier", "coordinatorRun": true}
+```
+
+---
+### Task 4: PROV-N parser
+
+**Goal:** `prov.serializers.provn_parser` parses a PROV-N document into a `ProvDocument` through `ProvBundle.new_record()`, covering document structure, namespace declarations, bundles, every expression form of the Recommendation with its optional identifier, marker positions and optional argument groups, every literal form, and precise errors; the profile machinery is present but Task 5 tests it.
+
+**Files:**
+- Create: `src/prov/serializers/provn_parser.py`
+- Create: `src/prov/tests/test_provn.py`
+
+**Acceptance Criteria:**
+- [ ] `ProvNParser(text, profile).parse()` returns a `ProvDocument` for every expression form in the Recommendation, with formal attributes mapped in `FORMAL_ATTRIBUTES` order and `-` markers omitted
+- [ ] Namespace declarations (`prefix`, `default`) at document and bundle level register on the right container; bare names resolve through the default namespace
+- [ ] Literals: bare int, `"v" %% xsd:type`, `"v"@lang`, `'prefix:local'`, plain and long strings, produce the same model values the PROV-JSON deserializer produces for the equivalent JSON
+- [ ] A relation with the wrong number of arguments, a time where an identifier is expected, an undeclared prefix, a nested bundle, a missing `endDocument`, an unknown keyword and an extensibility expression each raise `ProvNSyntaxError` with the position of the statement or token at fault
+- [ ] `examples.primer_example()`, `w3c_publication_1()`, `bundles1()`, `collections()`, `datatypes()` and `long_literals()` each satisfy `parse(doc.get_provn()) == doc`
+- [ ] The arity table agrees with `FORMAL_ATTRIBUTES`: for every keyword, `max(arities) == len(PROV_REC_CLS[rec_type].FORMAL_ATTRIBUTES)`
+- [ ] `uv run mypy src` passes; coverage of `provn_parser.py` at least 95% after Task 5
+
+**Verify:** `uv run pytest src/prov/tests/test_provn.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/prov/tests/test_provn.py`:
+
+```python
+"""PROV-N parser tests: document structure, every expression form, literal
+forms, error paths and equality with documents the writer produced.
+Profile behaviour (default, lenient) is in test_provn_profiles.py."""
+
+import datetime
+
+import pytest
+
+from prov.constants import PROV_REC_CLS
+from prov.model import Literal, ProvDocument, ProvMention
+from prov.serializers.provn_lexer import ProvNSyntaxError
+from prov.serializers.provn_parser import (
+    _ELEMENTS,
+    _RELATIONS,
+    _MENTION,
+    ProvNParser,
+)
+from prov.tests import examples
+
+PREFIXES = "prefix ex <http://example.org/>\nprefix dc <http://purl.org/dc/terms/>\n"
+
+
+def parse(body, profile="strict", prefixes=PREFIXES):
+    return ProvNParser(f"document\n{prefixes}{body}\nendDocument", profile).parse()
+
+
+def only_record(doc):
+    records = list(doc.get_records())
+    assert len(records) == 1
+    return records[0]
+
+
+def test_empty_document():
+    doc = ProvNParser("document endDocument", "strict").parse()
+    assert list(doc.get_records()) == []
+
+
+def test_prefix_and_default_declarations():
+    doc = parse("entity(e1)\nentity(ex:e2)", prefixes="default <http://d.org/>\n" + PREFIXES)
+    ids = sorted(str(r.identifier) for r in doc.get_records())
+    assert ids == ["e1", "ex:e2"]
+    assert doc.get_default_namespace().uri == "http://d.org/"
+
+
+@pytest.mark.parametrize(
+    ("text", "keyword", "n_formal"),
+    [
+        ("entity(ex:e1)", "entity", 0),
+        ("activity(ex:a1)", "activity", 0),
+        ("activity(ex:a1, 2011-11-16T16:05:00, 2011-11-16T16:06:00)", "activity", 2),
+        ("activity(ex:a1, -, -)", "activity", 0),
+        ("agent(ex:ag)", "agent", 0),
+        ("wasGeneratedBy(ex:e1)", "wasGeneratedBy", 1),
+        ("wasGeneratedBy(ex:e1, ex:a1, 2011-11-16T16:05:00)", "wasGeneratedBy", 3),
+        ("wasGeneratedBy(ex:g1; ex:e1, -, -)", "wasGeneratedBy", 1),
+        ("used(ex:a1)", "used", 1),
+        ("used(ex:u1; ex:a1, ex:e1, -)", "used", 2),
+        ("wasInformedBy(ex:a2, ex:a1)", "wasInformedBy", 2),
+        ("wasStartedBy(ex:a1)", "wasStartedBy", 1),
+        ("wasStartedBy(ex:a1, ex:e1, ex:a0, 2011-11-16T16:05:00)", "wasStartedBy", 4),
+        ("wasEndedBy(ex:a1, -, ex:a0, -)", "wasEndedBy", 2),
+        ("wasInvalidatedBy(ex:e1, ex:a1, -)", "wasInvalidatedBy", 2),
+        ("wasDerivedFrom(ex:e2, ex:e1)", "wasDerivedFrom", 2),
+        ("wasDerivedFrom(ex:e2, ex:e1, ex:a, ex:g2, ex:u1)", "wasDerivedFrom", 5),
+        ("wasDerivedFrom(ex:d; ex:e2, ex:e1, -, -, -)", "wasDerivedFrom", 2),
+        ("wasAttributedTo(ex:e1, ex:ag)", "wasAttributedTo", 2),
+        ("wasAssociatedWith(ex:a1)", "wasAssociatedWith", 1),
+        ("wasAssociatedWith(ex:a1, ex:ag, ex:plan)", "wasAssociatedWith", 3),
+        ("actedOnBehalfOf(ex:ag2, ex:ag1)", "actedOnBehalfOf", 2),
+        ("actedOnBehalfOf(ex:ag2, ex:ag1, ex:a1)", "actedOnBehalfOf", 3),
+        ("wasInfluencedBy(ex:e2, ex:e1)", "wasInfluencedBy", 2),
+        ("alternateOf(ex:e1, ex:e2)", "alternateOf", 2),
+        ("specializationOf(ex:e1, ex:e2)", "specializationOf", 2),
+        ("hadMember(ex:c, ex:e)", "hadMember", 2),
+        ("prov:mentionOf(ex:e1, ex:e0, ex:b)", "prov:mentionOf", 3),
+    ],
+)
+def test_every_expression_form(text, keyword, n_formal):
+    record = only_record(parse(text))
+    assert len([v for _, v in record.formal_attributes if v is not None]) == n_formal
+    assert text.split("(")[0] == keyword
+
+
+def test_relation_identifier_is_kept():
+    record = only_record(parse("wasGeneratedBy(ex:g1; ex:e1, ex:a1, -)"))
+    assert str(record.identifier) == "ex:g1"
+
+
+def test_formal_time_is_a_datetime():
+    record = only_record(parse("used(ex:a1, ex:e1, 2011-11-16T16:05:00Z)"))
+    (time,) = [v for k, v in record.formal_attributes if str(k) == "prov:time"]
+    assert time == datetime.datetime(2011, 11, 16, 16, 5, tzinfo=datetime.timezone.utc)
+
+
+def test_mention_maps_to_prov_mention():
+    record = only_record(parse("prov:mentionOf(ex:e1, ex:e0, ex:b)"))
+    assert isinstance(record, ProvMention)
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [
+        ('"plain"', "plain"),
+        ('"""two\nlines"""', "two\nlines"),
+        ("42", 42),
+        ('"1" %% xsd:int', 1),
+        ('"2.5" %% xsd:double', 2.5),
+        ('"1" %% xsd:boolean', True),
+        ('"5000000000" %% xsd:long', 5000000000),
+        ("'ex:abc'", "QNAME"),
+        ('"a place"@en', Literal("a place", langtag="en")),
+        ('"2019-03-27T12:52:02" %% xsd:dateTime', datetime.datetime(2019, 3, 27, 12, 52, 2)),
+    ],
+)
+def test_literal_forms(literal, expected):
+    record = only_record(parse(f"entity(ex:e1, [ex:v={literal}])"))
+    (value,) = record.get_attribute("ex:v")
+    if expected == "QNAME":
+        assert str(value) == "ex:abc"
+    else:
+        assert value == expected
+
+
+def test_literal_equivalence_with_json():
+    body = (
+        'entity(ex:e1, [ex:s="x", ex:i=1, ex:f="1.5" %% xsd:double, ex:q=\'ex:q1\','
+        ' ex:l="un lieu"@fr, ex:t="2019-03-27T12:52:02" %% xsd:dateTime])'
+    )
+    doc = parse(body)
+    reloaded = ProvDocument.deserialize(content=doc.serialize(format="json"), format="json")
+    assert doc == reloaded
+
+
+def test_multiple_attributes_and_repeated_keys():
+    record = only_record(parse('entity(ex:e1, [prov:type="a", prov:type="b", ex:k=1])'))
+    assert record.get_attribute("prov:type") == {"a", "b"}
+
+
+def test_bundle_with_own_prefixes():
+    body = "bundle ex:b1\n  prefix bob <http://bob.org/>\n  entity(bob:e1)\nendBundle"
+    doc = parse(body)
+    (bundle,) = doc.bundles
+    assert str(bundle.identifier) == "ex:b1"
+    assert str(only_record(bundle).identifier) == "bob:e1"
+    assert "bob" not in {ns.prefix for ns in doc.get_registered_namespaces()}
+
+
+def test_bundle_bare_name_uses_document_default():
+    doc = parse("bundle ex:b1\n  entity(e1)\nendBundle", prefixes="default <http://d.org/>\n" + PREFIXES)
+    (bundle,) = doc.bundles
+    assert only_record(bundle).identifier.uri == "http://d.org/e1"
+
+
+def test_comments_anywhere():
+    doc = parse("entity(ex:e1) // trailing\n/* block */ entity(ex:e2)")
+    assert len(list(doc.get_records())) == 2
+
+
+@pytest.mark.parametrize(
+    ("body", "message", "line"),
+    [
+        ("entity(ex:e1)", "expected 'endDocument'", None),  # closing removed below
+        ("foo(ex:e1)", "unknown statement keyword 'foo'", 4),
+        ("ex:custom(ex:e1)", "extensibility expression", 4),
+        ("wasGeneratedBy(ex:e1, ex:a1)", "takes 1 or 3 arguments, got 2", 4),
+        ("used(ex:a1, 2011-11-16T16:05:00, -)", "expected an identifier", 4),
+        ("entity(zz:e1)", "prefix 'zz' is not declared", 4),
+        ("entity(e1)", "no default namespace", 4),
+        ("entity(ex:e1, [ex:k=1)", "expected ']'", 4),
+        ("bundle ex:b\n bundle ex:c\n endBundle\nendBundle", "cannot contain a bundle", 5),
+        ("entity(ex:e1,, [])", "expected an identifier, a time or '-'", 4),
+        ("entity(ex:e1) endDocument entity(ex:e2)", "after 'endDocument'", 4),
+    ],
+)
+def test_errors_name_the_problem_and_position(body, message, line):
+    if line is None:
+        text = f"document\n{PREFIXES}{body}"  # no endDocument
+        with pytest.raises(ProvNSyntaxError, match=message):
+            ProvNParser(text, "strict").parse()
+        return
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        parse(body)
+    assert message in str(ctx.value)
+    assert ctx.value.line == line
+
+
+def test_strict_rejects_bare_mention_and_shorthand():
+    with pytest.raises(ProvNSyntaxError, match="unknown statement keyword 'mentionOf'"):
+        parse("mentionOf(ex:e1, ex:e0, ex:b)")
+    with pytest.raises(ProvNSyntaxError, match="unknown statement keyword 'person'"):
+        parse("person(ex:p)")
+
+
+def test_model_errors_carry_the_statement_position():
+    # A membership whose collection identifier resolves but the record
+    # constructor rejects (an element with no identifier cannot happen via
+    # the grammar; a relation to a bundle-typed value can), so exercise the
+    # generic wrapping with a time literal the model cannot parse.
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        parse("used(ex:a1, ex:e1, 2011-13-40T99:00:00)")
+    assert ctx.value.line == 4
+
+
+def test_unknown_profile_rejected():
+    with pytest.raises(ValueError, match="profile"):
+        ProvNParser("document endDocument", "loose")
+
+
+def test_arity_table_matches_formal_attributes():
+    for rec_type, arities in [*_ELEMENTS.values(), *_RELATIONS.values(), _MENTION]:
+        assert max(arities) == len(PROV_REC_CLS[rec_type].FORMAL_ATTRIBUTES)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        examples.primer_example,
+        examples.w3c_publication_1,
+        examples.bundles1,
+        examples.collections,
+        examples.datatypes,
+        examples.long_literals,
+        examples.default_namespace_attributes,
+    ],
+)
+def test_writer_output_parses_to_an_equal_document(build):
+    doc = build()
+    reloaded = ProvNParser(doc.get_provn(), "default").parse()
+    assert reloaded == doc
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `uv run pytest src/prov/tests/test_provn.py -q`
+Expected: collection error, `No module named 'prov.serializers.provn_parser'`.
+
+- [ ] **Step 3: Write the parser**
+
+`src/prov/serializers/provn_parser.py`:
+
+```python
+"""Recursive-descent parser for PROV-N (https://www.w3.org/TR/prov-n/).
+
+Every statement opens with a keyword, so the parser reads one token and
+enters the matching rule; there is no backtracking. Records are built
+through :meth:`ProvBundle.new_record` with the same arguments the PROV-JSON
+deserializer passes, so attribute typing, literal parsing and namespace
+registration match every other format.
+
+Profiles:
+
+- ``strict``: the Recommendation grammar only.
+- ``default``: also the de-facto extensions ``prov`` and ProvToolbox write,
+  the bare ``mentionOf`` keyword and the shorthand keywords for typed
+  agents, entities and derivations.
+- ``lenient``: as ``default``; a statement that fails to parse is skipped
+  with a :class:`ProvWarning` and parsing resumes at the next statement.
+  Tokenisation errors are fatal in every profile.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterator
+from typing import Any
+
+from prov.constants import (
+    PROV,
+    PROV_ACTIVITY,
+    PROV_AGENT,
+    PROV_ALTERNATE,
+    PROV_ASSOCIATION,
+    PROV_ATTRIBUTE_LITERALS,
+    PROV_ATTRIBUTION,
+    PROV_COMMUNICATION,
+    PROV_DELEGATION,
+    PROV_DERIVATION,
+    PROV_END,
+    PROV_ENTITY,
+    PROV_GENERATION,
+    PROV_INFLUENCE,
+    PROV_INVALIDATION,
+    PROV_MEMBERSHIP,
+    PROV_MENTION,
+    PROV_QUALIFIEDNAME,
+    PROV_SPECIALIZATION,
+    PROV_START,
+    PROV_USAGE,
+)
+from prov.identifier import Namespace, QualifiedName
+from prov.model import (
+    PROV_REC_CLS,
+    Literal,
+    ProvBundle,
+    ProvDocument,
+    ProvException,
+    ProvWarning,
+    parse_xsd_datetime,
+)
+from prov.serializers.provn_lexer import ProvNSyntaxError, Token, TokenKind, tokenize
+
+__all__ = ["PROFILES", "ProvNParser"]
+
+PROFILES = ("strict", "default", "lenient")
+
+# keyword -> (record type, allowed argument counts after the identifier)
+_ELEMENTS: dict[str, tuple[QualifiedName, tuple[int, ...]]] = {
+    "entity": (PROV_ENTITY, (0,)),
+    "activity": (PROV_ACTIVITY, (0, 2)),
+    "agent": (PROV_AGENT, (0,)),
+}
+# keyword -> (record type, allowed argument counts)
+_RELATIONS: dict[str, tuple[QualifiedName, tuple[int, ...]]] = {
+    "wasGeneratedBy": (PROV_GENERATION, (1, 3)),
+    "used": (PROV_USAGE, (1, 3)),
+    "wasInvalidatedBy": (PROV_INVALIDATION, (1, 3)),
+    "wasStartedBy": (PROV_START, (1, 4)),
+    "wasEndedBy": (PROV_END, (1, 4)),
+    "wasInformedBy": (PROV_COMMUNICATION, (2,)),
+    "wasAttributedTo": (PROV_ATTRIBUTION, (2,)),
+    "wasAssociatedWith": (PROV_ASSOCIATION, (1, 3)),
+    "actedOnBehalfOf": (PROV_DELEGATION, (2, 3)),
+    "wasDerivedFrom": (PROV_DERIVATION, (2, 5)),
+    "wasInfluencedBy": (PROV_INFLUENCE, (2,)),
+    "alternateOf": (PROV_ALTERNATE, (2,)),
+    "specializationOf": (PROV_SPECIALIZATION, (2,)),
+    "hadMember": (PROV_MEMBERSHIP, (2,)),
+}
+_MENTION: tuple[QualifiedName, tuple[int, ...]] = (PROV_MENTION, (3,))
+# default-profile shorthand keyword -> (base keyword, asserted prov:type)
+_SHORTHAND: dict[str, tuple[str, QualifiedName]] = {
+    "person": ("agent", PROV["Person"]),
+    "organization": ("agent", PROV["Organization"]),
+    "softwareAgent": ("agent", PROV["SoftwareAgent"]),
+    "collection": ("entity", PROV["Collection"]),
+    "emptyCollection": ("entity", PROV["EmptyCollection"]),
+    "plan": ("entity", PROV["Plan"]),
+    "wasRevisionOf": ("wasDerivedFrom", PROV["Revision"]),
+    "wasQuotedFrom": ("wasDerivedFrom", PROV["Quotation"]),
+    "hadPrimarySource": ("wasDerivedFrom", PROV["PrimarySource"]),
+}
+_STRUCTURAL = frozenset({"document", "endDocument", "bundle", "endBundle"})
+_ARGUMENT_KINDS = (TokenKind.NAME, TokenKind.MARKER, TokenKind.DATETIME)
+
+
+class ProvNParser:
+    """Parse one PROV-N document.
+
+    Args:
+        text: The PROV-N source.
+        profile: One of :data:`PROFILES`.
+
+    Raises:
+        ValueError: If ``profile`` is not one of :data:`PROFILES`.
+    """
+
+    def __init__(self, text: str, profile: str = "default"):
+        if profile not in PROFILES:
+            raise ValueError(f"profile must be one of {PROFILES}, got {profile!r}")
+        self.profile = profile
+        self._tokens: Iterator[Token] = tokenize(text)
+        self._current: Token = next(self._tokens)
+
+    # -- token helpers -----------------------------------------------------
+
+    def _advance(self) -> Token:
+        token = self._current
+        self._current = next(self._tokens)
+        return token
+
+    def _error(self, message: str, token: Token | None = None) -> ProvNSyntaxError:
+        token = token or self._current
+        return ProvNSyntaxError(message, token.line, token.column)
+
+    def _found(self) -> str:
+        token = self._current
+        return token.kind.value if token.kind is TokenKind.EOF else repr(token.text)
+
+    def _expect(self, kind: TokenKind, what: str | None = None) -> Token:
+        if self._current.kind is not kind:
+            raise self._error(f"expected {what or kind.value!r}, found {self._found()}")
+        return self._advance()
+
+    def _at_keyword(self, keyword: str) -> bool:
+        return self._current.kind is TokenKind.NAME and self._current.value == ("", keyword)
+
+    def _expect_keyword(self, keyword: str) -> None:
+        if not self._at_keyword(keyword):
+            raise self._error(f"expected '{keyword}', found {self._found()}")
+        self._advance()
+
+    # -- structure -------------------------------------------------------------
+
+    def parse(self) -> ProvDocument:
+        """Parse the whole input and return the document."""
+        document = ProvDocument()
+        self._expect_keyword("document")
+        self._declarations(document)
+        while not self._at_keyword("endDocument"):
+            if self._current.kind is TokenKind.EOF:
+                raise self._error("expected 'endDocument', found end of input")
+            if self._at_keyword("bundle"):
+                self._bundle(document)
+            else:
+                self._statement(document)
+        self._advance()
+        if self._current.kind is not TokenKind.EOF:
+            raise self._error("unexpected content after 'endDocument'")
+        return document
+
+    def _declarations(self, bundle: ProvBundle) -> None:
+        while True:
+            if self._at_keyword("prefix"):
+                self._advance()
+                name = self._expect(TokenKind.NAME, "a prefix")
+                prefix, local = name.value
+                if prefix:
+                    raise self._error(f"expected a prefix, found {name.text!r}", name)
+                iri = self._expect(TokenKind.IRI, "an IRI in angle brackets")
+                bundle.add_namespace(Namespace(local, iri.value))
+            elif self._at_keyword("default"):
+                self._advance()
+                iri = self._expect(TokenKind.IRI, "an IRI in angle brackets")
+                bundle.set_default_namespace(iri.value)
+            else:
+                return
+
+    def _bundle(self, document: ProvDocument) -> None:
+        self._advance()  # 'bundle'
+        identifier = self._identifier(document)
+        bundle = document.bundle(identifier)
+        self._declarations(bundle)
+        while not self._at_keyword("endBundle"):
+            if self._current.kind is TokenKind.EOF:
+                raise self._error("expected 'endBundle', found end of input")
+            if self._at_keyword("bundle"):
+                raise self._error("a bundle cannot contain a bundle")
+            self._statement(bundle)
+        self._advance()
+
+    def _statement(self, bundle: ProvBundle) -> None:
+        start = self._current
+        try:
+            self._expression(bundle)
+        except ProvNSyntaxError as exc:
+            if self.profile != "lenient":
+                raise
+            warnings.warn(f"PROV-N statement skipped: {exc}", ProvWarning, stacklevel=4)
+            self._resync()
+        except ProvException as exc:
+            raise ProvNSyntaxError(str(exc), start.line, start.column) from exc
+
+    def _resync(self) -> None:
+        """Skip to the next statement boundary at bracket depth zero."""
+        depth = 0
+        while self._current.kind is not TokenKind.EOF:
+            token = self._current
+            if token.kind in (TokenKind.LPAREN, TokenKind.LBRACKET):
+                depth += 1
+            elif token.kind in (TokenKind.RPAREN, TokenKind.RBRACKET):
+                depth = max(0, depth - 1)
+            elif depth == 0 and token.kind is TokenKind.NAME:
+                prefix, local = token.value
+                if not prefix and (
+                    local in _STRUCTURAL
+                    or local in _ELEMENTS
+                    or local in _RELATIONS
+                    or local in _SHORTHAND
+                    or local == "mentionOf"
+                ):
+                    return
+                if (prefix, local) == ("prov", "mentionOf"):
+                    return
+            self._advance()
+
+    # -- expressions -------------------------------------------------------------
+
+    def _classify(self, token: Token) -> tuple[QualifiedName, tuple[int, ...], bool, QualifiedName | None]:
+        """Return (record type, arities, is_element, asserted type) for a keyword token."""
+        prefix, local = token.value
+        extensions = self.profile != "strict"
+        if (prefix, local) == ("prov", "mentionOf") or (
+            extensions and (prefix, local) == ("", "mentionOf")
+        ):
+            return (*_MENTION, False, None)
+        if prefix:
+            raise self._error(
+                f"extensibility expression '{token.text}(...)' is not supported", token
+            )
+        if local in _ELEMENTS:
+            return (*_ELEMENTS[local], True, None)
+        if local in _RELATIONS:
+            return (*_RELATIONS[local], False, None)
+        if extensions and local in _SHORTHAND:
+            base, asserted = _SHORTHAND[local]
+            if base in _ELEMENTS:
+                return (*_ELEMENTS[base], True, asserted)
+            return (*_RELATIONS[base], False, asserted)
+        raise self._error(f"unknown statement keyword '{local}'", token)
+
+    def _expression(self, bundle: ProvBundle) -> None:
+        keyword = self._expect(TokenKind.NAME, "a statement keyword")
+        rec_type, arities, is_element, asserted_type = self._classify(keyword)
+        self._expect(TokenKind.LPAREN, "'('")
+        identifier: QualifiedName | None = None
+        args: list[Token] = []
+        if is_element:
+            identifier = self._identifier(bundle)
+        else:
+            first = self._argument()
+            if self._current.kind is TokenKind.SEMICOLON:
+                if first.kind is not TokenKind.NAME:
+                    raise self._error("expected an identifier before ';'", first)
+                identifier = self._resolve(first, bundle)
+                self._advance()
+                args.append(self._argument())
+            else:
+                args.append(first)
+        other_attributes: list[tuple[QualifiedName, Any]] = []
+        while self._current.kind is TokenKind.COMMA:
+            self._advance()
+            if self._current.kind is TokenKind.LBRACKET:
+                other_attributes = self._attributes(bundle)
+                break
+            args.append(self._argument())
+        self._expect(TokenKind.RPAREN, "')'")
+
+        if len(args) not in arities:
+            allowed = " or ".join(str(n) for n in arities)
+            raise self._error(
+                f"'{keyword.text}' takes {allowed} arguments, got {len(args)}", keyword
+            )
+        formal_names = PROV_REC_CLS[rec_type].FORMAL_ATTRIBUTES
+        attributes = []
+        for attr, token in zip(formal_names, args, strict=False):
+            value = self._argument_value(token, attr, bundle)
+            if value is not None:
+                attributes.append((attr, value))
+        record = bundle.new_record(rec_type, identifier, attributes, other_attributes)
+        if asserted_type is not None:
+            record.add_asserted_type(asserted_type)
+
+    def _argument(self) -> Token:
+        if self._current.kind not in _ARGUMENT_KINDS:
+            raise self._error(f"expected an identifier, a time or '-', found {self._found()}")
+        return self._advance()
+
+    def _argument_value(self, token: Token, attr: QualifiedName, bundle: ProvBundle) -> Any:
+        if token.kind is TokenKind.MARKER:
+            return None
+        if attr in PROV_ATTRIBUTE_LITERALS:
+            if token.kind is not TokenKind.DATETIME:
+                raise self._error(f"expected a time for {attr}, found {token.text!r}", token)
+            value = parse_xsd_datetime(token.value)
+            if value is None:
+                raise self._error(f"invalid xsd:dateTime {token.text!r}", token)
+            return value
+        if token.kind is not TokenKind.NAME:
+            raise self._error(f"expected an identifier for {attr}, found {token.text!r}", token)
+        return self._resolve(token, bundle)
+
+    def _identifier(self, bundle: ProvBundle) -> QualifiedName:
+        return self._resolve(self._expect(TokenKind.NAME, "an identifier"), bundle)
+
+    def _resolve(self, token: Token, bundle: ProvBundle) -> QualifiedName:
+        prefix, local = token.value
+        if prefix:
+            qname = bundle.valid_qualified_name(f"{prefix}:{local}")
+            if qname is None:
+                raise self._error(
+                    f"cannot resolve {token.text!r}: prefix '{prefix}' is not declared", token
+                )
+            return qname
+        default = bundle.get_default_namespace()
+        if default is None and bundle.document is not None:
+            default = bundle.document.get_default_namespace()
+        if default is None:
+            raise self._error(
+                f"cannot resolve {token.text!r}: no default namespace declared", token
+            )
+        return default[local]
+
+    # -- attributes and literals -----------------------------------------------
+
+    def _attributes(self, bundle: ProvBundle) -> list[tuple[QualifiedName, Any]]:
+        self._expect(TokenKind.LBRACKET, "'['")
+        pairs: list[tuple[QualifiedName, Any]] = []
+        if self._current.kind is TokenKind.RBRACKET:
+            self._advance()
+            return pairs
+        while True:
+            name = self._expect(TokenKind.NAME, "an attribute name")
+            attr = self._resolve(name, bundle)
+            self._expect(TokenKind.EQUALS, "'='")
+            pairs.append((attr, self._literal(bundle)))
+            if self._current.kind is TokenKind.COMMA:
+                self._advance()
+                continue
+            self._expect(TokenKind.RBRACKET, "']'")
+            return pairs
+
+    def _literal(self, bundle: ProvBundle) -> Any:
+        token = self._current
+        if token.kind is TokenKind.STRING:
+            self._advance()
+            if self._current.kind is TokenKind.LANGTAG:
+                return Literal(token.value, langtag=self._advance().value)
+            if self._current.kind is TokenKind.TYPED:
+                self._advance()
+                datatype = self._resolve(self._expect(TokenKind.NAME, "a datatype"), bundle)
+                return Literal(token.value, datatype)
+            return token.value
+        if token.kind is TokenKind.INT:
+            return self._advance().value
+        if token.kind is TokenKind.QNAME_LITERAL:
+            self._advance()
+            prefix, local = token.value
+            text = f"{prefix}:{local}" if prefix else local
+            qname = bundle.valid_qualified_name(text)
+            # An unresolvable prefix stays an opaque literal, as it does when
+            # decoded from PROV-JSON (#257 lock).
+            return qname if qname is not None else Literal(text, PROV_QUALIFIEDNAME)
+        raise self._error(f"expected a literal value, found {self._found()}")
+```
+
+- [ ] **Step 4: Run the tests until they pass**
+
+Run: `uv run pytest src/prov/tests/test_provn.py -q`
+
+Points to check while iterating:
+
+- `test_every_expression_form` counts non-`None` formal values. `record.formal_attributes` yields every formal attribute with `None` for unset ones; confirm that with `uv run python -c "import prov.model as pm; d=pm.ProvDocument(); d.add_namespace('ex','http://e/'); print(d.wasGeneratedBy('ex:e').formal_attributes)"`. If it yields only set attributes, change the test to `len(record.formal_attributes)`.
+- The `bundles1` example holds a `mentionOf`, so it parses under `default` only, which the test uses.
+- `long_literals` writes triple-quoted strings; `datatypes` writes every typed literal the writer produces. A failure in either points at `_literal()` or the lexer's string handling, not at the example.
+- `test_model_errors_carry_the_statement_position` relies on `parse_xsd_datetime` returning `None` for a month of 13; if it raises `ValueError` instead, wrap that in `_argument_value`.
+- `stacklevel=4` in the lenient warning points at the caller of `ProvNSerializer.deserialize()` once Task 5 wires it; adjust after Task 5 if the warning's reported location is inside `prov`.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+codacy-analysis analyze --files src/prov/serializers/provn_parser.py src/prov/tests/test_provn.py
+git add src/prov/serializers/provn_parser.py src/prov/tests/test_provn.py
+git commit -m "feat(provn): add the PROV-N parser"
+git push -u origin provn/parser
+```
+
+```json:metadata
+{"files": ["src/prov/serializers/provn_parser.py", "src/prov/tests/test_provn.py"], "verifyCommand": "uv run pytest src/prov/tests/test_provn.py -q", "acceptanceCriteria": ["Every expression form parses with correct formal mapping", "Namespace declarations at both levels", "Literal forms match PROV-JSON model values", "Error paths raise ProvNSyntaxError with position", "Seven example documents parse equal from get_provn()", "Arity table agrees with FORMAL_ATTRIBUTES", "mypy passes"], "modelTier": "standard"}
+```
+
+---
+### Task 5: Profiles, error type and registry wiring
+
+**Goal:** `ProvNSerializer.deserialize()` runs the parser with a `profile` argument, `prov.read()` passes keyword arguments through, `ProvNSyntaxError` is public from `prov.serializers.provn`, the `default` and `lenient` profiles are tested, and the benchmark suite's PROV-N deserialise case runs.
+
+**Files:**
+- Modify: `src/prov/serializers/provn.py`
+- Modify: `src/prov/__init__.py:70-100, 140-200` (`read()` and `_detect_and_parse()`)
+- Create: `src/prov/tests/test_provn_profiles.py`
+- Modify: `src/prov/tests/test_extras.py:283-292` (drop the `NotImplementedError` guard)
+- Modify: `src/prov/tests/test_read.py` (auto-detection of PROV-N)
+- Modify: `benchmarks/test_bench.py` (remove the provn skip)
+- Modify: `benchmarks/baseline.json` (refreshed)
+- Modify: `HISTORY.md` (PROV-N subsection)
+
+**Acceptance Criteria:**
+- [ ] `ProvDocument.deserialize(content=text, format="provn")` returns the parsed document; `profile="strict"` and `profile="lenient"` are honoured; an unknown profile raises `ValueError`
+- [ ] `prov.read(text)` with no format auto-detects PROV-N; `prov.read(path, format="provn", profile="strict")` passes the profile through
+- [ ] `default` accepts bare `mentionOf` and each of the nine shorthand keywords, producing the base record plus the asserted `prov:type`; `strict` rejects each
+- [ ] `lenient` warns once per unparseable statement with line and column, resumes at the next statement boundary (including across a multi-line attribute list), and returns every well-formed statement; a tokenisation error still raises
+- [ ] `test_extras.py` round-trips `provn` through the registry without an exception guard
+- [ ] `benchmarks/test_bench.py` measures PROV-N deserialisation; `baseline.json` is refreshed from CI
+- [ ] Suite counts: new tests added, 26 skipped, 0 xfailed
+
+**Verify:** `uv run pytest src/prov/tests/test_provn_profiles.py src/prov/tests/test_read.py src/prov/tests/test_extras.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing profile tests**
+
+`src/prov/tests/test_provn_profiles.py`:
+
+```python
+"""Parsing profiles: strict (Recommendation only), default (de-facto
+extensions), lenient (skip unparseable statements with a warning)."""
+
+import warnings
+
+import pytest
+
+from prov.constants import PROV
+from prov.model import ProvDocument, ProvMention, ProvWarning
+from prov.serializers.provn import PROFILES, ProvNSyntaxError
+
+PREFIXES = "prefix ex <http://example.org/>\n"
+
+
+def parse(body, profile="default"):
+    text = f"document\n{PREFIXES}{body}\nendDocument"
+    return ProvDocument.deserialize(content=text, format="provn", profile=profile)
+
+
+def records(doc):
+    return list(doc.get_records())
+
+
+def test_profiles_constant():
+    assert PROFILES == ("strict", "default", "lenient")
+
+
+def test_default_is_the_default_profile():
+    doc = ProvDocument.deserialize(
+        content=f"document\n{PREFIXES}mentionOf(ex:e1, ex:e0, ex:b)\nendDocument",
+        format="provn",
+    )
+    assert isinstance(records(doc)[0], ProvMention)
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(ValueError, match="profile"):
+        parse("entity(ex:e1)", profile="loose")
+
+
+@pytest.mark.parametrize(
+    ("keyword", "base", "asserted"),
+    [
+        ("person", "agent", PROV["Person"]),
+        ("organization", "agent", PROV["Organization"]),
+        ("softwareAgent", "agent", PROV["SoftwareAgent"]),
+        ("collection", "entity", PROV["Collection"]),
+        ("emptyCollection", "entity", PROV["EmptyCollection"]),
+        ("plan", "entity", PROV["Plan"]),
+    ],
+)
+def test_default_shorthand_elements(keyword, base, asserted):
+    (record,) = records(parse(f"{keyword}(ex:x)"))
+    assert record.get_type() == PROV[base.capitalize()]
+    assert asserted in record.get_asserted_types()
+    with pytest.raises(ProvNSyntaxError, match=f"unknown statement keyword '{keyword}'"):
+        parse(f"{keyword}(ex:x)", profile="strict")
+
+
+@pytest.mark.parametrize(
+    ("keyword", "asserted"),
+    [
+        ("wasRevisionOf", PROV["Revision"]),
+        ("wasQuotedFrom", PROV["Quotation"]),
+        ("hadPrimarySource", PROV["PrimarySource"]),
+    ],
+)
+def test_default_shorthand_derivations(keyword, asserted):
+    (record,) = records(parse(f"{keyword}(ex:e2, ex:e1)"))
+    assert record.get_type() == PROV["Derivation"]
+    assert asserted in record.get_asserted_types()
+    with pytest.raises(ProvNSyntaxError):
+        parse(f"{keyword}(ex:e2, ex:e1)", profile="strict")
+
+
+def test_shorthand_equals_xml_decoding():
+    doc = parse("person(ex:p, [prov:label=\"P\"])")
+    reloaded = ProvDocument.deserialize(content=doc.serialize(format="xml"), format="xml")
+    assert doc == reloaded
+
+
+def test_strict_rejects_bare_mention_but_accepts_prefixed():
+    with pytest.raises(ProvNSyntaxError):
+        parse("mentionOf(ex:e1, ex:e0, ex:b)", profile="strict")
+    (record,) = records(parse("prov:mentionOf(ex:e1, ex:e0, ex:b)", profile="strict"))
+    assert isinstance(record, ProvMention)
+
+
+def test_extensibility_rejected_in_default():
+    with pytest.raises(ProvNSyntaxError, match="extensibility expression"):
+        parse("ex:custom(ex:e1)")
+
+
+def test_lenient_skips_bad_statement_and_warns_with_position():
+    body = "entity(ex:e1)\nfoo(ex:e2)\nentity(ex:e3)"
+    with pytest.warns(ProvWarning, match=r"line 3, column 1: unknown statement keyword 'foo'"):
+        doc = parse(body, profile="lenient")
+    assert sorted(str(r.identifier) for r in records(doc)) == ["ex:e1", "ex:e3"]
+
+
+def test_lenient_resumes_after_multiline_attribute_list():
+    body = (
+        "entity(ex:e1, [\n"
+        "  ex:a=1,\n"
+        "  ex:b=\n"       # missing value
+        "])\n"
+        "entity(ex:e2, [\n"
+        "  ex:c=3\n"
+        "])"
+    )
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 1
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e2"]
+
+
+def test_lenient_warns_once_per_bad_statement():
+    body = "foo(ex:e1)\nentity(ex:e2)\nbar(ex:e3)\nentity(ex:e4, [ex:k=])"
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 3
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e2"]
+
+
+def test_lenient_skips_extensibility_expression():
+    with pytest.warns(ProvWarning, match="extensibility"):
+        doc = parse("ex:custom(ex:e1)\nentity(ex:e2)", profile="lenient")
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e2"]
+
+
+def test_lenient_still_raises_on_tokenisation_error():
+    with pytest.raises(ProvNSyntaxError, match="unterminated string"):
+        parse('entity(ex:e1, [ex:k="open])', profile="lenient")
+
+
+def test_lenient_returns_bundle_statements_after_a_skip():
+    body = "bundle ex:b\n  foo(ex:x)\n  entity(ex:e1)\nendBundle"
+    with pytest.warns(ProvWarning):
+        doc = parse(body, profile="lenient")
+    (bundle,) = doc.bundles
+    assert [str(r.identifier) for r in records(bundle)] == ["ex:e1"]
+
+
+def test_strict_and_default_do_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        parse("entity(ex:e1)", profile="strict")
+        parse("entity(ex:e1)")
+```
+
+- [ ] **Step 2: Wire the serializer**
+
+Replace `src/prov/serializers/provn.py` with:
+
+```python
+__author__ = "Trung Dong Huynh"
+__email__ = "trungdong@donggiang.com"
+
+import io
+from typing import Any
+
+from prov.model import ProvDocument
+from prov.serializers import Serializer, _is_text_stream
+from prov.serializers.provn_lexer import ProvNSyntaxError
+from prov.serializers.provn_parser import PROFILES, ProvNParser
+
+__all__ = ["PROFILES", "ProvNSerializer", "ProvNSyntaxError"]
+
+
+class ProvNSerializer(Serializer):
+    """PROV-N serializer and deserializer for ProvDocument."""
+
+    def serialize(self, stream: io.IOBase, **args: Any) -> None:
+        """Serialize ``self.document`` to `PROV-N <http://www.w3.org/TR/prov-n/>`_.
+
+        Args:
+            stream: Stream to write the output to. Text streams receive the
+                PROV-N text directly; other (binary) streams receive it
+                UTF-8-encoded.
+            **args: Unused; accepted for interface compatibility with
+                :meth:`Serializer.serialize`.
+
+        Raises:
+            Exception: If ``self.document`` is ``None``.
+        """
+        if self.document is None:
+            raise Exception("No document to serialize")
+
+        provn_content = self.document.get_provn()
+        stream.write(
+            provn_content if _is_text_stream(stream) else provn_content.encode("utf-8")
+        )
+
+    def deserialize(
+        self, stream: io.IOBase, profile: str = "default", **args: Any
+    ) -> ProvDocument:
+        """Parse PROV-N text from ``stream`` into a new document.
+
+        Args:
+            stream: Text or binary stream holding PROV-N; binary content is
+                decoded as UTF-8.
+            profile: ``"strict"`` (the Recommendation grammar only),
+                ``"default"`` (plus the bare ``mentionOf`` keyword and the
+                shorthand keywords ``prov`` and ProvToolbox write) or
+                ``"lenient"`` (as ``default``, skipping any statement that
+                fails to parse with a :class:`~prov.model.ProvWarning`).
+            **args: Unused; accepted for interface compatibility.
+
+        Returns:
+            The parsed :class:`~prov.model.ProvDocument`.
+
+        Raises:
+            ProvNSyntaxError: On the first tokenisation or, outside the
+                ``lenient`` profile, parse error, with line and column.
+            ValueError: If ``profile`` is not one of :data:`PROFILES`.
+        """
+        content = stream.read()
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        return ProvNParser(content, profile).parse()
+```
+
+Update the `load_serializers()` docstring in `src/prov/serializers/__init__.py` where it says "JSON/PROV-N work in a minimal install" only if the wording implies PROV-N is write-only; otherwise leave it.
+
+- [ ] **Step 3: Pass keyword arguments through `prov.read()`**
+
+In `src/prov/__init__.py`, change the signatures and calls:
+
+```python
+def _detect_and_parse(
+    src: StreamOrPath | None,
+    content: str | bytes | None,
+    serializers: Iterable[str],
+    **kwargs: Any,
+) -> ProvDocument:
+```
+
+with the inner call becoming `ProvDocument.deserialize(source=src, content=content, format=format, **kwargs)`, and
+
+```python
+def read(
+    source: StreamOrPath,
+    format: str | None = None,
+    **kwargs: Any,
+) -> ProvDocument | None:
+```
+
+with `ProvDocument.deserialize(source=src, content=content, format=format.lower(), **kwargs)` and `return _detect_and_parse(src, content, serializers, **kwargs)`. Extend the `read()` docstring's Args with:
+
+```
+        **kwargs: Passed to the deserializer, for example ``profile`` for
+            PROV-N. With auto-detection every candidate receives them.
+```
+
+Add `Any` to the `typing` import if it is not already there.
+
+- [ ] **Step 4: Update the existing tests**
+
+In `src/prov/tests/test_read.py`, add:
+
+```python
+def test_read_auto_detects_provn():
+    text = "document\n  prefix ex <http://example.org/>\n  entity(ex:e1)\nendDocument"
+    document = prov.read(text)
+    assert [str(r.identifier) for r in document.get_records()] == ["ex:e1"]
+
+
+def test_read_passes_profile_through(tmp_path):
+    path = tmp_path / "doc.provn"
+    path.write_text(
+        "document\n  prefix ex <http://example.org/>\n"
+        "  mentionOf(ex:e1, ex:e0, ex:b)\nendDocument"
+    )
+    from prov.serializers.provn import ProvNSyntaxError
+
+    with pytest.raises(ProvNSyntaxError):
+        prov.read(str(path), format="provn", profile="strict")
+    assert prov.read(str(path), format="provn") is not None
+```
+
+In `src/prov/tests/test_extras.py` the round-trip loop (around line 283) drops its `try`/`except NotImplementedError` so that every registered format, PROV-N included, must round-trip:
+
+```python
+    for obj in objects:
+        for format in formats:
+            buf = obj()
+            try:
+                document.serialize(destination=buf, format=format)
+                buf.seek(0, 0)
+                new_document = ProvDocument.deserialize(source=buf, format=format)
+                assert document == new_document
+            finally:
+                buf.close()
+```
+
+- [ ] **Step 5: Benchmarks and changelog**
+
+In `benchmarks/test_bench.py`, `test_deserialize` becomes:
+
+```python
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_deserialize(benchmark, document, fmt):
+    content = serialized(document, fmt)
+    benchmark(ProvDocument.deserialize, content=content, format=fmt)
+```
+
+Under `### PROV-N` in `HISTORY.md`:
+
+```markdown
+- PROV-N can now be read as well as written: `ProvDocument.deserialize(format="provn")`,
+  `prov.read()` (including auto-detection) and `prov-compare` accept PROV-N text, parsed
+  by a hand-written recursive-descent parser with no new dependency
+  ([#122](https://github.com/trungdong/prov/issues/122))
+- Three parsing profiles, selected with `profile=`: `strict` accepts the W3C grammar only;
+  `default` also accepts the bare `mentionOf` keyword and the shorthand keywords
+  (`person`, `organization`, `softwareAgent`, `collection`, `emptyCollection`, `plan`,
+  `wasRevisionOf`, `wasQuotedFrom`, `hadPrimarySource`) that `prov` and ProvToolbox write;
+  `lenient` skips any statement that fails to parse with a `ProvWarning` naming its line
+  and column and resumes at the next statement
+- `prov.serializers.provn.ProvNSyntaxError` (a `ProvException`) reports the line, column
+  and expectation of every syntax error
+```
+
+- [ ] **Step 6: Run everything, then refresh the baseline and push**
+
+```bash
+uv run pytest src/prov/tests/test_provn_profiles.py src/prov/tests/test_read.py src/prov/tests/test_extras.py src/prov/tests/test_provn.py -q
+uv run mypy src && uv run ruff check src/ benchmarks/ && uv run ruff format src/ benchmarks/
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+codacy-analysis analyze --files src/prov/serializers/provn.py src/prov/__init__.py src/prov/tests/test_provn_profiles.py src/prov/tests/test_read.py src/prov/tests/test_extras.py benchmarks/test_bench.py HISTORY.md
+git add -A src/prov benchmarks/test_bench.py HISTORY.md
+git commit -m "feat(provn): wire the parser into the serializer registry with parsing profiles"
+git push
+gh pr create --title "PROV-N parser with strict, default and lenient profiles" --body "Adds prov.serializers.provn_parser, a hand-written recursive-descent parser for PROV-N, and wires it into ProvNSerializer.deserialize(), so PROV-N is now readable through ProvDocument.deserialize(), prov.read() (with auto-detection) and prov-compare. Closes #122.
+
+Three profiles select what the parser accepts: strict is the Recommendation grammar only; default also accepts the bare mentionOf keyword and the shorthand keywords prov and ProvToolbox write; lenient skips any statement that fails to parse with a ProvWarning and resumes at the next statement boundary. Errors are ProvNSyntaxError with line and column.
+
+Records are built through ProvBundle.new_record() with the same arguments the PROV-JSON deserializer passes, so literal typing and namespace handling match the other formats. Seven canonical example documents parse back equal from get_provn(); the shared round-trip suite and conformance corpus follow in the next PR."
+gh workflow run CI.yml --ref provn/parser
+```
+
+When the dispatched run finishes, download the `benchmark-baseline` artifact as `benchmarks/README.md` describes, commit it as `benchmarks/baseline.json` with the message `bench: refresh the baseline with PROV-N deserialisation`, and push. Do not merge; Task 6 reviews this PR first.
+
+```json:metadata
+{"files": ["src/prov/serializers/provn.py", "src/prov/__init__.py", "src/prov/tests/test_provn_profiles.py", "src/prov/tests/test_extras.py", "src/prov/tests/test_read.py", "benchmarks/test_bench.py", "benchmarks/baseline.json", "HISTORY.md"], "verifyCommand": "uv run pytest src/prov/tests/test_provn_profiles.py src/prov/tests/test_read.py src/prov/tests/test_extras.py -q", "acceptanceCriteria": ["deserialize(format='provn') with profile works; unknown profile ValueError", "prov.read auto-detects PROV-N and passes profile through", "default accepts mentionOf and nine shorthand keywords; strict rejects", "lenient warns once per bad statement and resumes correctly; lexer errors raise", "test_extras round-trips provn without guard", "Benchmark measures PROV-N deserialise; baseline refreshed", "Suite counts: new tests, 26 skipped, 0 xfailed"], "modelTier": "standard"}
+```
+
+---
+
+### Task 6: Code-review round on the parser PR
+
+**Goal:** PR 4 has passed a `/code-review` round, every confirmed finding is fixed in the same PR, and the PR is merged closing #122.
+
+**Files:**
+- Modify: `src/prov/serializers/provn_parser.py`, `src/prov/serializers/provn.py`, `src/prov/__init__.py`, the three PROV-N test modules (as findings require)
+
+**Acceptance Criteria:**
+- [ ] The coordinator invoked the `code-review` skill on PR 4 at level `high`
+- [ ] Every CONFIRMED finding is fixed with a test that pins it, or dismissed in the PR with the reason
+- [ ] CI green after the fixes; PR 4 merged with `--merge --delete-branch`; #122 closed by the merge
+
+**Verify:** `gh issue view 122 --json state` → `CLOSED`.
+
+**Steps:**
+
+- [ ] **Step 1: Run the review (coordinator, main session)**
+
+Invoke the `code-review` skill with arguments `<PR 4 number> high`. Ask it to weigh: the two-token lookahead workaround for the optional relation identifier (a relation whose first argument is `-` followed by `;`), lenient resynchronisation when the error is raised inside brackets, `stacklevel` of the lenient warning, the bare-name resolution fallback to the document's default namespace, `Literal` values that `new_record()` may reject, and whether any Recommendation production is unreachable in the tests.
+
+- [ ] **Step 2: Fix confirmed findings in the PR branch**
+
+For each confirmed finding, add a test that fails before the fix, fix the code, and commit as `fix(provn): <finding>`. Dismissed findings get a one-line reply in the PR.
+
+- [ ] **Step 3: Merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+gh issue view 122 --json state
+```
+
+```json:metadata
+{"files": ["src/prov/serializers/provn_parser.py", "src/prov/serializers/provn.py", "src/prov/__init__.py"], "verifyCommand": "gh issue view 122 --json state", "acceptanceCriteria": ["code-review skill run at level high on PR 4", "Confirmed findings fixed with pinning tests or dismissed with reasons", "PR 4 merged and #122 closed"], "modelTier": "frontier", "coordinatorRun": true}
+```
+
+---
+
+### Task 7: PROV-N joins the shared round-trip suite and the property test
+
+**Goal:** `provn` is a member of `ROUNDTRIP_FORMATS`, so every shared statement, attribute, qualified-name and example case and the Hypothesis property test run write-then-read through the parser, and any writer defect they expose is fixed.
+
+**Files:**
+- Modify: `src/prov/tests/conftest.py:29-35`
+- Modify: `src/prov/tests/test_property_roundtrip.py:1-10` (docstring)
+- Modify: `src/prov/tests/strategies.py` (only if a generation exclusion is needed)
+- Modify: `src/prov/model/records.py` or `src/prov/identifier.py` (only if a writer defect surfaces)
+- Modify: `HISTORY.md` (Tests subsection)
+
+**Acceptance Criteria:**
+- [ ] `ROUNDTRIP_FORMATS == ("json", "xml", "rdf", "jsonld", "provn")`
+- [ ] `test_statements.py`, `test_attributes.py`, `test_qnames.py`, `test_examples.py` and `test_property_roundtrip.py` pass for `fmt == "provn"` with no new skip or xfail
+- [ ] `HYPOTHESIS_PROFILE=ci uv run pytest src/prov/tests/test_property_roundtrip.py -k provn` passes; a local run with the default profile (more examples) passes
+- [ ] Any writer defect found is fixed in the writer with a pinning test in `test_provn_escaping.py`, and listed in `HISTORY.md` under Fixes
+- [ ] Suite counts: passed rises by the number of shared cases (one per shared test node), 26 skipped, 0 xfailed
+
+**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -k "provn" src/prov/tests/test_statements.py src/prov/tests/test_attributes.py src/prov/tests/test_qnames.py src/prov/tests/test_examples.py src/prov/tests/test_property_roundtrip.py` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Add the format**
+
+In `src/prov/tests/conftest.py`:
+
+```python
+# Formats that support a full serialize -> deserialize -> compare round trip.
+ROUNDTRIP_FORMATS = ("json", "xml", "rdf", "jsonld", "provn")
+```
+
+Update the `test_property_roundtrip.py` module docstring's format list to include `provn`.
+
+- [ ] **Step 2: Run the shared suite for provn and triage failures**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -k provn src/prov/tests/test_statements.py src/prov/tests/test_attributes.py src/prov/tests/test_qnames.py src/prov/tests/test_examples.py 2>&1 | tail -30
+```
+
+Each failure is one of three things. Decide which before touching code:
+
+1. **Writer defect.** The writer produced text the parser rejects, or text that reads back to a different value. Fix the writer (`encoding_provn_value`, `Literal.provn_representation`, `QualifiedName.provn_bare_representation`, or `ProvRecord.get_provn`) and add a test to `test_provn_escaping.py` that asserts the exact text. Example shape:
+
+   ```python
+   def test_negative_int_attribute_round_trips():
+       document = _doc()
+       document.entity("ex:e1", {"ex:n": -5})
+       assert "ex:n=-5" in document.get_provn()
+       reloaded = ProvDocument.deserialize(content=document.get_provn(), format="provn")
+       assert reloaded == document
+   ```
+
+2. **Parser defect.** The text is valid PROV-N and the parser rejects or misreads it. Fix the parser and add the case to `test_provn.py`.
+
+3. **Model asymmetry.** The value survives as text but the model compares unequal (for example a `Literal` the model keeps opaque on one side and converts on the other). These are the cases that PROV-JSON and PROV-XML already handle identically; make the PROV-N parser produce the same model value the JSON decoder produces for the equivalent JSON, which usually means passing a `Literal` and letting `_auto_literal_conversion` decide.
+
+There are no known-lossy PROV-N constructs. Do not add a `provn` mark to any `known-lossy` parametrisation in `test_statements.py`.
+
+- [ ] **Step 3: Run the property test**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -k provn src/prov/tests/test_property_roundtrip.py
+```
+
+Hypothesis prints the minimal falsifying document on failure. Triage as in step 2. The local-part alphabet in `strategies.py` already excludes `%`, `-` and `.`, which the Recommendation restricts, so no new generation exclusion is expected. If one becomes necessary, it must carry a comment naming the PROV-N production and an issue filed with `gh issue create`, like the existing #341 exclusion.
+
+- [ ] **Step 4: Changelog and commit**
+
+Under `### Tests` in `HISTORY.md`:
+
+```markdown
+- The shared round-trip suite and the Hypothesis round-trip property now cover PROV-N,
+  so every statement form, attribute datatype and qualified-name shape is written and
+  read back through the new parser
+```
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+git add src/prov/tests/conftest.py src/prov/tests/test_property_roundtrip.py HISTORY.md
+git add src/prov/tests/strategies.py src/prov/tests/test_provn_escaping.py src/prov/model src/prov/identifier.py 2>/dev/null
+git commit -m "test(provn): add PROV-N to the shared round-trip suite and property test"
+git push -u origin provn/roundtrip-corpus
+```
+
+```json:metadata
+{"files": ["src/prov/tests/conftest.py", "src/prov/tests/test_property_roundtrip.py", "HISTORY.md"], "verifyCommand": "uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -k provn src/prov/tests/test_statements.py src/prov/tests/test_attributes.py src/prov/tests/test_qnames.py src/prov/tests/test_examples.py src/prov/tests/test_property_roundtrip.py", "acceptanceCriteria": ["ROUNDTRIP_FORMATS includes provn", "Shared modules pass for provn with no new skip or xfail", "Property test passes for provn", "Writer defects fixed with pinning tests and changelog lines", "Suite counts consistent"], "modelTier": "standard"}
+```
+
+---
+### Task 8: PROV-N conformance corpus
+
+**Goal:** Three vendored sets of PROV-N documents under `src/prov/tests/provn/` with a README naming source and licence, and a test module that parses every file, round-trips the specification examples through the writer, and compares the ProvToolbox-written corpus against the matching PROV-JSON fixtures for equality, with every exception listed by name and reason.
+
+**Files:**
+- Create: `src/prov/tests/provn/README.md`
+- Create: `src/prov/tests/provn/extract_spec_examples.py`
+- Create: `src/prov/tests/provn/spec/prov-n/*.provn` (about 64 files)
+- Create: `src/prov/tests/provn/spec/prov-dm/*.provn` (about 63 files)
+- Create: `src/prov/tests/provn/provtoolbox/*.provn` (9 files)
+- Create: `src/prov/tests/provn/provtoolbox-corpus/*.provn` (388 files)
+- Create: `src/prov/tests/test_provn_corpus.py`
+- Modify: `.pre-commit-config.yaml:12-14` (exclude the new fixture directory like the others)
+- Modify: `HISTORY.md` (Tests subsection)
+- Modify: `pyproject.toml` (only if `package-data` or `MANIFEST` rules need the new directory excluded from the wheel; check with `uv build && unzip -l dist/*.whl | grep provn/`)
+
+**Acceptance Criteria:**
+- [ ] Every file under `spec/` parses under `strict` and satisfies `parse(parsed.get_provn(strict=True)) == parsed` once Task 9 lands (until then, `default`)
+- [ ] Every file under `provtoolbox/` parses under `default`
+- [ ] Every file under `provtoolbox-corpus/` parses under `default` and equals the document loaded from `src/prov/tests/json/<same name>.json`, except the names in `KNOWN_DIFFERENCES`, each marked `xfail(strict=True)` with a reason naming the difference
+- [ ] The README lists the ten JSON fixtures with no ProvToolbox counterpart (`attr_*43`, `attr_*44`) and every excluded specification example with the reason
+- [ ] The wheel does not ship the corpus (`unzip -l dist/prov-*.whl | grep -c tests/provn` → 0) if the existing `json/`/`xml/` fixture directories are likewise excluded; if they are shipped today, the new directory follows the same rule
+- [ ] Suite counts: passed rises by about 520, skipped stays 26, xfailed rises by `len(KNOWN_DIFFERENCES)`
+
+**Verify:** `uv run pytest src/prov/tests/test_provn_corpus.py -q` → all pass or xfail, no skips, no failures.
+
+**Steps:**
+
+- [ ] **Step 1: Write the extraction script**
+
+`src/prov/tests/provn/extract_spec_examples.py`:
+
+```python
+"""Extract the PROV-N examples from the W3C PROV-N and PROV-DM
+Recommendations into ``spec/prov-n/`` and ``spec/prov-dm/``.
+
+Fragments (anything not already a ``document ... endDocument``) are wrapped
+in a document that declares every prefix the fragment uses under
+``http://example.org/<prefix>/``. Run from this directory:
+
+    uv run python extract_spec_examples.py
+
+The Recommendations are fetched from w3.org; the generated files are
+committed so the tests need no network.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import urllib.request
+from pathlib import Path
+
+SOURCES = {
+    "prov-n": "https://www.w3.org/TR/2013/REC-prov-n-20130430/",
+    "prov-dm": "https://www.w3.org/TR/2013/REC-prov-dm-20130430/",
+}
+_BLOCK = re.compile(r'<pre class="codeexample"[^>]*>(.*?)</pre>', re.S)
+_TAG = re.compile(r"<[^>]+>")
+_PREFIX = re.compile(r"(?<![\w<:/])([A-Za-z][\w.-]*):(?=[\w%\\])")
+_STRIP_STRINGS = re.compile(r'"(?:\\.|[^"\\])*"|<[^>]*>|\'(?:\\.|[^\'\\])*\'')
+
+
+def wrap(fragment: str) -> str:
+    stripped = _STRIP_STRINGS.sub("", fragment)
+    prefixes = sorted({m.group(1) for m in _PREFIX.finditer(stripped)} - {"prov", "xsd"})
+    declarations = "".join(f"  prefix {p} <http://example.org/{p}/>\n" for p in prefixes)
+    body = "".join(f"  {line}\n" for line in fragment.splitlines())
+    return f"document\n{declarations}{body}endDocument\n"
+
+
+def main() -> None:
+    here = Path(__file__).parent
+    for name, url in SOURCES.items():
+        target = here / "spec" / name
+        target.mkdir(parents=True, exist_ok=True)
+        page = urllib.request.urlopen(url).read().decode("utf-8")
+        for index, raw in enumerate(_BLOCK.findall(page), start=1):
+            text = html.unescape(_TAG.sub("", raw)).strip("\n")
+            if "endDocument" not in text:
+                text = wrap(text)
+            elif not text.endswith("\n"):
+                text += "\n"
+            (target / f"{name}-example-{index:02d}.provn").write_text(text, encoding="utf-8")
+        print(name, index, "examples")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Run it: `cd src/prov/tests/provn && uv run python extract_spec_examples.py`. Expected: `prov-n 64 examples`, `prov-dm 63 examples`.
+
+- [ ] **Step 2: Vendor the ProvToolbox sets**
+
+```bash
+mkdir -p src/prov/tests/provn/provtoolbox src/prov/tests/provn/provtoolbox-corpus
+cp ~/projects/ProvToolbox/modules-core/prov-n/src/test/resources/prov/*.provn src/prov/tests/provn/provtoolbox/
+for f in src/prov/tests/json/*.json; do
+  n=$(basename "$f" .json)
+  src=~/projects/ProvToolbox/modules-legacy/prov-n/target/$n.provn
+  [ -f "$src" ] && cp "$src" src/prov/tests/provn/provtoolbox-corpus/
+done
+ls src/prov/tests/provn/provtoolbox-corpus | wc -l   # expect 388
+```
+
+The ProvToolbox checkout is at `~/projects/ProvToolbox`; its licence is MIT (`license.txt`, King's College London and University of Southampton). If the `modules-legacy/prov-n/target` directory is absent, rebuild it with `mvn -pl modules-legacy/prov-n test` inside the checkout, or take the files from the ProvToolbox release that matches.
+
+- [ ] **Step 3: Write the tests**
+
+`src/prov/tests/test_provn_corpus.py`:
+
+```python
+"""PROV-N conformance corpus (src/prov/tests/provn/README.md).
+
+Three sets: the examples of the PROV-N and PROV-DM Recommendations (strict
+grammar, and round-trip through our writer), ProvToolbox's own PROV-N test
+documents (default profile), and the PROV-N that ProvToolbox's writer
+produced from the shared test corpus, compared for equality with the
+PROV-JSON fixture of the same name (the interoperability claim)."""
+
+from pathlib import Path
+
+import pytest
+
+from prov.model import ProvDocument
+
+CORPUS = Path(__file__).parent / "provn"
+JSON_FIXTURES = Path(__file__).parent / "json"
+
+# Specification examples that are not complete statements and so cannot
+# parse. Keep this list in step with provn/README.md.
+EXCLUDED_SPEC_EXAMPLES: dict[str, str] = {
+    # filled in during step 4, e.g.
+    # "prov-n-example-52.provn": "extensibility expression (grammar [43]); not supported",
+}
+
+# ProvToolbox-written documents that legitimately differ from our JSON
+# fixture. Each entry is documented on docs/reference/conformance.md.
+KNOWN_DIFFERENCES: dict[str, str] = {
+    # filled in during step 4
+}
+
+
+def _files(subdir: str) -> list[Path]:
+    return sorted((CORPUS / subdir).glob("*.provn"))
+
+
+def _param(subdir: str, excluded: dict[str, str] | None = None):
+    params = []
+    for path in _files(subdir):
+        marks = []
+        if excluded and path.name in excluded:
+            marks.append(pytest.mark.xfail(strict=True, reason=excluded[path.name]))
+        params.append(pytest.param(path, id=path.name, marks=marks))
+    return params
+
+
+@pytest.mark.parametrize("path", _param("spec/prov-n", EXCLUDED_SPEC_EXAMPLES))
+def test_prov_n_spec_examples_parse_strictly_and_round_trip(path):
+    document = ProvDocument.deserialize(str(path), format="provn", profile="strict")
+    reloaded = ProvDocument.deserialize(
+        content=document.get_provn(), format="provn", profile="default"
+    )
+    assert reloaded == document
+
+
+@pytest.mark.parametrize("path", _param("spec/prov-dm", EXCLUDED_SPEC_EXAMPLES))
+def test_prov_dm_spec_examples_parse_strictly_and_round_trip(path):
+    document = ProvDocument.deserialize(str(path), format="provn", profile="strict")
+    reloaded = ProvDocument.deserialize(
+        content=document.get_provn(), format="provn", profile="default"
+    )
+    assert reloaded == document
+
+
+@pytest.mark.parametrize("path", _param("provtoolbox"))
+def test_provtoolbox_documents_parse(path):
+    document = ProvDocument.deserialize(str(path), format="provn")
+    assert document.get_records() or document.has_bundles()
+
+
+@pytest.mark.parametrize("path", _param("provtoolbox-corpus", KNOWN_DIFFERENCES))
+def test_provtoolbox_corpus_equals_json_fixture(path):
+    expected = ProvDocument.deserialize(str(JSON_FIXTURES / f"{path.stem}.json"), format="json")
+    document = ProvDocument.deserialize(str(path), format="provn")
+    assert document == expected
+
+
+def test_every_json_fixture_has_a_counterpart_or_is_listed():
+    readme = (CORPUS / "README.md").read_text()
+    have = {p.stem for p in _files("provtoolbox-corpus")}
+    for path in sorted(JSON_FIXTURES.glob("*.json")):
+        if path.stem not in have:
+            assert path.stem in readme, f"{path.stem} has no counterpart and is not listed"
+```
+
+Once Task 9 lands, change `document.get_provn()` in the two spec tests to `document.get_provn(strict=True)` and the reloading profile to `"strict"`.
+
+- [ ] **Step 4: Run, triage, fill the two lists**
+
+```bash
+uv run pytest src/prov/tests/test_provn_corpus.py -q 2>&1 | tail -40
+```
+
+For each failing specification example, open the file. If it is not a complete statement (a bare identifier, an attribute list on its own, a grammar snippet, an extensibility expression), add it to `EXCLUDED_SPEC_EXAMPLES` with a reason that names what it is. If it is a valid statement, the parser has a bug; fix it in `provn_parser.py` or `provn_lexer.py` with a test in `test_provn.py` or `test_provn_lexer.py`, and mention the fix in the PR body.
+
+For each failing corpus comparison, diff the two documents (`print(document.get_provn()); print(expected.get_provn())`). If the difference is a deliberate ProvToolbox choice (for example a typed literal ProvToolbox writes with a datatype our JSON fixture leaves untyped), add the name to `KNOWN_DIFFERENCES` with a one-line reason and add a matching line to the "PROV-N" notes in `docs/reference/conformance.md` (Task 17 finalises that page; leave a `<!-- 3.2.0: corpus exceptions -->` marker line for it to find). If the difference is our parser misreading valid PROV-N, fix the parser.
+
+- [ ] **Step 5: Write the README and finish**
+
+`src/prov/tests/provn/README.md`:
+
+```markdown
+# PROV-N conformance corpus
+
+Fixtures for `test_provn_corpus.py`. Three sets:
+
+| Directory | Source | Licence | Profile |
+|---|---|---|---|
+| `spec/prov-n/` | Examples in the [PROV-N Recommendation](https://www.w3.org/TR/2013/REC-prov-n-20130430/), extracted by `extract_spec_examples.py`; fragments are wrapped in a document declaring the prefixes they use | W3C Document Licence | strict |
+| `spec/prov-dm/` | Examples in the [PROV-DM Recommendation](https://www.w3.org/TR/2013/REC-prov-dm-20130430/), same treatment | W3C Document Licence | strict |
+| `provtoolbox/` | `modules-core/prov-n/src/test/resources/prov/*.provn` from [ProvToolbox](https://github.com/lucmoreau/ProvToolbox) | MIT | default |
+| `provtoolbox-corpus/` | PROV-N that ProvToolbox's writer produced from the shared test corpus (`modules-legacy/prov-n` test output); each file has a PROV-JSON fixture of the same name in `../json/` | MIT | default |
+
+## Specification examples that do not parse
+
+<!-- one line per entry in EXCLUDED_SPEC_EXAMPLES, filled in step 4 -->
+
+## JSON fixtures with no ProvToolbox counterpart
+
+`attr_association_one_role_attr43`, `attr_association_one_role_attr44`,
+`attr_entity_one_attr43`, `attr_entity_one_attr44`,
+`attr_entity_one_location_attr43`, `attr_entity_one_location_attr44`,
+`attr_entity_one_other_attr43`, `attr_entity_one_other_attr44`,
+`attr_entity_one_value_attr43`, `attr_entity_one_value_attr44`. These were added to
+the JSON corpus after the ProvToolbox output was generated.
+
+## Known differences
+
+<!-- one line per entry in KNOWN_DIFFERENCES, filled in step 4 -->
+```
+
+In `.pre-commit-config.yaml`, change both `exclude` lines to `^src/prov/tests/(json|rdf|xml|unification|jsonld|provn)/`.
+
+Under `### Tests` in `HISTORY.md`:
+
+```markdown
+- A PROV-N conformance corpus: every example in the PROV-N and PROV-DM Recommendations
+  parses under the strict profile and round-trips through the writer, ProvToolbox's own
+  PROV-N test documents parse, and the PROV-N that ProvToolbox writes for the shared test
+  corpus reads back equal to the PROV-JSON fixture of the same name
+```
+
+```bash
+uv build && unzip -l dist/prov-*.whl | grep -c "tests/provn" ; unzip -l dist/prov-*.whl | grep -c "tests/json"
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+codacy-analysis analyze --files src/prov/tests/test_provn_corpus.py src/prov/tests/provn/README.md src/prov/tests/provn/extract_spec_examples.py .pre-commit-config.yaml HISTORY.md
+git add src/prov/tests/provn src/prov/tests/test_provn_corpus.py .pre-commit-config.yaml HISTORY.md
+git commit -m "test(provn): vendor the PROV-N conformance corpus"
+git push
+gh pr create --title "PROV-N in the shared round-trip suite, plus a conformance corpus" --body "Adds provn to ROUNDTRIP_FORMATS so the shared statement, attribute, qualified-name and example cases and the Hypothesis property run write-then-read through the parser, and vendors a three-part PROV-N conformance corpus: the examples of the PROV-N and PROV-DM Recommendations (strict profile, round-tripped through the writer), ProvToolbox's own PROV-N test documents, and the PROV-N ProvToolbox's writer produced for the shared test corpus, each compared for equality with the PROV-JSON fixture of the same name.
+
+Exceptions are listed by name with a reason in src/prov/tests/provn/README.md and marked xfail(strict=True); nothing is skipped silently."
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+The two `grep -c` counts must agree (both 0 or both non-zero); if `tests/json` ships but `tests/provn` does not or the reverse, fix the packaging rule in `pyproject.toml` before merging.
+
+```json:metadata
+{"files": ["src/prov/tests/provn/README.md", "src/prov/tests/provn/extract_spec_examples.py", "src/prov/tests/test_provn_corpus.py", ".pre-commit-config.yaml", "HISTORY.md"], "verifyCommand": "uv run pytest src/prov/tests/test_provn_corpus.py -q", "acceptanceCriteria": ["Spec examples parse strictly and round-trip", "ProvToolbox documents parse", "Corpus equals JSON fixtures except documented xfails", "README lists the ten missing counterparts and every exclusion", "Wheel packaging consistent with existing fixtures", "Suite counts as stated"], "modelTier": "standard"}
+```
+
+---
+
+### Task 9: Strict output option for the writer
+
+**Goal:** `get_provn(strict=True)` and `serialize(format="provn", strict=True)` write `prov:mentionOf` instead of `mentionOf`, so the output parses under the `strict` profile; the default output is unchanged.
+
+**Files:**
+- Modify: `src/prov/model/records.py:945-1000` (`ProvRecord.get_provn`)
+- Modify: `src/prov/model/bundle.py:510-560` (`ProvBundle.get_provn`)
+- Modify: `src/prov/serializers/provn.py` (`serialize`)
+- Modify: `src/prov/tests/test_provn_escaping.py`
+- Modify: `src/prov/tests/test_provn_corpus.py` (the two spec tests, per Task 8 step 3)
+- Modify: `HISTORY.md` (PROV-N subsection)
+
+**Acceptance Criteria:**
+- [ ] `document.get_provn()` output is byte-identical to before for every document in `examples.tests`
+- [ ] `document.get_provn(strict=True)` contains `prov:mentionOf(` and never bare `mentionOf(` for a document with a Mention; identical to the default output otherwise
+- [ ] `document.serialize(format="provn", strict=True)` equals `document.get_provn(strict=True)`
+- [ ] Strict output parses under `profile="strict"` to an equal document
+- [ ] Suite counts: new tests added, 26 skipped, xfail unchanged
+
+**Verify:** `uv run pytest src/prov/tests/test_provn_escaping.py src/prov/tests/test_provn_corpus.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/prov/tests/test_provn_escaping.py`:
+
+```python
+def _mention_doc():
+    document = _doc()
+    bundle = document.bundle("ex:b")
+    bundle.entity("ex:e0")
+    document.entity("ex:e1")
+    document.mention("ex:e1", "ex:e0", "ex:b")
+    return document
+
+
+def test_default_output_keeps_bare_mention_keyword():
+    assert "\n  mentionOf(ex:e1, ex:e0, ex:b)" in _mention_doc().get_provn()
+
+
+def test_strict_output_writes_prefixed_mention_keyword():
+    provn = _mention_doc().get_provn(strict=True)
+    assert "prov:mentionOf(ex:e1, ex:e0, ex:b)" in provn
+    assert "\n  mentionOf(" not in provn
+
+
+def test_strict_output_parses_under_strict_profile():
+    document = _mention_doc()
+    reloaded = ProvDocument.deserialize(
+        content=document.get_provn(strict=True), format="provn", profile="strict"
+    )
+    assert reloaded == document
+
+
+def test_serialize_strict_matches_get_provn_strict():
+    document = _mention_doc()
+    assert document.serialize(format="provn", strict=True) == document.get_provn(strict=True)
+
+
+def test_strict_flag_changes_nothing_without_a_mention():
+    document = _doc()
+    document.entity("ex:e1", {"ex:k": "v"})
+    assert document.get_provn(strict=True) == document.get_provn()
+```
+
+- [ ] **Step 2: Thread the flag**
+
+In `ProvRecord.get_provn` (`records.py`), change the signature to `def get_provn(self, strict: bool = False) -> str:` and the keyword line to:
+
+```python
+        keyword = PROV_N_MAP[self.get_type()]
+        if strict and self.get_type() == PROV_MENTION:
+            # The Recommendation grammar has no Mention; PROV-Links writes it
+            # as prov:mentionOf. The default keeps the bare keyword ProvToolbox
+            # reads (#248).
+            keyword = "prov:mentionOf"
+        prov_n = "{}({}{})".format(keyword, relation_id, ", ".join(items))
+```
+
+Extend the docstring: `Args: strict: Write \`\`prov:mentionOf\`\` instead of the bare \`\`mentionOf\`\` keyword so the output parses under the strict PROV-N profile.` Import `PROV_MENTION` from `prov.constants` if not already imported.
+
+In `ProvBundle.get_provn` (`bundle.py`), the signature becomes `def get_provn(self, _indent_level: int = 0, strict: bool = False) -> str:`; the record line becomes `lines.extend([record.get_provn(strict=strict) for record in self._records])` and the bundle line `lines.extend(bundle.get_provn(_indent_level + 1, strict=strict) for bundle in self.bundles)`. Add the same `strict` docstring sentence.
+
+In `ProvNSerializer.serialize`, the signature becomes `def serialize(self, stream: io.IOBase, strict: bool = False, **args: Any) -> None:`, the call `self.document.get_provn(strict=strict)`, and the docstring gains the `strict` argument.
+
+`ProvRecord.__str__` still calls `self.get_provn()` with no argument.
+
+- [ ] **Step 3: Switch the corpus tests to strict**
+
+In `test_provn_corpus.py`, the two spec-example tests use `document.get_provn(strict=True)` and reload with `profile="strict"`.
+
+- [ ] **Step 4: Changelog, gates, commit**
+
+Under `### PROV-N` in `HISTORY.md`:
+
+```markdown
+- `get_provn(strict=True)` and `serialize(format="provn", strict=True)` write `prov:mentionOf`
+  instead of the bare `mentionOf` keyword, so the output parses under the strict profile;
+  the default output is unchanged
+```
+
+```bash
+uv run pytest src/prov/tests/test_provn_escaping.py src/prov/tests/test_provn_corpus.py -q
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+git add src/prov/model/records.py src/prov/model/bundle.py src/prov/serializers/provn.py src/prov/tests/test_provn_escaping.py src/prov/tests/test_provn_corpus.py HISTORY.md
+git commit -m "feat(provn): add a strict output option that writes prov:mentionOf"
+git push -u origin provn/strict-writer-cli-input
+```
+
+```json:metadata
+{"files": ["src/prov/model/records.py", "src/prov/model/bundle.py", "src/prov/serializers/provn.py", "src/prov/tests/test_provn_escaping.py", "src/prov/tests/test_provn_corpus.py", "HISTORY.md"], "verifyCommand": "uv run pytest src/prov/tests/test_provn_escaping.py src/prov/tests/test_provn_corpus.py -q", "acceptanceCriteria": ["Default output byte-identical", "strict=True writes prov:mentionOf", "serialize strict equals get_provn strict", "Strict output parses under strict profile", "Suite counts as stated"], "modelTier": "mechanical"}
+```
+
+---
+
+### Task 10: `prov-convert` reads any registered format
+
+**Goal:** `prov-convert` gains `-i/--input-format` (default `json`) and reads its input in binary so PROV-N, PROV-XML, PROV-O and PROV-JSONLD inputs all work; the CLI how-to documents it.
+
+**Files:**
+- Modify: `src/prov/scripts/convert.py:87-130, 175-205`
+- Modify: `src/prov/tests/test_scripts.py`
+- Modify: `docs/howto/cli.md:1-60`
+- Modify: `HISTORY.md` (PROV-N subsection)
+
+**Acceptance Criteria:**
+- [ ] `prov-convert -i provn -f json in.provn out.json` converts a PROV-N file to PROV-JSON
+- [ ] `prov-convert -f provn in.json out.provn` works exactly as before
+- [ ] `prov-convert -i xml -f json in.xml out.json` converts PROV-XML input (proves the binary read path)
+- [ ] `prov-convert -i nope in.json out.json` exits 2 with an error naming the format
+- [ ] `cat in.provn | prov-convert -i provn > out.json` reads stdin
+- [ ] `docs/howto/cli.md` documents the flag and drops the "no flag for the input format" paragraph
+
+**Verify:** `uv run pytest src/prov/tests/test_scripts.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/prov/tests/test_scripts.py`:
+
+```python
+@pytest.fixture
+def provn_infile(tmp_path):
+    path = tmp_path / "doc.provn"
+    primer_example().serialize(str(path), format="provn")
+    return path
+
+
+def test_convert_from_provn(provn_infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-i", "provn", "-f", "json", str(provn_infile), str(outfile)]
+    )
+    assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
+
+
+def test_convert_from_xml(tmp_path, monkeypatch):
+    pytest.importorskip("lxml")
+    infile = tmp_path / "doc.xml"
+    primer_example().serialize(str(infile), format="xml")
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-i", "xml", str(infile), str(outfile)]
+    )
+    assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
+
+
+def test_convert_unknown_input_format_exits_2(infile, tmp_path, monkeypatch, capsys):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-i", "nope", str(infile), str(outfile)]
+    )
+    assert convert_main() == 2
+    assert "nope" in capsys.readouterr().err
+
+
+def test_convert_reads_provn_from_stdin(provn_infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(sys, "argv", ["prov-convert", "-i", "provn", "-f", "json"])
+    monkeypatch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(provn_infile.read_bytes())))
+    with outfile.open("wb") as out:
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(out))
+        assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
+```
+
+Add `import io` and `from prov.model import ProvDocument` to the module imports if absent. The stdin test wraps a `BytesIO` in a `TextIOWrapper` so `sys.stdin.buffer` exists, as it does for a real terminal.
+
+- [ ] **Step 2: Implement**
+
+In `src/prov/scripts/convert.py`:
+
+```python
+def convert_file(
+    infile: io.FileIO, outfile: io.FileIO, output_format: str, input_format: str = "json"
+) -> None:
+    """Read a PROV document from ``infile`` and write it to ``outfile`` in ``output_format``.
+
+    ``infile`` is read in ``input_format`` (default PROV-JSON) through
+    :meth:`~prov.model.ProvDocument.deserialize`. For ``output_format``,
+    ``"provn"`` is written directly via
+    :meth:`~prov.model.ProvDocument.get_provn`, a name in
+    :data:`GRAPHVIZ_SUPPORTED_FORMATS` is rendered through
+    :func:`~prov.dot.prov_to_dot` and Graphviz, and any other format is
+    delegated to :meth:`~prov.model.ProvDocument.serialize`.
+
+    Args:
+        infile: File-like object (opened in binary mode) to read the source
+            document from.
+        outfile: File-like object (opened in binary mode) to write the
+            converted output to.
+        output_format: Target format name (e.g. ``"json"``, ``"xml"``,
+            ``"rdf"``, ``"jsonld"``, ``"provn"``, or a Graphviz output format such as
+            ``"svg"``/``"pdf"``/``"png"``).
+        input_format: Source format name, any registered serializer format.
+
+    Raises:
+        CLIError: If ``input_format`` is not a registered serializer format,
+            or if ``output_format`` is not ``"provn"``, not a Graphviz
+            format, and not a registered serializer format.
+    """
+    try:
+        prov_doc = ProvDocument.deserialize(infile, format=input_format)
+    except serializers.DoNotExist as e:
+        raise CLIError(f'Input format "{input_format}" is not supported.') from e
+```
+
+with the rest of the body unchanged. In `main()`, add before the `-f` argument:
+
+```python
+        parser.add_argument(
+            "-i",
+            "--input-format",
+            dest="input_format",
+            action="store",
+            default="json",
+            help="input format: json, xml, rdf, jsonld or provn",
+        )
+```
+
+change the `infile` argument to `type=FileType("rb"), default=sys.stdin.buffer` and the outfile default to `sys.stdout.buffer`, and the call to `convert_file(args.infile, args.outfile, args.format.lower(), args.input_format.lower())`. Update the module docstring's first line (`convert -- Convert ...`) to say "Convert a PROV document between PROV-JSON, PROV-N, PROV-XML, PROV-O, PROV-JSONLD and graphical formats". Update the `main()` docstring sentence "Parses ``-f/--format``, an optional input file" to mention `-i/--input-format`.
+
+Run `uv run pytest src/prov/tests/test_scripts.py -q`. The existing `test_convert_*` tests pass a path, so `FileType("rb")` changes nothing for them; if any monkeypatches `sys.stdin` with a plain `StringIO`, give it a `TextIOWrapper(BytesIO(...))` as the new stdin test does.
+
+- [ ] **Step 3: Document**
+
+In `docs/howto/cli.md`:
+
+- Synopsis: `prov-convert [-h] [-i INPUT_FORMAT] [-f FORMAT] [-V] [infile] [outfile]`
+- Options table: add the row `| \`-i\`, \`--input-format\` | \`INPUT_FORMAT\` | \`json\` | Input format: \`json\`, \`xml\`, \`rdf\`, \`jsonld\` or \`provn\` |` and change the `infile` row to "Input file, read in `--input-format`".
+- Delete the paragraph beginning "There is no flag for the input format."
+- Change the section lead to "Convert a PROV document between PROV-JSON, PROV-N, PROV-XML, PROV-O (RDF) and PROV-JSONLD, or render it as any image format Graphviz supports."
+- Add an example:
+
+````markdown
+Convert a PROV-N file to PROV-JSON:
+
+```bash
+prov-convert -i provn -f json document.provn document.json
+```
+````
+
+Under `### PROV-N` in `HISTORY.md`:
+
+```markdown
+- `prov-convert` gains `-i/--input-format`, so it reads PROV-N (or any other registered
+  format), not only PROV-JSON
+```
+
+- [ ] **Step 4: Gates, commit, PR**
+
+```bash
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+codacy-analysis analyze --files src/prov/scripts/convert.py src/prov/tests/test_scripts.py docs/howto/cli.md HISTORY.md
+git add src/prov/scripts/convert.py src/prov/tests/test_scripts.py docs/howto/cli.md HISTORY.md
+git commit -m "feat(cli): let prov-convert read any registered input format"
+git push
+gh pr create --title "Strict PROV-N output option and prov-convert input format" --body "Two additions on top of the parser. get_provn(strict=True) and serialize(format=\"provn\", strict=True) write prov:mentionOf instead of the bare mentionOf keyword so the output parses under the strict profile; the default output is unchanged byte for byte. prov-convert gains -i/--input-format and reads its input in binary, so PROV-N, PROV-XML, PROV-O and PROV-JSONLD inputs work; previously it read PROV-JSON only."
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+```json:metadata
+{"files": ["src/prov/scripts/convert.py", "src/prov/tests/test_scripts.py", "docs/howto/cli.md", "HISTORY.md"], "verifyCommand": "uv run pytest src/prov/tests/test_scripts.py -q", "acceptanceCriteria": ["-i provn converts PROV-N to JSON", "Default JSON input unchanged", "-i xml works (binary read)", "Unknown input format exits 2", "stdin works", "cli.md updated"], "modelTier": "standard"}
+```
+
+---
+### Task 11: Resolve-once cache in `NamespaceManager` and one default-namespace setter
+
+**Goal:** `NamespaceManager.valid_qualified_name()` answers repeat string lookups from a per-manager cache that is cleared whenever a namespace is added or the default changes, with both places that set the default routed through one private method, and the construction benchmark shows the gain.
+
+**Files:**
+- Modify: `src/prov/model/namespaces.py:20-50, 88-96, 100-150, 169-245`
+- Create: `src/prov/tests/test_namespace_cache.py`
+- Modify: `benchmarks/baseline.json` (refreshed from CI after merge of the number in the PR body)
+- Modify: `HISTORY.md` (Performance subsection)
+
+**Acceptance Criteria:**
+- [ ] A second `valid_qualified_name("ex:e1")` on the same manager returns the same `QualifiedName` object without re-resolving (observable: the cache dict holds the key)
+- [ ] Adding a namespace whose prefix shadows a cached resolution, or changing the default namespace, invalidates the cache, and the next lookup resolves afresh
+- [ ] Child managers do not cache resolutions their parent answered in a way that survives the parent changing (the cache is per manager and cleared on the child's own mutations; a parent-answered result is cached only when the child has no namespace of that prefix)
+- [ ] `_default` is assigned in exactly one method, `_set_default()`, called from `set_default_namespace()` and `_reconcile_qualified_name()`
+- [ ] `benchmarks/test_bench.py::test_construct` mean improves by at least 20% at N=100000 on the maintainer's machine; the PR body states before and after
+- [ ] Full suite green; no public API change
+
+**Verify:** `uv run pytest src/prov/tests/test_namespace_cache.py src/prov/tests/test_model.py src/prov/tests/test_qnames.py -q` → all pass; `PROV_BENCH_N=100000 uv run pytest benchmarks/ -k construct --benchmark-json=/tmp/after.json -q` faster than the same run on `main`.
+
+**Steps:**
+
+- [ ] **Step 1: Measure before**
+
+```bash
+git checkout main && git pull --ff-only
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or deserialize" --benchmark-json=/tmp/before.json -q
+git checkout -b perf/resolve-cache
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`src/prov/tests/test_namespace_cache.py`:
+
+```python
+"""The resolve-once cache in NamespaceManager and its invalidation."""
+
+from prov.identifier import Namespace
+from prov.model import NamespaceManager, ProvDocument
+
+
+def test_repeat_lookup_is_served_from_the_cache():
+    manager = NamespaceManager({"ex": "http://example.org/"})
+    first = manager.valid_qualified_name("ex:e1")
+    assert "ex:e1" in manager._resolve_cache
+    assert manager.valid_qualified_name("ex:e1") is first
+
+
+def test_unresolvable_names_are_not_cached():
+    manager = NamespaceManager()
+    assert manager.valid_qualified_name("zz:e1") is None
+    assert "zz:e1" not in manager._resolve_cache
+
+
+def test_adding_a_namespace_clears_the_cache():
+    manager = NamespaceManager({"ex": "http://example.org/"})
+    manager.valid_qualified_name("ex:e1")
+    manager.add_namespace(Namespace("other", "http://other.org/"))
+    assert manager._resolve_cache == {}
+
+
+def test_changing_the_default_clears_the_cache_and_re_resolves():
+    manager = NamespaceManager(default="http://one.org/")
+    first = manager.valid_qualified_name("e1")
+    manager.set_default_namespace("http://two.org/")
+    second = manager.valid_qualified_name("e1")
+    assert first.uri == "http://one.org/e1"
+    assert second.uri == "http://two.org/e1"
+
+
+def test_implicit_default_from_a_prefixless_qualified_name_uses_the_setter():
+    manager = NamespaceManager()
+    qname = Namespace("", "http://implicit.org/")["e1"]
+    manager.valid_qualified_name(qname)
+    assert manager.get_default_namespace().uri == "http://implicit.org/"
+    assert manager[""] is manager.get_default_namespace()
+
+
+def test_child_lookup_answered_by_parent_is_invalidated_by_child_change():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    bundle = document.bundle("ex:b")
+    resolved = bundle.valid_qualified_name("ex:e1")
+    assert resolved.uri == "http://example.org/e1"
+    bundle.add_namespace("ex", "http://shadow.org/")
+    shadowed = bundle.valid_qualified_name("ex:e1")
+    assert shadowed.uri == "http://shadow.org/e1"
+```
+
+Confirm `NamespaceManager` is importable from `prov.model` (`uv run python -c "from prov.model import NamespaceManager"`); if not, import it from `prov.model.namespaces` in the test only and note it in the PR body.
+
+- [ ] **Step 3: Implement**
+
+In `NamespaceManager.__init__`, after `self._prefix_renamed_map = {}`, add:
+
+```python
+        # String -> resolved QualifiedName. Cleared by every mutation that can
+        # change how a string resolves: add_namespace() and _set_default().
+        self._resolve_cache: dict[str, QualifiedName] = {}
+```
+
+and place the `_resolve_cache` initialisation *before* the `if default is not None:` block (move that block down), so `_set_default()` can clear it.
+
+Replace `set_default_namespace`:
+
+```python
+    def set_default_namespace(self, uri: str) -> None:
+        """Set the default namespace to one with the given URI.
+
+        Args:
+            uri: The URI of the default namespace.
+        """
+        self._set_default(Namespace("", uri))
+
+    def _set_default(self, namespace: Namespace) -> None:
+        self._default = namespace
+        self[""] = namespace
+        self._resolve_cache.clear()
+```
+
+In `_reconcile_qualified_name`, the branch `if self._default is None:` becomes:
+
+```python
+            if self._default is None:
+                # no default namespace is defined, reuse the one given
+                self._set_default(namespace)
+                return qname  # no change, return the original
+```
+
+(This also registers the implicit default under the `""` key, which `set_default_namespace()` already does; the test above pins that.)
+
+In `add_namespace`, immediately before `self._namespaces[prefix] = namespace`, add `self._resolve_cache.clear()`.
+
+In `valid_qualified_name`, replace the body from `# Trying to generate a valid qualified name from here` onward with:
+
+```python
+        # Trying to generate a valid qualified name from here
+        if not isinstance(qname, (str, Identifier)):
+            # Only proceed with a string or URI value
+            return None
+        # Extract the URI string value if it is an identifier
+        str_value = qname.uri if isinstance(qname, Identifier) else qname
+        cached = self._resolve_cache.get(str_value)
+        if cached is not None:
+            return cached
+        resolved = self._resolve_string(str_value, is_plain_str=isinstance(qname, str))
+        if resolved is None and self.parent:
+            # all attempts have failed so far
+            # now delegate this to the parent NamespaceManager
+            resolved = self.parent.valid_qualified_name(qname)
+        if resolved is not None:
+            self._resolve_cache[str_value] = resolved
+        return resolved
+
+    def _resolve_string(self, str_value: str, is_plain_str: bool) -> QualifiedName | None:
+        if str_value.startswith("_:"):
+            # this is a blank node ID
+            return None
+        if ":" in str_value:
+            return self._resolve_prefixed_string(str_value)
+        if self._default and is_plain_str:
+            # no colon in the identifier and a default namespace is defined,
+            # create and return a qualified name in the default namespace
+            return self._default[str_value]
+        return None
+```
+
+The parent-delegation result is cached in the child too. That is safe because the only child mutations that can change the answer, `add_namespace()` and `_set_default()`, both clear the child's cache, and a parent cannot re-bind a prefix it already holds (`add_namespace()` renames the newcomer instead).
+
+- [ ] **Step 4: Run, measure after, changelog**
+
+```bash
+uv run pytest src/prov/tests/test_namespace_cache.py -q
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or deserialize" --benchmark-json=/tmp/after.json -q
+uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json
+```
+
+The compare table's `change` column is negative for an improvement. If `test_construct` improved by less than 20%, profile with `uv run python -X importtime -c ...` is not the tool; use `uv run python -m cProfile -s cumtime -c "from benchmarks.conftest import build_document; build_document(100000)" | head -30` to see whether `valid_qualified_name` still dominates, and report in the PR what was found. Do not widen the change beyond the cache.
+
+Under `### Performance` in `HISTORY.md`:
+
+```markdown
+- `NamespaceManager` caches string-to-`QualifiedName` resolutions per manager, cleared
+  whenever a namespace is added or the default namespace changes, so building or
+  deserialising a document no longer re-resolves the same identifier text for every
+  record that mentions it
+```
+
+- [ ] **Step 5: Commit and PR with numbers**
+
+```bash
+codacy-analysis analyze --files src/prov/model/namespaces.py src/prov/tests/test_namespace_cache.py HISTORY.md
+git add src/prov/model/namespaces.py src/prov/tests/test_namespace_cache.py HISTORY.md
+git commit -m "perf: cache qualified-name resolution per namespace manager"
+git push -u origin perf/resolve-cache
+gh pr create --title "Cache qualified-name resolution in NamespaceManager" --body "$(printf 'Adds a per-manager cache of string-to-QualifiedName resolutions to NamespaceManager.valid_qualified_name(), cleared whenever a namespace is added or the default namespace changes. The two places that set the default now go through one private method so the cache has a single invalidation point.\n\nBenchmarks at N=100000 (M2 Max, Python 3.12):\n\n%s\n\nNo public API change; equality and hash semantics unchanged.' "$(uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json)")"
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+After the merge, refresh `benchmarks/baseline.json` from a `workflow_dispatch` run on `main` as `benchmarks/README.md` describes, in a one-line follow-up commit on a branch (`bench: refresh baseline after the resolve cache`) merged the same way.
+
+```json:metadata
+{"files": ["src/prov/model/namespaces.py", "src/prov/tests/test_namespace_cache.py", "HISTORY.md", "benchmarks/baseline.json"], "verifyCommand": "uv run pytest src/prov/tests/test_namespace_cache.py src/prov/tests/test_model.py src/prov/tests/test_qnames.py -q", "acceptanceCriteria": ["Repeat lookups cached", "add_namespace and default change invalidate", "Child/parent invalidation correct", "_default assigned only in _set_default", "construct mean improves >=20% at N=100000, numbers in PR", "Suite green, no API change"], "modelTier": "standard", "requireEvidenceTokens": [["before", "baseline"], ["after", "current"]]}
+```
+
+---
+
+### Task 12: Precomputed hash and `__slots__` on the identifier and literal classes
+
+**Goal:** `QualifiedName` and `Identifier` compute their hash once at construction, and `Identifier`, `QualifiedName`, `Namespace` and `Literal` declare `__slots__`, cutting per-record memory and hashing cost with no change to equality or public attributes.
+
+**Files:**
+- Modify: `src/prov/identifier.py:18-60, 100-102, 122-140, 202-204`
+- Modify: `src/prov/model/records.py:385-420` (`Literal`)
+- Create: `src/prov/tests/test_identifier_slots.py`
+- Modify: `HISTORY.md` (Performance subsection)
+
+**Acceptance Criteria:**
+- [ ] `QualifiedName.__hash__` returns a stored value; `hash(q) == hash(q.uri)` still holds (hash equality with plain `Identifier` of the same URI is unchanged from today: check `Identifier.__hash__` uses `(uri, cls)` and keep that)
+- [ ] `Identifier`, `QualifiedName`, `Namespace`, `Literal` have `__slots__` and no `__dict__`; setting an undeclared attribute raises `AttributeError`
+- [ ] `copy.copy`, `copy.deepcopy` and `pickle` round-trip each of the four classes with equality preserved
+- [ ] `benchmarks/test_bench.py::test_construct` and `test_equality` means improve; memory per record measured with `tracemalloc` on `build_document(100000)` drops; both stated in the PR body
+- [ ] Full suite green
+
+**Verify:** `uv run pytest src/prov/tests/test_identifier_slots.py src/prov/tests/test_identifier.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Measure before**
+
+```bash
+git checkout main && git pull --ff-only
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or equality or unified" --benchmark-json=/tmp/before.json -q
+uv run python - <<'PY'
+import tracemalloc
+from benchmarks.conftest import build_document
+tracemalloc.start()
+build_document(100000)
+current, peak = tracemalloc.get_traced_memory()
+print(f"traced {current/1e6:.0f} MB, peak {peak/1e6:.0f} MB")
+PY
+git checkout -b perf/slots-hash
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`src/prov/tests/test_identifier_slots.py`:
+
+```python
+"""__slots__ and precomputed hashes on Identifier, QualifiedName, Namespace
+and Literal: no __dict__, unchanged equality, copy and pickle intact."""
+
+import copy
+import pickle
+
+import pytest
+
+from prov.constants import XSD_INT
+from prov.identifier import Identifier, Namespace, QualifiedName
+from prov.model import Literal
+
+NS = Namespace("ex", "http://example.org/")
+OBJECTS = [
+    Identifier("http://example.org/id"),
+    NS,
+    NS["e1"],
+    Literal("1", XSD_INT),
+    Literal("un lieu", langtag="fr"),
+]
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_no_instance_dict(obj):
+    assert not hasattr(obj, "__dict__")
+    with pytest.raises(AttributeError):
+        obj.undeclared = 1
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_copy_and_pickle_preserve_equality(obj):
+    assert copy.copy(obj) == obj
+    assert copy.deepcopy(obj) == obj
+    assert pickle.loads(pickle.dumps(obj)) == obj
+
+
+def test_qualified_name_hash_is_stored_and_uri_based():
+    qname = NS["e1"]
+    assert hash(qname) == hash(qname.uri)
+    assert qname._hash == hash(qname)
+
+
+def test_identifier_hash_unchanged():
+    ident = Identifier("http://example.org/e1")
+    assert hash(ident) == hash((ident.uri, Identifier))
+    assert hash(ident) != hash(NS["e1"])  # class-distinguished, as before
+
+
+def test_namespace_cache_still_interns_qualified_names():
+    assert NS["e1"] is NS["e1"]
+```
+
+- [ ] **Step 3: Implement**
+
+In `src/prov/identifier.py`:
+
+```python
+class Identifier:
+    """Base class for all identifiers and also represents xsd:anyURI."""
+
+    __slots__ = ("_hash", "_uri")
+
+    def __init__(self, uri: str):
+        self._uri: str = str(uri)  # Ensure this is a unicode string
+        self._hash = hash((self._uri, self.__class__))
+```
+
+with `__hash__` returning `self._hash`. Keep the docstring. In `QualifiedName`:
+
+```python
+    __slots__ = ("_localpart", "_namespace", "_str")
+
+    def __init__(self, namespace: Namespace, localpart: str):
+        Identifier.__init__(self, "".join([namespace.uri, localpart]))
+        self._namespace = namespace
+        self._localpart = localpart
+        self._str = (
+            ":".join([namespace.prefix, localpart]) if namespace.prefix else localpart
+        )
+        self._hash = hash(self._uri)
+```
+
+with `__hash__` returning `self._hash` (URI-based, as today). In `Namespace`, add `__slots__ = ("_cache", "_prefix", "_uri")`. In `Literal` (`records.py`), add `__slots__ = ("_datatype", "_langtag", "_value")` directly under the class docstring.
+
+Pickling a slotted class without `__dict__` works through the default protocol 2+ reduction, which copies slots; the tests above prove it. If `copy.copy` fails for `Namespace` because `_cache` holds `QualifiedName`s that reference the namespace, that is a shallow copy sharing the cache, which is fine and is what happens today.
+
+- [ ] **Step 4: Check for external attribute setting**
+
+```bash
+grep -rn "\._uri = \|\._hash = \|\._namespace = \|\._localpart = \|\._str = \|\._prefix = \|\._cache = \|\._value = \|\._datatype = \|\._langtag = " src/prov --include='*.py' | grep -v "identifier.py\|records.py:3[89][0-9]\|records.py:4[0-3][0-9]"
+```
+
+Expected: no output. Any hit is code that sets one of these attributes from outside the class and must be reviewed: it keeps working if the name is in `__slots__`, and breaks otherwise.
+
+- [ ] **Step 5: Run, measure after, changelog, PR**
+
+```bash
+uv run pytest src/prov/tests/test_identifier_slots.py src/prov/tests/test_identifier.py -q
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or equality or unified" --benchmark-json=/tmp/after.json -q
+uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json
+```
+
+Re-run the `tracemalloc` snippet from step 1 for the after number. Under `### Performance` in `HISTORY.md`:
+
+```markdown
+- `Identifier`, `QualifiedName`, `Namespace` and `Literal` declare `__slots__` and
+  `QualifiedName` stores its hash at construction, cutting memory per record and the
+  cost of the many hash lookups a record's attributes require
+```
+
+```bash
+codacy-analysis analyze --files src/prov/identifier.py src/prov/model/records.py src/prov/tests/test_identifier_slots.py HISTORY.md
+git add src/prov/identifier.py src/prov/model/records.py src/prov/tests/test_identifier_slots.py HISTORY.md
+git commit -m "perf: precompute identifier hashes and add __slots__ to the value classes"
+git push -u origin perf/slots-hash
+gh pr create --title "Precomputed hashes and __slots__ on identifier and literal classes" --body "$(printf 'QualifiedName and Identifier compute their hash once at construction, and Identifier, QualifiedName, Namespace and Literal declare __slots__. Equality, hashing semantics and every public attribute are unchanged; copy, deepcopy and pickle are covered by tests.\n\nBenchmarks at N=100000 (M2 Max, Python 3.12):\n\n%s\n\nTraced heap after build_document(100000): before %s, after %s.' "$(uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json)" "<fill in>" "<fill in>")"
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+Replace the two `<fill in>` placeholders with the measured figures before running the command. Refresh the baseline afterwards as in Task 11.
+
+```json:metadata
+{"files": ["src/prov/identifier.py", "src/prov/model/records.py", "src/prov/tests/test_identifier_slots.py", "HISTORY.md"], "verifyCommand": "uv run pytest src/prov/tests/test_identifier_slots.py src/prov/tests/test_identifier.py -q", "acceptanceCriteria": ["Stored hashes, unchanged hash semantics", "__slots__ on four classes, no __dict__", "copy/deepcopy/pickle round-trip", "construct and equality improve; memory drops; numbers in PR", "Suite green"], "modelTier": "standard", "requireEvidenceTokens": [["before", "baseline"], ["after", "current"]]}
+```
+
+---
+
+### Task 13: Typed-value fast path in attribute conversion
+
+**Goal:** `ProvRecord._auto_literal_conversion()` returns the common exact types without walking the isinstance ladder, and JSON deserialisation shows the gain.
+
+**Files:**
+- Modify: `src/prov/model/records.py:750-800`
+- Modify: `src/prov/tests/test_attribute_merging.py` or `test_literal_semantics.py` (one regression test)
+- Modify: `HISTORY.md` (Performance subsection)
+
+**Acceptance Criteria:**
+- [ ] For a value whose exact type is `str`, `int`, `float`, `datetime.datetime`, `bool` or `QualifiedName`, `_auto_literal_conversion` takes the fast branch; `bool` still stays `bool`, subclasses of these types still take the general path
+- [ ] `benchmarks/test_bench.py::test_deserialize[json]` and `test_construct` means improve; the PR body states before and after
+- [ ] The Hypothesis property test and the shared attribute suite pass for every format
+- [ ] Full suite green
+
+**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_attributes.py src/prov/tests/test_literal_semantics.py src/prov/tests/test_property_roundtrip.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Measure before**
+
+```bash
+git checkout main && git pull --ff-only
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or deserialize" --benchmark-json=/tmp/before.json -q
+git checkout -b perf/literal-fast-path
+```
+
+- [ ] **Step 2: Write the regression test**
+
+Append to `src/prov/tests/test_literal_semantics.py`:
+
+```python
+def test_exact_type_fast_path_preserves_values_and_subclass_handling():
+    import datetime
+
+    from prov.model import ProvDocument
+
+    class MyStr(str):
+        pass
+
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    when = datetime.datetime(2026, 1, 1)
+    entity = document.entity(
+        "ex:e1",
+        {"ex:s": "s", "ex:i": 1, "ex:f": 1.5, "ex:b": True, "ex:d": when, "ex:sub": MyStr("x")},
+    )
+    values = {str(k): v for k, v in entity.attributes if str(k).startswith("ex:")}
+    assert values["ex:s"] == "s" and type(values["ex:s"]) is str
+    assert values["ex:i"] == 1 and type(values["ex:i"]) is int
+    assert values["ex:f"] == 1.5
+    assert values["ex:b"] is True
+    assert values["ex:d"] == when
+    assert values["ex:sub"] == "x" and type(values["ex:sub"]) is str
+```
+
+The last assertion pins today's behaviour for a `str` subclass (`str(literal)` normalises it); confirm on `main` before implementing, and if today it keeps the subclass, change the assertion to match, because this task changes no semantics.
+
+- [ ] **Step 3: Implement**
+
+At the top of `_auto_literal_conversion`, before the `ProvRecord` check:
+
+```python
+    def _auto_literal_conversion(self, literal: Any) -> Any:
+        # This method normalise datatype for literals
+
+        # Exact-type fast path for the values that dominate real documents;
+        # subclasses and Literal fall through to the general handling below.
+        literal_type = type(literal)
+        if literal_type is str or literal_type in _PASSTHROUGH_TYPES:
+            return literal
+        if literal_type is QualifiedName:
+            return self._bundle.valid_qualified_name(literal)
+```
+
+with, at module level near the other constants:
+
+```python
+# Values _auto_literal_conversion() returns unchanged when their exact type
+# matches; bool is listed so it is not treated as an int subclass.
+_PASSTHROUGH_TYPES = frozenset({int, float, bool, datetime.datetime})
+```
+
+Leave the rest of the method as it is; the general path still handles subclasses, `Literal` and everything else.
+
+- [ ] **Step 4: Run, measure after, changelog, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_attributes.py src/prov/tests/test_literal_semantics.py src/prov/tests/test_property_roundtrip.py -q
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+PROV_BENCH_N=100000 uv run pytest benchmarks/ -k "construct or deserialize" --benchmark-json=/tmp/after.json -q
+uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json
+```
+
+If neither `construct` nor `deserialize[json]` improves by a measurable margin (more than runner noise, about 3%), do not open the PR and add no changelog line; note "no measurable gain, not merged" against Task 13 in the tasks file and move on. The spec's rule is that an improvement without a number does not merge.
+
+Under `### Performance` in `HISTORY.md`:
+
+```markdown
+- Attribute values whose exact type is `str`, `int`, `float`, `bool`, `datetime` or
+  `QualifiedName` skip the general literal-conversion path
+```
+
+```bash
+codacy-analysis analyze --files src/prov/model/records.py src/prov/tests/test_literal_semantics.py HISTORY.md
+git add src/prov/model/records.py src/prov/tests/test_literal_semantics.py HISTORY.md
+git commit -m "perf: fast path for exact common types in attribute conversion"
+git push -u origin perf/literal-fast-path
+gh pr create --title "Fast path for common value types in attribute conversion" --body "$(printf '_auto_literal_conversion() returns str, int, float, bool, datetime and QualifiedName values by exact type check before the general isinstance ladder. Subclasses and Literal values take the general path as before, so semantics are unchanged.\n\nBenchmarks at N=100000 (M2 Max, Python 3.12):\n\n%s' "$(uv run python benchmarks/compare.py /tmp/before.json /tmp/after.json)")"
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+Refresh the baseline afterwards as in Task 11. This is the last performance PR, so the refreshed baseline is the one the release ships with.
+
+```json:metadata
+{"files": ["src/prov/model/records.py", "src/prov/tests/test_literal_semantics.py", "HISTORY.md"], "verifyCommand": "uv run --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_attributes.py src/prov/tests/test_literal_semantics.py src/prov/tests/test_property_roundtrip.py -q", "acceptanceCriteria": ["Fast branch for exact common types; subclasses take general path", "deserialize[json] and construct improve; numbers in PR or PR not opened", "Property and shared attribute tests pass", "Suite green"], "modelTier": "standard", "requireEvidenceTokens": [["before", "baseline"], ["after", "current"]]}
+```
+
+---
+### Task 14: `prov.dot` unset-endpoint warning and #341 colon local parts through PROV-O
+
+**Goal:** `prov.dot` warns with `ProvWarning` when it draws a relation whose endpoint is unset or drops one with too few endpoints, and the PROV-O decoder resolves attribute keys under a declared namespace even when the local part ends in a metacharacter, closing #341 and lifting the property test's generation exclusion.
+
+**Files:**
+- Modify: `src/prov/dot.py:446-475` (`_add_relation`)
+- Modify: `src/prov/tests/test_dot.py`
+- Modify: `src/prov/serializers/provrdf.py:1533-1595` (`_decode_attribute_triple`)
+- Modify: `src/prov/tests/test_rdf.py`
+- Modify: `src/prov/tests/strategies.py:85-140`
+- Modify: `docs/reference/conformance.md:60-80` (the #341 caveat)
+- Modify: `HISTORY.md` (Fixes subsection)
+
+**Acceptance Criteria:**
+- [ ] `prov_to_dot()` on a document with `generation(entity="ex:e1", activity=None)` emits exactly one `ProvWarning` naming the relation and `prov:activity`, and the output still contains the blank-node edge it drew before
+- [ ] `prov_to_dot()` on a complete document emits no warning
+- [ ] The three failing shapes below round-trip through PROV-O: an attribute key `ex2:k:` and `ex2:k=` in a namespace no identifier uses, and the issue's falsifying document
+- [ ] `strategies.py` no longer restricts attribute-key endings; the property test passes for `rdf` under the `ci` profile and a local default-profile run
+- [ ] The #341 caveat is removed from the conformance page and the issue closes with the merge
+- [ ] Suite counts: new tests added, 26 skipped, xfail unchanged
+
+**Verify:** `uv run --extra rdf --extra dot --extra graph pytest src/prov/tests/test_dot.py src/prov/tests/test_rdf.py src/prov/tests/test_property_roundtrip.py -k "rdf or dot or warning" -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing dot tests**
+
+Append to `src/prov/tests/test_dot.py`:
+
+```python
+def test_unset_endpoint_is_drawn_to_a_blank_node_with_a_warning():
+    from prov.model import ProvWarning
+
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.generation(entity="ex:e1", activity=None)
+    with pytest.warns(ProvWarning, match=r"Generation.*prov:activity") as record:
+        dot = prov_to_dot(document)
+    assert sum(issubclass(w.category, ProvWarning) for w in record) == 1
+    assert len(dot.get_edges()) == 1
+
+
+def test_complete_relation_draws_without_warning():
+    import warnings
+
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.wasGeneratedBy("ex:e1", "ex:a1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        prov_to_dot(document)
+```
+
+- [ ] **Step 2: Warn in `_add_relation`**
+
+In `src/prov/dot.py`, after `inferred_types = list(...)` and before `other_attributes = [...]`, add:
+
+```python
+    unset = [
+        str(attr_name)
+        for attr_name, node in zip(attr_names[:2], nodes[:2], strict=False)
+        if node is None
+    ]
+    if unset:
+        warnings.warn(
+            f"{rec!r} has no value for {', '.join(unset)}; drawing the "
+            "relation to a blank node",
+            ProvWarning,
+            stacklevel=3,
+        )
+```
+
+and change the `if len(nodes) < 2:` branch to warn before returning:
+
+```python
+    if len(nodes) < 2:  # too few elements for a relation?
+        warnings.warn(
+            f"Skipping {rec!r}: it has fewer than two element endpoints",
+            ProvWarning,
+            stacklevel=3,
+        )
+        return
+```
+
+Add `import warnings` and `ProvWarning` to the module imports (`from prov.model import ... ProvWarning`). `stacklevel=3` points at the caller of `prov_to_dot()`, two frames above `_add_relation`; check with the test's `record[0].filename` and adjust if it points inside `prov`.
+
+- [ ] **Step 3: Write the failing RDF tests**
+
+Append to `src/prov/tests/test_rdf.py`:
+
+```python
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda d: d.entity("ex:e0", {"ex2:k:": ""}),
+        lambda d: d.entity("ex:e0", {"ex2:k=": ""}),
+        lambda d: (d.entity("ex:e:0", {"ex:k:": ""}), d.activity("ex:a:0"), d.agent("ex:g'0")),
+    ],
+    ids=["key-colon-unshared-ns", "key-equals-unshared-ns", "issue-341-falsifier"],
+)
+def test_metachar_attribute_keys_round_trip_through_provo(build):
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.add_namespace("ex2", "http://example2.org/")
+    build(document)
+    content = document.serialize(format="rdf")
+    assert ProvDocument.deserialize(content=content, format="rdf") == document
+```
+
+Run: `uv run --extra rdf pytest src/prov/tests/test_rdf.py -k metachar -q`. Expected: the three cases fail with `ProvExceptionInvalidQualifiedName: Invalid Qualified Name: http://example2.org/k:` (or `k=`, or `http://example.org/k:`). The first shape is a namespace only the key uses, so nothing registered it on the decoding document before the key was resolved; the third is the issue's own document, where `ex:e:0` splits wrongly in rdflib and so never registers `ex` cleanly either.
+
+- [ ] **Step 4: Resolve keys through `_resolve_iri`**
+
+In `_decode_attribute_triple`, the `else` branch that appends to `other_attributes` currently stores the key as `str(pred_new)` and leaves resolution to `ProvRecord.add_attributes()`, which only knows namespaces already registered on the document. Resolve it here instead, where the graph's own bindings are available:
+
+```python
+        elif "qualified" not in str(pred_new) and "asInBundle" not in str(pred_new):
+            key: Any = pred_new
+            if isinstance(pred_new, URIRef):
+                # Resolve against the graph's bindings so a key under a
+                # namespace no identifier has registered yet still splits
+                # at the declared namespace, colon or not (#341).
+                key = self.document.valid_qualified_name(str(pred_new)) or self._resolve_iri(
+                    str(pred_new), graph
+                )
+            state.other_attributes.setdefault(subj, []).append((key, obj1))
+```
+
+`_resolve_iri` returns a `QualifiedName`, which `add_attributes()` accepts as a key without re-resolving. If `state.other_attributes` is typed as `list[tuple[str, Any]]`, widen it to `list[tuple[QualifiedNameCandidate, Any]]` in `_DecodeState`. Check whether `pred_new` from `predicate_mapper` can be a `QualifiedName` already (the comment above the branch says it can); the `isinstance(pred_new, URIRef)` guard leaves those untouched.
+
+Run the three tests again. If a case still fails, print `document.get_provn()` and the reloaded document's, and compare namespaces: the fix may need the same treatment for the formal-attribute branch four lines above (`mandatory_valid_qname(pred_new)`), which the same `valid_qualified_name(...) or _resolve_iri(...)` expression fixes.
+
+- [ ] **Step 5: Lift the generation exclusion**
+
+In `src/prov/tests/strategies.py`, delete the `_KEY_SAFE_ENDING` constant, the long comment above it, and the `attribute_key_part = st.builds(...)` definition, and make attribute keys draw from `local_part` like identifiers do (find the consumer of `attribute_key_part` and point it at `local_part`). Run:
+
+```bash
+HYPOTHESIS_PROFILE=ci uv run --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_property_roundtrip.py -q
+uv run --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_property_roundtrip.py -q
+```
+
+Both must pass. If Hypothesis finds a new falsifying document, it is a real decode defect of the same family; fix it in `_decode_attribute_triple` or `_resolve_iri`, never by restoring the exclusion.
+
+- [ ] **Step 6: Conformance page and changelog**
+
+In `docs/reference/conformance.md`, delete the #341 caveat paragraph(s) around line 72 (the ones that describe the attribute-key limitation and say it "remains open for a fix"). If the page's PROV-O section elsewhere lists #341 as a limitation, remove that mention too.
+
+Under `### Fixes` in `HISTORY.md`:
+
+```markdown
+- `prov.dot` warns with `ProvWarning` when a relation's endpoint is unset (it is drawn to a
+  blank node, as before) or when a relation has too few endpoints to draw, instead of
+  staying silent, matching what `prov_to_graph()` does since 3.1.1
+- PROV-O decoding resolves attribute keys against the namespaces declared in the RDF
+  source, so a key whose local part ends in a PROV-N metacharacter (`= ' , : ; [ ]`) under
+  a namespace no identifier uses now reads back; the last generation-time exclusion in the
+  round-trip property test is lifted
+  ([#341](https://github.com/trungdong/prov/issues/341))
+```
+
+- [ ] **Step 7: Gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra dot --extra graph pytest src/prov/tests/test_dot.py src/prov/tests/test_rdf.py -q
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+uv run mypy src && uv run ruff check src/ && uv run ruff format src/
+codacy-analysis analyze --files src/prov/dot.py src/prov/serializers/provrdf.py src/prov/tests/test_dot.py src/prov/tests/test_rdf.py src/prov/tests/strategies.py docs/reference/conformance.md HISTORY.md
+git add src/prov/dot.py src/prov/serializers/provrdf.py src/prov/tests/test_dot.py src/prov/tests/test_rdf.py src/prov/tests/strategies.py docs/reference/conformance.md HISTORY.md
+git commit -m "fix: warn on unset prov.dot endpoints and resolve metachar attribute keys from PROV-O"
+git push -u origin fix/dot-warning-provo-colon
+gh pr create --title "prov.dot endpoint warning and PROV-O attribute keys with metacharacters" --body "Two follow-ups from 3.1.1. prov.dot now warns with ProvWarning when it draws a relation whose endpoint is unset (the blank-node rendering is unchanged) or skips one with too few endpoints, matching prov_to_graph(). The PROV-O decoder resolves extra attribute keys through the same graph-binding-aware resolver identifiers already use, so a key whose local part ends in a PROV-N metacharacter under a namespace no identifier has registered yet reads back; the last generation-time exclusion in the Hypothesis round-trip test is lifted and the conformance page's caveat removed. Closes #341 and #<dot issue from Task 0>."
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+```json:metadata
+{"files": ["src/prov/dot.py", "src/prov/serializers/provrdf.py", "src/prov/tests/test_dot.py", "src/prov/tests/test_rdf.py", "src/prov/tests/strategies.py", "docs/reference/conformance.md", "HISTORY.md"], "verifyCommand": "uv run --extra rdf --extra dot --extra graph pytest src/prov/tests/test_dot.py src/prov/tests/test_rdf.py src/prov/tests/test_property_roundtrip.py -q", "acceptanceCriteria": ["prov.dot warns once on unset endpoint; rendering unchanged", "No warning on complete document", "Three metachar key shapes round-trip through PROV-O", "Generation exclusion lifted; property test passes", "Conformance caveat removed; #341 closed"], "modelTier": "standard"}
+```
+
+---
+
+### Task 15: `test_citation` skip guard and pre-commit whitespace
+
+**Goal:** The citation test module skips cleanly from an installed wheel because its guard covers every file it reads, and `pre-commit run --all-files` passes on a clean tree.
+
+**Files:**
+- Modify: `src/prov/tests/test_citation.py:19-21`
+- Modify: `.codacy/codacy.config.json` (add the final newline)
+- Modify: `.pre-commit-config.yaml:12-14` (exclude `src/prov/tests/schemas/`)
+- Modify: `HISTORY.md` (Project subsection)
+
+**Acceptance Criteria:**
+- [ ] `pytestmark` in `test_citation.py` skips unless both `CITATION.cff` and `.zenodo.json` exist
+- [ ] `uv run pre-commit run --all-files` exits 0 on a clean checkout
+- [ ] The four vendored `.xsd` schemas are byte-identical to before (excluded, not edited)
+
+**Verify:** `uv run pre-commit run --all-files` → every hook `Passed`; `git status --short src/prov/tests/schemas` → empty.
+
+**Steps:**
+
+- [ ] **Step 1: Guard**
+
+In `src/prov/tests/test_citation.py`:
+
+```python
+pytestmark = pytest.mark.skipif(
+    not (CITATION_FILE.is_file() and ZENODO_FILE.is_file()),
+    reason="CITATION.cff and .zenodo.json only exist in a source checkout",
+)
+```
+
+- [ ] **Step 2: Whitespace**
+
+```bash
+printf '\n' >> .codacy/codacy.config.json   # only if the file lacks a final newline: tail -c1 .codacy/codacy.config.json | od -c
+```
+
+In `.pre-commit-config.yaml`, both `exclude` patterns become `^src/prov/tests/(json|rdf|xml|unification|jsonld|provn|schemas)/` (Task 8 already added `provn`; add `schemas`). The schemas are W3C text vendored for validation and are not edited.
+
+```bash
+uv run pre-commit run --all-files
+git status --short   # only the three intended files
+```
+
+- [ ] **Step 3: Changelog, commit, PR**
+
+Under `### Project` in `HISTORY.md`:
+
+```markdown
+- `pre-commit run --all-files` passes on a clean checkout: the vendored W3C schemas are
+  excluded from the whitespace hooks and the Codacy configuration file ends with a newline
+- The citation tests skip from an installed wheel when either repository metadata file is
+  absent
+```
+
+```bash
+codacy-analysis analyze --files src/prov/tests/test_citation.py .pre-commit-config.yaml .codacy/codacy.config.json HISTORY.md
+git add src/prov/tests/test_citation.py .pre-commit-config.yaml .codacy/codacy.config.json HISTORY.md
+git commit -m "chore: make pre-commit pass on a clean tree and widen the citation skip guard"
+git push -u origin chore/citation-guard-precommit
+gh pr create --fill
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+```
+
+```json:metadata
+{"files": ["src/prov/tests/test_citation.py", ".codacy/codacy.config.json", ".pre-commit-config.yaml", "HISTORY.md"], "verifyCommand": "uv run pre-commit run --all-files", "acceptanceCriteria": ["Guard covers both files", "pre-commit passes on clean tree", "Schemas unchanged"], "modelTier": "mechanical"}
+```
+
+---
+
+### Task 16: `/simplify` round over the release
+
+**Goal:** Every file this release touched has been through a `simplify` pass on a `release/3.2.0` branch, and the resulting cleanups are committed with the suite green, so the whole-release review reads the final code.
+
+**Files:**
+- Modify: any file changed since `main` @ 112fb91, as the pass finds (`git diff --name-only 112fb91..main`)
+
+**Acceptance Criteria:**
+- [ ] The coordinator invoked the `simplify` skill on the diff `112fb91..HEAD` of the `release/3.2.0` branch
+- [ ] Every applied cleanup keeps the full suite, mypy, ruff and the benchmarks' compare step green; behaviour-changing suggestions are rejected and noted in the commit body
+- [ ] Cleanups are committed as `refactor: simplify after the 3.2.0 changes` on `release/3.2.0`
+
+**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2` unchanged counts from the end of Task 15; `uv run mypy src && uv run ruff check src/ benchmarks/`.
+
+**Steps:**
+
+- [ ] **Step 1: Branch (coordinator, main session)**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b release/3.2.0
+```
+
+- [ ] **Step 2: Run the pass**
+
+Invoke the `simplify` skill with the argument `112fb91..HEAD`. Apply reuse, simplification and altitude cleanups it proposes across the parser modules, benchmarks, `namespaces.py`, `identifier.py`, `records.py`, `dot.py`, `provrdf.py` and the new test modules. Reject anything that changes behaviour, the public API, or the token and error semantics the tests pin.
+
+- [ ] **Step 3: Gates and commit**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2
+uv run mypy src && uv run ruff check src/ benchmarks/ && uv run ruff format src/ benchmarks/
+uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q && uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json
+git add -A && git commit -m "refactor: simplify after the 3.2.0 changes"
+```
+
+```json:metadata
+{"files": [], "verifyCommand": "uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -2", "acceptanceCriteria": ["simplify skill run on 112fb91..HEAD", "Suite, mypy, ruff, benchmark compare green after cleanups", "Committed on release/3.2.0"], "modelTier": "frontier", "coordinatorRun": true}
+```
+
+---
+
+### Task 17: Documentation
+
+**Goal:** Every shipped page that describes PROV-N as write-only says it is two-way, the how-to teaches reading with profiles and errors, the conformance page treats PROV-N as a round-trip format, the packaging metadata names the feature, and the What's new and architecture pages describe 3.2.0.
+
+**Files:**
+- Modify: `docs/howto/provn.md` (rewrite)
+- Modify: `docs/reference/conformance.md:14-30` and the `<!-- 3.2.0: corpus exceptions -->` marker from Task 8
+- Modify: `docs/reference/serializers.md` (one sentence plus autodoc of the error type)
+- Modify: `docs/whats-new-3.md:36-75`
+- Modify: `docs/explanation/architecture.md:44-52, 71-80`
+- Modify: `README.md:18-27`
+- Modify: `pyproject.toml:3-9` (`description`, `keywords`)
+- Modify: `src/prov/serializers/__init__.py` (docstrings that say PROV-N is write-only, if any)
+- Modify: `HISTORY.md` (Documentation subsection)
+
+**Acceptance Criteria:**
+- [ ] `grep -rn "write-only\|NotImplementedError" docs/ README.md src/prov --include='*.md' --include='*.py' | grep -i "prov-n\|provn"` returns nothing
+- [ ] `docs/howto/provn.md` has sections: reading a file, reading a string, `prov.read()` auto-detection, profiles with one example each, handling `ProvNSyntaxError` with its line and column, strict output, `prov-convert` with `-i provn`, and keeps the existing writing sections
+- [ ] The conformance page's intro describes PROV-N as a round-trip format with strict and default profiles, keeps the keyword column, and lists the corpus exceptions from Task 8 by name
+- [ ] `uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html -W` succeeds
+- [ ] `README.md` feature list and `pyproject.toml` description say PROV-N is read and written
+
+**Verify:** the grep above is empty and the Sphinx build passes with `-W`.
+
+**Steps:**
+
+- [ ] **Step 1: Rewrite the how-to**
+
+Replace `docs/howto/provn.md` with:
+
+````markdown
+# Work with PROV-N
+
+`prov` reads and writes [PROV-N](https://www.w3.org/TR/prov-n/), the W3C notation for
+PROV. Neither direction needs an extra.
+
+## Get the PROV-N text directly
+
+{py:meth}`~prov.model.ProvBundle.get_provn` returns the notation as a string. This is the
+simplest way to print or inspect a document:
+
+```python
+import prov.model as pm
+
+document = pm.ProvDocument()
+document.set_default_namespace("http://example.org/")
+e = document.entity("e1")
+a = document.activity("a1")
+document.wasGeneratedBy(e, a)
+
+print(document.get_provn())
+```
+
+## Serialize to a file
+
+`format="provn"` goes through the same {py:meth}`~prov.model.ProvDocument.serialize` API
+as the other formats, for tooling that dispatches on `format`:
+
+```python
+document.serialize("document.provn", format="provn")
+```
+
+## Serialize to a string
+
+```python
+provn_str = document.serialize(format="provn")
+assert provn_str == document.get_provn()
+```
+
+## Read a file or a string
+
+{py:meth}`~prov.model.ProvDocument.deserialize` with `format="provn"` parses PROV-N text:
+
+```python
+document = pm.ProvDocument.deserialize("document.provn", format="provn")
+document = pm.ProvDocument.deserialize(content=provn_str, format="provn")
+```
+
+{py:func}`prov.read` detects PROV-N without a `format` argument, because a PROV-N
+document starts with the `document` keyword:
+
+```python
+import prov
+
+document = prov.read("document.provn")
+```
+
+## Choose a parsing profile
+
+The parser accepts three dialects, selected with `profile`:
+
+| Profile | Accepts |
+| --- | --- |
+| `strict` | The W3C grammar only. Mention is written `prov:mentionOf`, as in the PROV-Links note. |
+| `default` | The grammar plus what `prov` and ProvToolbox write: the bare `mentionOf` keyword, and the shorthand keywords `person`, `organization`, `softwareAgent`, `collection`, `emptyCollection`, `plan`, `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource`, each read as the base record with the matching `prov:type`. |
+| `lenient` | As `default`. A statement that fails to parse is skipped with a {py:class}`~prov.model.ProvWarning` naming its line and column, and parsing resumes at the next statement. |
+
+```python
+document = pm.ProvDocument.deserialize("document.provn", format="provn", profile="strict")
+```
+
+Use `strict` to check that a document conforms to the Recommendation, `default` for
+files other tools wrote, and `lenient` to salvage what a damaged file still holds. The
+lenient profile recovers from parse errors only; an unterminated string or IRI still raises.
+
+## Handle syntax errors
+
+A syntax error raises {py:class}`~prov.serializers.provn.ProvNSyntaxError`, which carries
+the line, the column and what the parser expected:
+
+```python
+from prov.serializers.provn import ProvNSyntaxError
+
+try:
+    pm.ProvDocument.deserialize(content="document\n  entity(ex:e1)\nendDocument", format="provn")
+except ProvNSyntaxError as error:
+    print(error.line, error.column, error.message)
+    # 2 10 cannot resolve 'ex:e1': prefix 'ex' is not declared
+```
+
+With {py:func}`prov.read` and no `format`, a PROV-N error is swallowed like any other
+candidate format's error; pass `format="provn"` to see it.
+
+## Write strictly conformant output
+
+`get_provn()` and `serialize(format="provn")` write the bare `mentionOf` keyword by
+default, which ProvToolbox reads. Pass `strict=True` to write `prov:mentionOf` instead, so
+the output parses under the `strict` profile:
+
+```python
+document.serialize("document.provn", format="provn", strict=True)
+```
+
+## Convert on the command line
+
+`prov-convert` reads PROV-N with `-i provn`:
+
+```bash
+prov-convert -i provn -f json document.provn document.json
+```
+
+See {doc}`cli`.
+
+## Attribute order is stable
+
+A record stores its attribute values in the order they were added, and every format
+writes them in that order. Two runs of the same program produce the same text, so PROV-N
+output is safe to use in doctests and golden files:
+
+```python
+document.entity("e2", [(pm.PROV_TYPE, "foo"), (pm.PROV_TYPE, "bar")])
+print(document.get_provn())
+# entity(e2, [prov:type="foo", prov:type="bar"])
+```
+````
+
+Run the error example and paste the real output over the `# 2 10 ...` comment; the column depends on the exact message the parser produces.
+
+- [ ] **Step 2: Conformance page**
+
+Replace the PROV-N bullet in the intro (the one beginning "**PROV-N** is output only") with:
+
+```markdown
+- **PROV-N** round-trips every row: `deserialize(serialize(doc, format="provn"),
+  format="provn") == doc` for every shared test case, under the `default` profile. The
+  column shows the keyword `get_provn()` emits. Mention is the one keyword that differs
+  between profiles: the writer emits `mentionOf` by default and `prov:mentionOf` with
+  `strict=True`, and the `strict` profile reads only the latter. The
+  [conformance corpus](https://github.com/trungdong/prov/tree/main/src/prov/tests/provn)
+  additionally parses every example of the PROV-N and PROV-DM Recommendations and the
+  PROV-N that ProvToolbox writes for the shared test corpus; the differences it found are
+  listed under "PROV-N corpus" below.
+```
+
+Add a `### PROV-N corpus` subsection under "Caveats that span several rows" containing one line per `KNOWN_DIFFERENCES` entry from Task 8 (name, what ProvToolbox writes, what `prov` writes), replacing the `<!-- 3.2.0: corpus exceptions -->` marker. If the dict is empty, the subsection says so in one sentence.
+
+- [ ] **Step 3: Serializers reference, What's new, architecture**
+
+In `docs/reference/serializers.md`, after the `prov.read` autodoc block, add:
+
+````markdown
+## PROV-N errors
+
+```{eval-rst}
+.. autoclass:: prov.serializers.provn.ProvNSyntaxError
+   :members:
+   :show-inheritance:
+```
+````
+
+In `docs/whats-new-3.md`, after the PROV-JSONLD section, add:
+
+```markdown
+## Two-way PROV-N
+
+3.2.0 added a PROV-N parser, so the notation `prov` has always written can now be read:
+`format="provn"` in `deserialize()`, auto-detected by `prov.read()`, and accepted by
+`prov-convert -i provn`. The parser is hand-written and needs no extra. Three profiles
+select how much beyond the W3C grammar it accepts; the default reads what `prov` and
+ProvToolbox write. PROV-N joins the shared round-trip test matrix, and a conformance corpus
+checks every example of the PROV-N and PROV-DM Recommendations. See {doc}`howto/provn`.
+
+3.2.0 also ships a benchmark suite with a non-blocking regression check in CI, and the
+first measured speed-ups from it: namespace resolution is cached per document, identifier
+and literal objects are slimmer, and common attribute values skip the general conversion
+path.
+```
+
+and change the "What comes next" paragraph to: "Next is 3.3.0, which raises the Python floor to 3.11 under the support policy, Python 3.10 having reached end of life on 2026-10-31."
+
+In `docs/explanation/architecture.md`, in "Serializers and format detection", replace "PROV-N is write-only, and its deserializer raises `NotImplementedError`." with:
+
+```markdown
+PROV-N is read by a two-module parser in `prov.serializers.provn_lexer` (a tokeniser with
+line and column tracking) and `prov.serializers.provn_parser` (a recursive-descent parser,
+one function per grammar production, building records through `ProvBundle.new_record()`
+like the PROV-JSON deserializer). Three profiles, `strict`, `default` and `lenient`, decide
+how much beyond the W3C grammar the parser accepts.
+```
+
+In "Tests", change "the four round-trippable formats, PROV-JSON, PROV-XML, PROV-O and PROV-JSONLD. PROV-N is excluded because it is write-only." to "the five round-trippable formats, PROV-JSON, PROV-XML, PROV-O, PROV-JSONLD and PROV-N." and "through those same four formats" to "through those same five formats". Add one sentence at the end of the section: "A top-level `benchmarks/` directory, outside the package, holds a pytest-benchmark suite with a committed baseline that a non-blocking CI job compares against."
+
+- [ ] **Step 4: README and packaging metadata**
+
+In `README.md`, change the first two feature bullets to:
+
+```markdown
+- In-memory classes for every PROV-DM record type, readable from and printable as
+  [PROV-N](https://www.w3.org/TR/prov-n/).
+```
+
+and make sure the serialization bullet lists PROV-N among the formats read and written. In `pyproject.toml`, `description` becomes `"A library for W3C Provenance Data Model supporting PROV-N, PROV-JSON, PROV-XML, PROV-O (RDF) and PROV-JSONLD"`.
+
+Grep for leftovers and build the docs:
+
+```bash
+grep -rn "write-only\|NotImplementedError" docs/ README.md src/prov --include='*.md' --include='*.py' | grep -i "prov-n\|provn"
+uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html -W
+```
+
+- [ ] **Step 5: Changelog, commit**
+
+Under `### Documentation` in `HISTORY.md`:
+
+```markdown
+- The PROV-N how-to covers reading, the three profiles, syntax errors and strict output;
+  the conformance page treats PROV-N as a round-trip format and lists the corpus findings;
+  the What's new page describes 3.2.0
+```
+
+```bash
+codacy-analysis analyze --files docs/howto/provn.md docs/reference/conformance.md docs/reference/serializers.md docs/whats-new-3.md docs/explanation/architecture.md README.md pyproject.toml HISTORY.md
+git add docs README.md pyproject.toml src/prov/serializers/__init__.py HISTORY.md
+git commit -m "docs: document two-way PROV-N, profiles and the benchmark suite"
+```
+
+```json:metadata
+{"files": ["docs/howto/provn.md", "docs/reference/conformance.md", "docs/reference/serializers.md", "docs/whats-new-3.md", "docs/explanation/architecture.md", "README.md", "pyproject.toml", "HISTORY.md"], "verifyCommand": "uv run --group docs --extra rdf --extra xml --extra dot --extra graph sphinx-build -b html docs docs/_build/html -W", "acceptanceCriteria": ["No write-only or NotImplementedError mentions for PROV-N remain", "How-to has all listed sections", "Conformance intro and corpus subsection updated", "Sphinx builds with -W", "README and pyproject description updated"], "modelTier": "standard"}
+```
+
+---
+
+### Task 18: Stamp the release
+
+**Goal:** The five release files carry 3.2.0 and today's date, the changelog heading is dated and its subsections are complete, the conformance page's revision sentence is updated, and the release PR is open with green CI.
+
+**Files:**
+- Modify: `src/prov/__init__.py:14`
+- Modify: `HISTORY.md:3`
+- Modify: `ROADMAP.md` (3.2.0 row)
+- Modify: `docs/reference/conformance.md:4-6`
+- Modify: `CITATION.cff`
+
+**Acceptance Criteria:**
+- [ ] `prov.__version__ == "3.2.0"`; `CITATION.cff` agrees; `test_citation` passes
+- [ ] `HISTORY.md` heading is `## 3.2.0 (YYYY-MM-DD)`; no subsection is empty (delete an empty one rather than leave it)
+- [ ] `ROADMAP.md` row reads `**3.2.0** *(released YYYY-MM-DD)*` with the highlights matching what shipped
+- [ ] The conformance page's "last revision" sentence names 3.2.0 and the date
+- [ ] `uv build` succeeds and the wheel contains `py.typed` and the JSON-LD context; `docs/releasing.md` section 1 pre-flight all green, including the benchmark compare
+- [ ] Release PR open from `release/3.2.0` with CI green
+
+**Verify:** `uv run pytest src/prov/tests/test_citation.py -q` passes; `gh pr checks --watch` green.
+
+**Steps:**
+
+- [ ] **Step 1: Pre-flight per `docs/releasing.md` section 1**
+
+```bash
+for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest -q || break; done
+uv run --python 3.13 --extra rdf --extra xml --extra dot --extra graph mypy src
+uv run ruff check src/ benchmarks/ && uv run ruff format --check src/ benchmarks/
+uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q && uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json
+uv build && unzip -l dist/prov-*.whl | grep -E "py.typed|prov-jsonld-context"
+```
+
+Compare the suite's counts against the number at the end of Task 15 and explain every difference in the PR body.
+
+- [ ] **Step 2: Stamp**
+
+Set `__version__ = "3.2.0"` in `src/prov/__init__.py`; `version: "3.2.0"` in `CITATION.cff` (and its `date-released` if present); date the `HISTORY.md` heading; stamp the `ROADMAP.md` row and re-read its highlights against the changelog; update the conformance page's revision sentence. Delete any empty `HISTORY.md` subsection.
+
+- [ ] **Step 3: Release PR**
+
+```bash
+git add -A && git commit -m "release: 3.2.0"
+git push -u origin release/3.2.0
+gh pr create --title "Release 3.2.0" --body "Stamps 3.2.0: version, changelog date, roadmap row, conformance revision and citation metadata, on top of the simplify pass and the documentation for two-way PROV-N. Suite: <counts> against <previous counts>; every difference is explained by the release's own tests. Benchmarks compared against the committed baseline: OK."
+gh pr checks --watch
+```
+
+Do not merge. Task 19 reviews the whole release first.
+
+```json:metadata
+{"files": ["src/prov/__init__.py", "HISTORY.md", "ROADMAP.md", "docs/reference/conformance.md", "CITATION.cff"], "verifyCommand": "uv run pytest src/prov/tests/test_citation.py -q", "acceptanceCriteria": ["Version and citation agree", "Changelog dated and complete", "Roadmap stamped", "Conformance revision sentence updated", "Pre-flight green including benchmarks and build", "Release PR open, CI green"], "modelTier": "mechanical"}
+```
+
+---
+
+### Task 19: Whole-release review, publish, close out
+
+**Goal:** The release branch passes a whole-release review with findings fixed, is merged, published to PyPI through the GitHub release, and followed up on conda-forge, the milestone and the announcement.
+
+**Files:**
+- Modify: as the review requires, on `release/3.2.0`
+
+**Acceptance Criteria:**
+- [ ] The coordinator ran a whole-release review (the `code-review` skill at level `high` on the release PR, with the instruction to read the full `112fb91..HEAD` diff, not only the stamp commit) and every confirmed finding is fixed with a test, or dismissed with a reason in the PR
+- [ ] Release PR merged; GitHub release `3.2.0` created from `main` with the `HISTORY.md` entry as its notes; `publish-pypi` job green; `pip install prov==3.2.0` in a clean venv reads and writes PROV-N
+- [ ] Zenodo minted a version DOI under concept DOI 10.5281/zenodo.22696001
+- [ ] conda-forge autotick-bot PR merged per `docs/releasing.md` section 6 (the `workflow`-scope gotcha applies)
+- [ ] Milestone 3.2.0 closed with every issue closed; `ROADMAP.md`'s tracking issue #181 has a comment naming the release
+- [ ] The "Reading PROV-N in Python" post is drafted outside the repo (Task 19 only records that it is next; it is not part of the plan's deliverable)
+
+**Verify:** `pip index versions prov | head -1` shows 3.2.0; `gh release view 3.2.0` exists; `gh api repos/trungdong/prov/milestones --jq '.[] | select(.title=="3.2.0") | .state'` → `closed`.
+
+**Steps:**
+
+- [ ] **Step 1: Whole-release review (coordinator, main session)**
+
+Invoke the `code-review` skill with arguments `<release PR number> high`, instructing it to review the full diff since 112fb91 and to weigh in particular: renderer-dependent behaviour in `prov.dot` (run Graphviz), `__slots__` interactions with any code path that sets attributes on identifiers, the lenient profile's resynchronisation on adversarial input, and the packaging metadata on the PyPI front page. Fix confirmed findings on `release/3.2.0` with pinning tests; re-run the Task 18 pre-flight after any code change.
+
+- [ ] **Step 2: Merge and publish per `docs/releasing.md` sections 3 to 5**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout main && git pull --ff-only
+gh release create 3.2.0 --title "3.2.0" --notes-file <(awk '/^## 3.2.0/{p=1;next} /^## /{p=0} p' HISTORY.md)
+gh run watch
+python -m venv /tmp/prov-320 && /tmp/prov-320/bin/pip install prov==3.2.0 && /tmp/prov-320/bin/python -c "import prov, prov.model as pm; print(prov.__version__); d=pm.ProvDocument(); d.add_namespace('ex','http://example.org/'); d.entity('ex:e'); print(pm.ProvDocument.deserialize(content=d.get_provn(), format='provn') == d)"
+```
+
+Expected: `3.2.0` and `True`.
+
+- [ ] **Step 3: Close out per `docs/releasing.md` section 6 onward**
+
+Check Zenodo for the new version DOI; merge the conda-forge feedstock PR when the bot opens it; close milestone 3.2.0; comment on #181; update the memory file for this release with PR numbers, counts and lessons. The website post is the first item of the announcement plan and lives outside this repository.
+
+```json:metadata
+{"files": [], "verifyCommand": "gh release view 3.2.0", "acceptanceCriteria": ["Whole-release review run and findings resolved", "Merged, GitHub release created, PyPI publish green, clean-venv check passes", "Zenodo DOI minted", "conda-forge PR merged", "Milestone closed, #181 commented"], "modelTier": "frontier", "coordinatorRun": true}
+```

--- a/planning/plans/2026-09-12-release-3.2.0.md
+++ b/planning/plans/2026-09-12-release-3.2.0.md
@@ -42,7 +42,7 @@
 | PR | Tasks | Branch | Closes |
 |---|---|---|---|
 | 1 | 0 | `release/3.2.0-spec` | none |
-| 2 | 1 | `bench/suite-and-gate` | benchmark-suite issue (Task 0 files it) |
+| 2 | 1 | `bench/suite-and-gate` | #433 |
 | 3 | 2, 3 | `provn/lexer` | none |
 | 4 | 4, 5, 6 | `provn/parser` | #122 |
 | 5 | 7, 8 | `provn/roundtrip-corpus` | none |
@@ -50,7 +50,7 @@
 | 7 | 11 | `perf/resolve-cache` | none |
 | 8 | 12 | `perf/slots-hash` | none |
 | 9 | 13 | `perf/literal-fast-path` | none |
-| 10 | 14 | `fix/dot-warning-provo-colon` | #341, prov.dot issue (Task 0 files it) |
+| 10 | 14 | `fix/dot-warning-provo-colon` | #341, #434 |
 | 11 | 15 | `chore/citation-guard-precommit` | none |
 | 12 | 16, 17, 18 | `release/3.2.0` | none |
 | publish | 19 | none | milestone 3.2.0 |
@@ -3447,7 +3447,7 @@ codacy-analysis analyze --files src/prov/dot.py src/prov/serializers/provrdf.py 
 git add src/prov/dot.py src/prov/serializers/provrdf.py src/prov/tests/test_dot.py src/prov/tests/test_rdf.py src/prov/tests/strategies.py docs/reference/conformance.md HISTORY.md
 git commit -m "fix: warn on unset prov.dot endpoints and resolve metachar attribute keys from PROV-O"
 git push -u origin fix/dot-warning-provo-colon
-gh pr create --title "prov.dot endpoint warning and PROV-O attribute keys with metacharacters" --body "Two follow-ups from 3.1.1. prov.dot now warns with ProvWarning when it draws a relation whose endpoint is unset (the blank-node rendering is unchanged) or skips one with too few endpoints, matching prov_to_graph(). The PROV-O decoder resolves extra attribute keys through the same graph-binding-aware resolver identifiers already use, so a key whose local part ends in a PROV-N metacharacter under a namespace no identifier has registered yet reads back; the last generation-time exclusion in the Hypothesis round-trip test is lifted and the conformance page's caveat removed. Closes #341 and #<dot issue from Task 0>."
+gh pr create --title "prov.dot endpoint warning and PROV-O attribute keys with metacharacters" --body "Two follow-ups from 3.1.1. prov.dot now warns with ProvWarning when it draws a relation whose endpoint is unset (the blank-node rendering is unchanged) or skips one with too few endpoints, matching prov_to_graph(). The PROV-O decoder resolves extra attribute keys through the same graph-binding-aware resolver identifiers already use, so a key whose local part ends in a PROV-N metacharacter under a namespace no identifier has registered yet reads back; the last generation-time exclusion in the Hypothesis round-trip test is lifted and the conformance page's caveat removed. Closes #341 and #434."
 gh pr checks --watch
 gh pr merge --merge --delete-branch
 ```

--- a/planning/specs/2026-09-12-release-3.2.0-design.md
+++ b/planning/specs/2026-09-12-release-3.2.0-design.md
@@ -1,0 +1,342 @@
+# Release 3.2.0: two-way PROV-N and speed
+
+**Date:** 2026-09-12
+**Status:** Draft for maintainer review
+**Scope:** A PROV-N parser (closes #122), a benchmark suite with an advisory CI
+gate, three measured performance improvements, and five small follow-ups from
+3.1.1. No new runtime dependency. Python floor unchanged at 3.10.
+
+## 1. Purpose
+
+`prov` writes PROV-N but cannot read it. ProvToolbox is the only implementation
+with a parser, so any workflow that starts from PROV-N text still needs Java.
+3.2.0 removes that dependency on Java for reading, and it does so with no new
+dependency of its own.
+
+The release also starts the performance track from the September 2026
+proposal. A benchmark suite lands first so that each improvement ships with a
+number, and a non-blocking CI job keeps later releases from regressing
+silently.
+
+3.2.0 ships before 2026-10-31, so it keeps the Python 3.10 floor. Under the
+published support policy the floor rises to 3.11 in the first release after
+that date, which is planned as 3.3.0.
+
+## 2. PROV-N parser
+
+### 2.1 Approach
+
+Hand-written recursive descent in pure Python, part of the core package, no
+extra. Two modules under `src/prov/serializers/`:
+
+- `provn_lexer.py` turns text into a token stream with line and column.
+- `provn_parser.py` consumes the stream and builds a `ProvDocument`.
+
+PROV-N suits recursive descent because every statement opens with a keyword,
+so the parser always knows which rule to enter after one token and never
+backtracks. The grammar is frozen (unchanged since the 2013 Recommendation),
+so a parser generator's ease of grammar change buys nothing, while its
+dependency and generic error messages would cost for the life of the library.
+
+The `What's new in 3` page already states that PROV-N needs no extra. This
+design keeps that true.
+
+### 2.2 Tokeniser
+
+Token classes, following the PROV-N Recommendation's lexical productions:
+
+| Token | Notes |
+|---|---|
+| keyword | `document`, `endDocument`, `bundle`, `endBundle`, `prefix`, `default`, and every expression keyword |
+| qualified name | `prefix:local` or bare `local`; the local part accepts the nine `PN_CHARS_ESC` backslash escapes (`= ' ( ) , : ; [ ]`) and percent-encoded characters; a trailing `.` is not part of the name |
+| IRI | `<...>` after `prefix`, `default`, or as an attribute value |
+| string | `"..."` and `"""..."""`, with `\"`, `\\` and the other escapes the writer emits |
+| integer | signed decimal; a bare integer is `xsd:int` sugar |
+| typed-literal marker | `%%` |
+| language tag | `@tag` after a string |
+| marker | `-` at an argument position |
+| punctuation | `( ) [ ] , ; =` |
+
+Comments (`//` to end of line and `/* ... */`) and whitespace are skipped.
+Every token records its line and column for error messages. The 2019 ANTLR
+attempt on #122 failed in the lexer on language tags and typed literals, so
+the tokeniser has its own unit tests before the parser exists.
+
+### 2.3 Parser
+
+One function per expression form in the Recommendation grammar. Each function
+reads the optional identifier, the formal arguments with `-` markers, the
+optional argument group where the grammar has one, and the optional attribute
+list, then calls `bundle.new_record()` with the same arguments the PROV-JSON
+deserializer passes. Attribute typing, literal parsing and namespace
+registration therefore behave exactly as they do for every other format.
+
+Document structure. `document ... endDocument` with `prefix` and `default`
+declarations, and `bundle <id> ... endBundle` blocks with their own
+declarations. A bundle inside a bundle is a syntax error.
+
+Literals invert `encoding_provn_value()` and `Literal.provn_representation()`:
+
+- a bare integer becomes an `int`;
+- `"v" %% xsd:type` goes through `parse_xsd_types()`, so the same datatypes
+  that other formats parse natively parse natively here;
+- `"v"@lang` becomes a `Literal` with `prov:InternationalizedString`;
+- `'prefix:local'` becomes a `QualifiedName`;
+- a plain string stays a `str`, with triple-quoted strings unescaped.
+
+Times are parsed with `parse_xsd_datetime()`.
+
+### 2.4 Profiles
+
+`deserialize()` and `prov.read()` accept `profile`, one of three strings.
+
+| Profile | Accepts | Rejects |
+|---|---|---|
+| `strict` | the Recommendation grammar only | bare `mentionOf`, the shorthand keywords below |
+| `default` | the grammar plus the de-facto extensions below | nothing in either set |
+| `lenient` | as `default`; a statement that fails to parse is skipped with a `ProvWarning` | nothing |
+
+The de-facto extensions are what `prov` and ProvToolbox write:
+
+- `mentionOf(e, e2, b)` becomes a `ProvMention` (#248; the Recommendation
+  grammar has no Mention production).
+- The shorthand keywords in `ADDITIONAL_N_MAP` map to their base record plus a
+  `prov:type`, exactly as the PROV-XML deserializer already decodes them:
+  `person`, `organization`, `softwareAgent` to `agent`; `collection`,
+  `emptyCollection`, `plan` to `entity`; `wasRevisionOf`, `wasQuotedFrom`,
+  `hadPrimarySource` to `wasDerivedFrom`.
+- Extensibility expressions (`prefix:name(...)`, grammar production
+  `extensibilityExpression`) are not an extension we accept. The model has no
+  record class for an unknown type (`new_record()` looks the type up in
+  `PROV_REC_CLS`), so they raise `ProvNSyntaxError` in `strict` and
+  `default`, and `lenient` skips them with a warning like any other
+  unparseable statement.
+
+Lenient recovery resynchronises at the next statement boundary, which is a
+keyword followed by `(` at bracket depth zero, or `bundle`, `endBundle` or
+`endDocument`. Newlines are not boundaries, because attribute lists span
+lines. Each skipped statement produces one warning with its line, column and
+message.
+
+`default` is the default. PROV-N documents in the wild come from `prov` or
+ProvToolbox, and both write the extensions.
+
+### 2.5 Errors and integration
+
+`ProvNSyntaxError(ProvException)` carries `line`, `column` and a message of
+the form "expected X, found Y". `prov.read()` auto-detection swallows it as it
+swallows the other formats' errors, and the registry order stays
+`json, rdf, provn, xml, jsonld`.
+
+`ProvNSerializer.deserialize()` calls the parser. `prov-convert` gains an
+input-format option so it can read PROV-N; today it reads only PROV-JSON.
+`prov-compare` already selects input formats, so it reads PROV-N with no
+change.
+
+### 2.6 Writer
+
+The serializer is not rewritten. The conformance audit checked its output
+against the grammar and found only the deviations chosen on purpose. What it
+lacked was a test oracle, which the parser now provides (section 3.3).
+
+One addition. `serialize(format="provn", strict=True)` writes `prov:mentionOf`
+instead of `mentionOf`, so strict readers, including our own `strict` profile,
+accept the output. The default stays `mentionOf` for ProvToolbox
+compatibility.
+
+#131 (pretty output) stays in the backlog.
+
+## 3. Tests
+
+### 3.1 Tokeniser
+
+`test_provn_lexer.py`, table-driven. One case per token class and one per
+awkward boundary: each `PN_CHARS_ESC` escape, percent-encoded local parts, a
+trailing `.`, triple-quoted strings containing quotes and newlines, `%%`
+against `%` inside a name, `@` after a string against `@` inside an IRI, and
+`-` as a marker against a negative integer. Malformed input asserts line and
+column.
+
+### 3.2 Parser
+
+`test_provn.py`, format-specific like `test_json.py`. One test per expression
+form covering the optional identifier, each marker position and the optional
+argument groups. Profile tests assert that `strict` rejects and `default`
+accepts each extension, and that `lenient` warns once per bad statement,
+resumes at the right boundary and returns everything else. Error paths:
+unterminated document, unknown keyword, unbalanced brackets, nested bundle.
+
+### 3.3 Shared round trip
+
+`provn` joins `ROUNDTRIP_FORMATS`. `test_statements.py`, `test_attributes.py`,
+`test_qnames.py` and `test_examples.py` then run write-then-read through the
+parser, and `test_property_roundtrip.py` does the same over generated
+documents. This is the writer's test oracle. PROV-N has no known-lossy
+constructs, so no new exclusions.
+
+### 3.4 Conformance corpus
+
+`src/prov/tests/provn/`, three vendored sets, each with a README naming source
+and licence.
+
+1. Every PROV-N example from the Recommendation and from PROV-DM. Each parses
+   under `strict` and round-trips through the writer.
+2. ProvToolbox's own test documents from
+   `modules-core/prov-n/src/test/resources/prov` (bundles, container, blog
+   and family files). Each parses under `default`.
+3. The PROV-N files ProvToolbox's writer produced from the shared test corpus
+   (388 of the 398 documents in `src/prov/tests/json/` have one). Each is
+   parsed and compared for equality with the document loaded from the
+   matching JSON fixture. The ten without a counterpart, and any file holding
+   a Dictionary form, are listed by name with the reason.
+
+Set 3 is the interop claim. Equality with the JSON document proves that we
+read ProvToolbox's output as ProvToolbox meant it. A comparison that fails
+because of a deliberate difference becomes a documented exception on the
+conformance page, never a silent skip.
+
+Coverage stays above the 97% floor; the tokeniser and parser get their own
+coverage check because malformed-input branches are easy to leave unreached.
+
+## 4. Performance
+
+### 4.1 Benchmark suite
+
+A top-level `benchmarks/` directory, outside the package and outside the
+default pytest paths, using pytest-benchmark from a new `bench` dependency
+group. One generator builds a document of N records with a realistic mix of
+elements, relations, attributes and a few bundles. Cases:
+
+- construct via the API;
+- serialise and deserialise for each of the five formats, including the new
+  PROV-N parser;
+- `unified()`, `prov_to_graph()`, `ProvDocument.__eq__`.
+
+N is 10k in CI; an environment variable raises it to 100k for local
+profiling. `uv run pytest benchmarks/` runs it.
+
+### 4.2 Gate
+
+`benchmarks/baseline.json`, produced on the CI runner type and committed. A
+non-blocking `benchmark` job in `CI.yml`, modelled on `own-warnings`
+(`continue-on-error`, one interpreter), compares against the baseline with
+pytest-benchmark's compare-fail option at a 20% mean regression. The baseline
+is refreshed by a documented command whenever a PR intends a change in speed.
+Runner noise is why the job is advisory; a red run is a prompt to look, not a
+merge block.
+
+### 4.3 Improvements
+
+Each is its own PR with before and after numbers in the body. Each leaves the
+full suite green and the public API, equality and hash semantics unchanged. An
+improvement that does not move its number does not merge.
+
+1. **Resolve-once cache.** `NamespaceManager.valid_qualified_name()` is about
+   30% of construction because every string identifier is re-resolved. A
+   per-manager dict from input string to resolved `QualifiedName`, cleared
+   whenever a namespace is added or the default changes, turns repeat
+   resolutions into a lookup. The parser and every deserializer benefit.
+2. **Precomputed hash and `__slots__`.** `QualifiedName.__hash__` runs about
+   19 times per record. Compute the hash once at construction, and add
+   `__slots__` to `Identifier`, `QualifiedName`, `Namespace` and `Literal`.
+   All four are immutable in practice. `ProvRecord` keeps its `__dict__`.
+3. **Typed-value fast path.** `_auto_literal_conversion()` runs every value
+   through the full ladder. Checking the exact common types (`str`, `int`,
+   `datetime`, `QualifiedName`) first skips the ladder for most values.
+
+Target, from the proposal's measurements on an M2 Max at 100k records: 2x on
+construction and JSON deserialisation.
+
+## 5. Follow-ups from 3.1.1
+
+1. **`prov.dot` unset endpoints.** A relation whose endpoint is unset is
+   routed to a blank node without a word. It gains the `ProvWarning` that
+   `prov_to_graph()` got in 3.1.1, naming the relation and the missing
+   endpoint. Rendering does not change.
+2. **#341, colon in a local part through PROV-O.** The decoder cannot split
+   `http://example.org/k:` because resolution has no record of where the
+   namespace ends. When an IRI starts with a namespace URI the document
+   itself declares, the remainder is the local part, colon or not. That reads
+   back what the encoder wrote without minting any new IRI form. The
+   generation-time exclusion in the property test is lifted and the
+   conformance page's note is removed. If the rule misreads a third-party
+   document in the corpus, the item reverts to documented and the issue
+   records why.
+3. **One default-namespace setter.** `NamespaceManager` sets its default in
+   `set_default_namespace()` and again inside `_reconcile_qualified_name()`
+   when a prefix-less qualified name arrives first. Both route through one
+   private method so the cache in 4.3 has a single invalidation point.
+4. **`test_citation` skip guard.** The guard checks only `CITATION.cff` but the
+   module also reads `.zenodo.json`. The guard covers both files.
+5. **Pre-commit noise.** Trailing whitespace in `.codacy/codacy.config.json`
+   and four vendored `.xsd` schemas fails `pre-commit run --all-files` on a
+   clean tree. The Codacy file is fixed; the schemas are vendored W3C text and
+   are excluded from the hook.
+
+## 6. Documentation and repository changes
+
+- `docs/howto/provn.md` loses the write-only warning and gains reading, the
+  three profiles, the error type with a line-and-column example, the strict
+  writer option and the `prov-convert` input option.
+- `docs/reference/conformance.md`. The PROV-N column becomes a round-trip
+  column like the other four; the #341 note goes if 5.2 lands; the
+  "last revised" sentence is updated at release.
+- `docs/howto/cli.md` documents the `prov-convert` input option.
+- `docs/whats-new-3.md` gains a 3.2.0 paragraph.
+- `docs/explanation/architecture.md` adds the two parser modules and the
+  benchmark suite.
+- `README.md` feature list and `pyproject.toml` description and keywords say
+  PROV-N is read and written.
+- `docs/releasing.md` and `CLAUDE.md` gain the benchmark command.
+- `ROADMAP.md`. The 3.2.0 row carries the widened theme and highlights, no
+  date, and states that it ships before 2026-10-31 and keeps the 3.10 floor
+  with the drop in 3.3.0. The Python support paragraph, which still reasons
+  about 3.1.0, is rewritten to name 3.2.0 as the last 3.10 release. This edit
+  lands in the first PR, before any code.
+- `HISTORY.md` gets the release entry, written by release, never by task.
+- Milestone 3.2.0 gets #122, #341 and new issues for the `prov.dot` warning
+  and the benchmark suite.
+
+## 7. Sequence
+
+Twelve focused PRs, green CI before merge, reviewed before merge.
+
+1. This spec, the implementation plan, and the `ROADMAP.md` edit.
+2. Benchmark suite, CI job, baseline. Lands before any tuning.
+3. Tokeniser and its tests. A `/code-review` round runs on this PR before it
+   merges, with findings fixed in the same PR.
+4. Parser, profiles, error type, registry wiring, tests. A `/code-review`
+   round runs on this PR before it merges, with findings fixed in the same
+   PR.
+5. `provn` in `ROUNDTRIP_FORMATS`, the conformance corpus, property test.
+6. Strict writer option and the `prov-convert` input option.
+7. to 9. The three performance improvements, one each.
+10. and 11. The five follow-ups, grouped by file.
+12. A `/simplify` round over everything the release touched, then the docs
+    changes, then the release stamp per `docs/releasing.md`.
+
+A whole-release review runs after PR 12 and before the GitHub release is
+created. In 3.1.1 the per-task reviews missed a renderer-dependent defect that
+only the final pass found.
+
+## 8. Out of scope
+
+- #131 pretty PROV-N output.
+- PROV-Dictionary forms (#129). The parser rejects `hadDictionaryMember`,
+  `derivedByInsertionFrom` and `derivedByRemovalFrom` in every profile.
+- Streaming or incremental parsing.
+- Any change to the Python floor.
+- Roadmap rows for 3.3.0 to 3.5.0; those themes are not yet approved.
+
+## 9. Verification
+
+The gates in `CLAUDE.md` on every PR: the interpreter matrix, `mypy`, `ruff`,
+the Codacy analyser on changed files, coverage above 97%. In addition:
+
+- PR 3 and PR 4 each pass a `/code-review` round.
+- PRs 7 to 9 each state before and after benchmark numbers.
+- The conformance corpus passes with the exceptions listed by name.
+- The release passes a `/simplify` round and then a whole-release review.
+- The suite's pass, skip and xfail counts are compared against 3.1.1
+  (1672 passed, 26 skipped) and every difference is explained by this
+  release's changes.


### PR DESCRIPTION
Adds the approved design spec and implementation plan for 3.2.0 (two-way PROV-N, benchmark suite and performance improvements, 3.1.1 follow-ups), updates the 3.2.0 row and the Python support paragraph in ROADMAP.md before any code lands, and scaffolds the 3.2.0 changelog section.

The roadmap row is written first so that the community-facing statement matches the release being built; it is stamped with the date at release time.