### PR TITLE
PROV-N tokeniser

### DIFF
--- a/src/prov/serializers/provn_lexer.py
+++ b/src/prov/serializers/provn_lexer.py
@@ -1,0 +1,268 @@
+"""Tokeniser for PROV-N (https://www.w3.org/TR/prov-n/, section 3.8).
+
+Produces a flat token stream with line and column positions. Keywords are
+not distinguished here: every bare or prefixed name is a ``NAME`` token, and
+the parser decides whether a name at statement start is a keyword. The one
+context-sensitive rule is the language tag, which only follows a string.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from prov.model import ProvException
+
+__all__ = ["ProvNSyntaxError", "Token", "TokenKind", "tokenize"]
+
+
+class ProvNSyntaxError(ProvException):
+    """A PROV-N document could not be tokenised or parsed.
+
+    Attributes:
+        message: What was expected and what was found.
+        line: 1-based line of the offending token.
+        column: 1-based column of the offending token.
+    """
+
+    def __init__(self, message: str, line: int, column: int):
+        super().__init__(f"line {line}, column {column}: {message}")
+        self.message = message
+        self.line = line
+        self.column = column
+
+
+class TokenKind(Enum):
+    """Token classes; the names follow the Recommendation's productions."""
+
+    NAME = "name"  # QUALIFIED_NAME [51], value (prefix, local)
+    QNAME_LITERAL = "qualified name literal"  # 'prefix:local', value (prefix, local)
+    IRI = "IRI"  # IRI_REF [56], value the IRI text
+    STRING = "string"  # STRING_LITERAL [60], value the unescaped text
+    INT = "integer"  # INT_LITERAL [61], value an int
+    DATETIME = "dateTime"  # DATETIME [62], value the lexical form
+    LANGTAG = "language tag"  # LANGTAG [63], value the tag
+    TYPED = "%%"
+    MARKER = "-"
+    LPAREN = "("
+    RPAREN = ")"
+    LBRACKET = "["
+    RBRACKET = "]"
+    COMMA = ","
+    SEMICOLON = ";"
+    EQUALS = "="
+    EOF = "end of input"
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: TokenKind
+    text: str
+    value: Any
+    line: int
+    column: int
+
+
+# Character classes from the Recommendation ([53] to [55]); '.' and '-' are
+# handled in the local-part patterns because their placement rules differ.
+_PN_CHARS_BASE = (
+    r"A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF"
+    r"\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF"
+    r"\uFDF0-\uFFFD\U00010000-\U000EFFFF"
+)
+_PN_CHARS_U = _PN_CHARS_BASE + "_"
+_PN_CHARS = _PN_CHARS_U + r"\-0-9\u00B7\u0300-\u036F\u203F-\u2040"
+_PN_OTHERS = r"/@~&+*?#$!"
+_PERCENT = r"%[0-9A-Fa-f]{2}"
+_ESC = r"\\[=',\-:;\[\]().]"
+_LOCAL_START = rf"[{_PN_CHARS_U}0-9{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
+_LOCAL_CONT = rf"[{_PN_CHARS}.{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
+_PN_LOCAL = rf"(?:{_LOCAL_START})(?:{_LOCAL_CONT})*"
+_PN_PREFIX = rf"[{_PN_CHARS_BASE}][{_PN_CHARS}.]*"
+
+_QNAME = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})")
+_QNAME_FULL = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})\Z")
+_DATETIME = re.compile(
+    r"-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?"
+)
+_INT = re.compile(r"-?\d+")
+_IRI = re.compile(r"<([^<>\"{}|^`\\\s]*)>")
+_LANGTAG = re.compile(r"@([A-Za-z]+(?:-[A-Za-z0-9]+)*)")
+_SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n])*)"')
+_LONG_STRING = re.compile(r'"""((?:\\.|"(?!"")|[^"\\])*)"""', re.S)
+_QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n])*)'")
+_SKIP = re.compile(r"(?:\s+|//[^\n]*|/\*.*?\*/)+", re.S)
+_UNESCAPE_LOCAL = re.compile(r"\\(.)")
+_STRING_ESCAPES = {
+    "t": "\t",
+    "b": "\b",
+    "n": "\n",
+    "r": "\r",
+    "f": "\f",
+    '"': '"',
+    "'": "'",
+    "\\": "\\",
+}
+
+_PUNCTUATION = {
+    "(": TokenKind.LPAREN,
+    ")": TokenKind.RPAREN,
+    "[": TokenKind.LBRACKET,
+    "]": TokenKind.RBRACKET,
+    ",": TokenKind.COMMA,
+    ";": TokenKind.SEMICOLON,
+    "=": TokenKind.EQUALS,
+}
+
+
+def _unescape_string(raw: str, line: int, column: int) -> str:
+    def replace(match: re.Match[str]) -> str:
+        char = match.group(1)
+        if char not in _STRING_ESCAPES:
+            raise ProvNSyntaxError(f"unknown string escape '\\{char}'", line, column)
+        return _STRING_ESCAPES[char]
+
+    return re.sub(r"\\(.)", replace, raw, flags=re.S)
+
+
+def _split_qname(raw: str, line: int, column: int) -> tuple[str, str]:
+    match = _QNAME_FULL.match(raw)
+    if match is None:
+        raise ProvNSyntaxError(f"invalid qualified name '{raw}'", line, column)
+    prefix, local = match.group(1) or "", match.group(2)
+    return prefix, _UNESCAPE_LOCAL.sub(r"\1", local)
+
+
+class _Lexer:
+    def __init__(self, text: str):
+        self.text = text
+        self.pos = 0
+        self.line = 1
+        self.line_start = 0
+        self.previous: TokenKind | None = None
+
+    @property
+    def column(self) -> int:
+        return self.pos - self.line_start + 1
+
+    def advance(self, length: int) -> None:
+        chunk = self.text[self.pos : self.pos + length]
+        newlines = chunk.count("\n")
+        if newlines:
+            self.line += newlines
+            self.line_start = self.pos + chunk.rfind("\n") + 1
+        self.pos += length
+
+    def error(self, message: str) -> ProvNSyntaxError:
+        return ProvNSyntaxError(message, self.line, self.column)
+
+    def emit(self, kind: TokenKind, text: str, value: Any) -> Token:
+        token = Token(kind, text, value, self.line, self.column)
+        self.advance(len(text))
+        self.previous = kind
+        return token
+
+    def tokens(self) -> Iterator[Token]:
+        text = self.text
+        while True:
+            skip = _SKIP.match(text, self.pos)
+            if skip:
+                self.advance(skip.end() - self.pos)
+            if self.pos >= len(text):
+                yield Token(TokenKind.EOF, "", None, self.line, self.column)
+                return
+            yield self.next_token()
+
+    def next_token(self) -> Token:
+        text, pos = self.text, self.pos
+        char = text[pos]
+        if char in _PUNCTUATION:
+            return self.emit(_PUNCTUATION[char], char, char)
+        if char == "<":
+            return self.iri_token()
+        if char == '"':
+            return self.string_token()
+        if char == "'":
+            return self.qname_literal_token()
+        if char == "@" and self.previous is TokenKind.STRING:
+            return self.langtag_token()
+        if text.startswith("%%", pos):
+            return self.emit(TokenKind.TYPED, "%%", "%%")
+        token = self.literal_or_name_token()
+        if token is not None:
+            return token
+        if char == "-":
+            return self.emit(TokenKind.MARKER, "-", "-")
+        raise self.error(f"unexpected character {char!r}")
+
+    def iri_token(self) -> Token:
+        match = _IRI.match(self.text, self.pos)
+        if match is None:
+            raise self.error("unterminated IRI")
+        return self.emit(TokenKind.IRI, match.group(0), match.group(1))
+
+    def qname_literal_token(self) -> Token:
+        match = _QNAME_LITERAL.match(self.text, self.pos)
+        if match is None:
+            raise self.error("unterminated qualified name literal")
+        value = _split_qname(match.group(1), self.line, self.column)
+        return self.emit(TokenKind.QNAME_LITERAL, match.group(0), value)
+
+    def langtag_token(self) -> Token:
+        match = _LANGTAG.match(self.text, self.pos)
+        if match is None:
+            raise self.error("invalid language tag")
+        return self.emit(TokenKind.LANGTAG, match.group(0), match.group(1))
+
+    def literal_or_name_token(self) -> Token | None:
+        text, pos = self.text, self.pos
+        datetime_match = _DATETIME.match(text, pos)
+        if datetime_match:
+            raw = datetime_match.group(0)
+            return self.emit(TokenKind.DATETIME, raw, raw)
+        int_match = _INT.match(text, pos)
+        name_match = _QNAME.match(text, pos)
+        if int_match and (name_match is None or name_match.end() <= int_match.end()):
+            raw = int_match.group(0)
+            return self.emit(TokenKind.INT, raw, int(raw))
+        if name_match:
+            return self.name_token(name_match)
+        return None
+
+    def name_token(self, match: re.Match[str]) -> Token:
+        raw = match.group(0)
+        # PN_LOCAL may contain '.' but not end with one ([54]); an escaped
+        # '\.' is a regular character, so only a bare trailing dot backs off.
+        while raw.endswith(".") and not raw.endswith("\\."):
+            raw = raw[:-1]
+        value = _split_qname(raw, self.line, self.column)
+        token = self.emit(TokenKind.NAME, raw, value)
+        if self.pos < len(self.text) and self.text[self.pos] == ":":
+            raise self.error("unexpected ':' inside a qualified name")
+        return token
+
+    def string_token(self) -> Token:
+        text, pos = self.text, self.pos
+        if text.startswith('"""', pos):
+            match = _LONG_STRING.match(text, pos)
+            if match is None:
+                raise self.error("unterminated long string")
+        else:
+            match = _SHORT_STRING.match(text, pos)
+            if match is None:
+                raise self.error("unterminated string")
+        value = _unescape_string(match.group(1), self.line, self.column)
+        return self.emit(TokenKind.STRING, match.group(0), value)
+
+
+def tokenize(text: str) -> Iterator[Token]:
+    """Yield the tokens of ``text``, ending with an ``EOF`` token.
+
+    Raises:
+        ProvNSyntaxError: On the first character that starts no valid token,
+            with the line and column of that character.
+    """
+    return _Lexer(text).tokens()

--- a/src/prov/serializers/provn_lexer.py
+++ b/src/prov/serializers/provn_lexer.py
@@ -9,6 +9,7 @@ context-sensitive rule is the language tag, which only follows a string.
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
@@ -33,6 +34,9 @@ class ProvNSyntaxError(ProvException):
         self.message = message
         self.line = line
         self.column = column
+
+    def __reduce__(self) -> tuple[type[ProvNSyntaxError], tuple[str, int, int]]:
+        return type(self), (self.message, self.line, self.column)
 
 
 class TokenKind(Enum):
@@ -80,25 +84,42 @@ _PERCENT = r"%[0-9A-Fa-f]{2}"
 _ESC = r"\\[=',\-:;\[\]().]"
 _LOCAL_START = rf"[{_PN_CHARS_U}0-9{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
 _LOCAL_CONT = rf"[{_PN_CHARS}.{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
-_PN_LOCAL = rf"(?:{_LOCAL_START})(?:{_LOCAL_CONT})*"
-_PN_PREFIX = rf"[{_PN_CHARS_BASE}][{_PN_CHARS}.]*"
+# The last character of a local part can't be a bare '.' ([54]); an escaped
+# '\.' or a percent-escape are still fine, so this is _LOCAL_CONT without
+# the bare-dot alternative. Folding the end rule into the grammar (rather
+# than stripping dots off the match afterwards) keeps matching linear even
+# for a long run of trailing dots.
+_LOCAL_LAST = rf"[{_PN_CHARS}{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
+_PN_LOCAL = rf"(?:{_LOCAL_START})(?:(?:{_LOCAL_CONT})*(?:{_LOCAL_LAST}))?"
+# SPARQL's PN_PREFIX ([52]'s reference production) is PN_CHARS_BASE
+# ((PN_CHARS | '.')* PN_CHARS)? -- a prefix can't end in '.' either.
+_PN_PREFIX = rf"[{_PN_CHARS_BASE}](?:[{_PN_CHARS}.]*[{_PN_CHARS}])?"
 
 # [52] allows "PN_PREFIX ':'" alone (empty local, e.g. the Recommendation's
 # own `bbc:`), so the prefixed branch's local part is optional; group 3 is
 # the bare, unprefixed local part.
 _QNAME = re.compile(rf"(?:({_PN_PREFIX}):({_PN_LOCAL})?|({_PN_LOCAL}))")
 _QNAME_FULL = re.compile(rf"(?:({_PN_PREFIX}):({_PN_LOCAL})?|({_PN_LOCAL}))\Z")
+# DIGIT is [0-9] ([55]); \d would also match other Unicode decimal digits,
+# which the grammar treats as ordinary name characters, not digits.
 _DATETIME = re.compile(
-    r"-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?"
+    r"-?[0-9]{4,}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})?"
 )
-_INT = re.compile(r"-?\d+")
-_IRI = re.compile(r"<([^<>\"{}|^`\\\s]*)>")
+_INT = re.compile(r"-?[0-9]+")
+# [56]'s UCHAR exclusion is [#x00-#x20], not full Unicode whitespace: \s
+# would reject non-breaking space (a legal IRI character) and admit other
+# control characters that aren't spaces.
+_IRI = re.compile(r"<([^<>\"{}|^`\\\x00-\x20]*)>")
 _LANGTAG = re.compile(r"@([A-Za-z]+(?:-[A-Za-z0-9]+)*)")
 _SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n])*)"')
 _LONG_STRING = re.compile(r'"""((?:\\.|"(?!"")|[^"\\])*)"""', re.S)
 _QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n])*)'")
-_SKIP = re.compile(r"(?:\s+|//[^\n]*|/\*.*?\*/)+", re.S)
-_UNESCAPE_LOCAL = re.compile(r"\\(.)")
+# A '//' comment ends at CR or LF (the Recommendation's note on comments),
+# not just LF.
+_SKIP = re.compile(r"(?:\s+|//[^\n\r]*|/\*.*?\*/)+", re.S)
+_LINEBREAK = re.compile(r"\r\n|\r|\n")
+_ESCAPE_CHAR = re.compile(r"\\(.)", re.S)
 _STRING_ESCAPES = {
     "t": "\t",
     "b": "\b",
@@ -126,6 +147,9 @@ _Locate = Callable[[int], tuple[int, int]]
 
 
 def _unescape_string(raw: str, locate: _Locate, start: int) -> str:
+    if "\\" not in raw:
+        return raw
+
     def replace(match: re.Match[str]) -> str:
         char = match.group(1)
         if char not in _STRING_ESCAPES:
@@ -133,7 +157,7 @@ def _unescape_string(raw: str, locate: _Locate, start: int) -> str:
             raise ProvNSyntaxError(f"unknown string escape '\\{char}'", line, column)
         return _STRING_ESCAPES[char]
 
-    return re.sub(r"\\(.)", replace, raw, flags=re.S)
+    return _ESCAPE_CHAR.sub(replace, raw)
 
 
 def _split_qname(raw: str, locate: _Locate, start: int) -> tuple[str, str]:
@@ -143,8 +167,8 @@ def _split_qname(raw: str, locate: _Locate, start: int) -> tuple[str, str]:
         line, column = locate(start + (partial.end() if partial else 0))
         raise ProvNSyntaxError(f"invalid qualified name '{raw}'", line, column)
     if match.group(1) is not None:
-        return match.group(1), _UNESCAPE_LOCAL.sub(r"\1", match.group(2) or "")
-    return "", _UNESCAPE_LOCAL.sub(r"\1", match.group(3) or "")
+        return match.group(1), _ESCAPE_CHAR.sub(r"\1", match.group(2) or "")
+    return "", _ESCAPE_CHAR.sub(r"\1", match.group(3) or "")
 
 
 class _Lexer:
@@ -159,12 +183,23 @@ class _Lexer:
     def column(self) -> int:
         return self.pos - self.line_start + 1
 
+    def _line_after(self, chunk: str) -> tuple[int, int]:
+        """(line, line_start) reached by moving past ``chunk``, which starts
+        at ``self.pos``; a CRLF pair counts as a single line break. Shared by
+        ``advance`` (moving the lexer itself) and ``locate`` (a read-only
+        look-ahead), so the newline arithmetic lives in one place."""
+        count = 0
+        last_end = 0
+        for match in _LINEBREAK.finditer(chunk):
+            count += 1
+            last_end = match.end()
+        if count:
+            return self.line + count, self.pos + last_end
+        return self.line, self.line_start
+
     def advance(self, length: int) -> None:
         chunk = self.text[self.pos : self.pos + length]
-        newlines = chunk.count("\n")
-        if newlines:
-            self.line += newlines
-            self.line_start = self.pos + chunk.rfind("\n") + 1
+        self.line, self.line_start = self._line_after(chunk)
         self.pos += length
 
     def error(self, message: str) -> ProvNSyntaxError:
@@ -174,12 +209,8 @@ class _Lexer:
         """Line and column of the absolute ``offset``, which must be at or
         after ``self.pos``; used to report errors inside a literal's body
         rather than at the literal's opening delimiter."""
-        segment = self.text[self.pos : offset]
-        newlines = segment.count("\n")
-        if newlines:
-            line_start = self.pos + segment.rfind("\n") + 1
-            return self.line + newlines, offset - line_start + 1
-        return self.line, offset - self.line_start + 1
+        line, line_start = self._line_after(self.text[self.pos : offset])
+        return line, offset - line_start + 1
 
     def emit(self, kind: TokenKind, text: str, value: Any) -> Token:
         token = Token(kind, text, value, self.line, self.column)
@@ -251,17 +282,22 @@ class _Lexer:
         name_match = _QNAME.match(text, pos)
         if int_match and (name_match is None or name_match.end() <= int_match.end()):
             raw = int_match.group(0)
-            return self.emit(TokenKind.INT, raw, int(raw))
+            return self.emit(TokenKind.INT, raw, self._int_value(raw))
         if name_match:
             return self.name_token(name_match)
         return None
 
+    def _int_value(self, raw: str) -> int:
+        try:
+            return int(raw)
+        except ValueError as exc:
+            limit = sys.get_int_max_str_digits()
+            raise self.error(f"integer literal has more than {limit} digits") from exc
+
     def name_token(self, match: re.Match[str]) -> Token:
+        # _PN_LOCAL already excludes a bare trailing '.' ([54]), so the
+        # match never needs trimming here.
         raw = match.group(0)
-        # PN_LOCAL may contain '.' but not end with one ([54]); an escaped
-        # '\.' is a regular character, so only a bare trailing dot backs off.
-        while raw.endswith(".") and not raw.endswith("\\."):
-            raw = raw[:-1]
         value = _split_qname(raw, self.locate, self.pos)
         token = self.emit(TokenKind.NAME, raw, value)
         if self.pos < len(self.text) and self.text[self.pos] == ":":

--- a/src/prov/serializers/provn_lexer.py
+++ b/src/prov/serializers/provn_lexer.py
@@ -9,7 +9,7 @@ context-sensitive rule is the language tag, which only follows a string.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -83,8 +83,11 @@ _LOCAL_CONT = rf"[{_PN_CHARS}.{_PN_OTHERS}]|{_PERCENT}|{_ESC}"
 _PN_LOCAL = rf"(?:{_LOCAL_START})(?:{_LOCAL_CONT})*"
 _PN_PREFIX = rf"[{_PN_CHARS_BASE}][{_PN_CHARS}.]*"
 
-_QNAME = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})")
-_QNAME_FULL = re.compile(rf"(?:({_PN_PREFIX}):)?({_PN_LOCAL})\Z")
+# [52] allows "PN_PREFIX ':'" alone (empty local, e.g. the Recommendation's
+# own `bbc:`), so the prefixed branch's local part is optional; group 3 is
+# the bare, unprefixed local part.
+_QNAME = re.compile(rf"(?:({_PN_PREFIX}):({_PN_LOCAL})?|({_PN_LOCAL}))")
+_QNAME_FULL = re.compile(rf"(?:({_PN_PREFIX}):({_PN_LOCAL})?|({_PN_LOCAL}))\Z")
 _DATETIME = re.compile(
     r"-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?"
 )
@@ -118,22 +121,30 @@ _PUNCTUATION = {
 }
 
 
-def _unescape_string(raw: str, line: int, column: int) -> str:
+# A locator maps an absolute offset in the source text to its (line, column).
+_Locate = Callable[[int], tuple[int, int]]
+
+
+def _unescape_string(raw: str, locate: _Locate, start: int) -> str:
     def replace(match: re.Match[str]) -> str:
         char = match.group(1)
         if char not in _STRING_ESCAPES:
+            line, column = locate(start + match.start())
             raise ProvNSyntaxError(f"unknown string escape '\\{char}'", line, column)
         return _STRING_ESCAPES[char]
 
     return re.sub(r"\\(.)", replace, raw, flags=re.S)
 
 
-def _split_qname(raw: str, line: int, column: int) -> tuple[str, str]:
+def _split_qname(raw: str, locate: _Locate, start: int) -> tuple[str, str]:
     match = _QNAME_FULL.match(raw)
     if match is None:
+        partial = _QNAME.match(raw)
+        line, column = locate(start + (partial.end() if partial else 0))
         raise ProvNSyntaxError(f"invalid qualified name '{raw}'", line, column)
-    prefix, local = match.group(1) or "", match.group(2)
-    return prefix, _UNESCAPE_LOCAL.sub(r"\1", local)
+    if match.group(1) is not None:
+        return match.group(1), _UNESCAPE_LOCAL.sub(r"\1", match.group(2) or "")
+    return "", _UNESCAPE_LOCAL.sub(r"\1", match.group(3) or "")
 
 
 class _Lexer:
@@ -159,6 +170,17 @@ class _Lexer:
     def error(self, message: str) -> ProvNSyntaxError:
         return ProvNSyntaxError(message, self.line, self.column)
 
+    def locate(self, offset: int) -> tuple[int, int]:
+        """Line and column of the absolute ``offset``, which must be at or
+        after ``self.pos``; used to report errors inside a literal's body
+        rather than at the literal's opening delimiter."""
+        segment = self.text[self.pos : offset]
+        newlines = segment.count("\n")
+        if newlines:
+            line_start = self.pos + segment.rfind("\n") + 1
+            return self.line + newlines, offset - line_start + 1
+        return self.line, offset - self.line_start + 1
+
     def emit(self, kind: TokenKind, text: str, value: Any) -> Token:
         token = Token(kind, text, value, self.line, self.column)
         self.advance(len(text))
@@ -171,6 +193,8 @@ class _Lexer:
             skip = _SKIP.match(text, self.pos)
             if skip:
                 self.advance(skip.end() - self.pos)
+            if text.startswith("/*", self.pos):
+                raise self.error("unterminated comment")
             if self.pos >= len(text):
                 yield Token(TokenKind.EOF, "", None, self.line, self.column)
                 return
@@ -208,7 +232,7 @@ class _Lexer:
         match = _QNAME_LITERAL.match(self.text, self.pos)
         if match is None:
             raise self.error("unterminated qualified name literal")
-        value = _split_qname(match.group(1), self.line, self.column)
+        value = _split_qname(match.group(1), self.locate, match.start(1))
         return self.emit(TokenKind.QNAME_LITERAL, match.group(0), value)
 
     def langtag_token(self) -> Token:
@@ -238,7 +262,7 @@ class _Lexer:
         # '\.' is a regular character, so only a bare trailing dot backs off.
         while raw.endswith(".") and not raw.endswith("\\."):
             raw = raw[:-1]
-        value = _split_qname(raw, self.line, self.column)
+        value = _split_qname(raw, self.locate, self.pos)
         token = self.emit(TokenKind.NAME, raw, value)
         if self.pos < len(self.text) and self.text[self.pos] == ":":
             raise self.error("unexpected ':' inside a qualified name")
@@ -254,7 +278,7 @@ class _Lexer:
             match = _SHORT_STRING.match(text, pos)
             if match is None:
                 raise self.error("unterminated string")
-        value = _unescape_string(match.group(1), self.line, self.column)
+        value = _unescape_string(match.group(1), self.locate, match.start(1))
         return self.emit(TokenKind.STRING, match.group(0), value)
 
 

--- a/src/prov/tests/test_provn_lexer.py
+++ b/src/prov/tests/test_provn_lexer.py
@@ -1,0 +1,172 @@
+"""Tokeniser tests for PROV-N (W3C PROV-N Recommendation, section 3.8
+lexical productions). Table-driven: one case per token class and one per
+boundary that a hand-written lexer gets wrong."""
+
+import pytest
+
+from prov.serializers.provn_lexer import ProvNSyntaxError, TokenKind, tokenize
+
+
+def kinds(text):
+    return [t.kind for t in tokenize(text) if t.kind is not TokenKind.EOF]
+
+
+def values(text):
+    return [t.value for t in tokenize(text) if t.kind is not TokenKind.EOF]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("entity", [TokenKind.NAME]),
+        ("ex:e1", [TokenKind.NAME]),
+        ("<http://example.org/>", [TokenKind.IRI]),
+        ('"hello"', [TokenKind.STRING]),
+        ('"""multi\nline"""', [TokenKind.STRING]),
+        ("42", [TokenKind.INT]),
+        ("-42", [TokenKind.INT]),
+        ("2011-11-16T16:00:00", [TokenKind.DATETIME]),
+        ("2011-11-16T16:00:00.123Z", [TokenKind.DATETIME]),
+        ("2011-11-16T16:00:00+01:00", [TokenKind.DATETIME]),
+        ("%%", [TokenKind.TYPED]),
+        ("-", [TokenKind.MARKER]),
+        ("'ex:abc'", [TokenKind.QNAME_LITERAL]),
+        (
+            "( ) [ ] , ; =",
+            [
+                TokenKind.LPAREN,
+                TokenKind.RPAREN,
+                TokenKind.LBRACKET,
+                TokenKind.RBRACKET,
+                TokenKind.COMMA,
+                TokenKind.SEMICOLON,
+                TokenKind.EQUALS,
+            ],
+        ),
+    ],
+)
+def test_token_kinds(text, expected):
+    assert kinds(text) == expected
+
+
+def test_comments_are_skipped():
+    text = "entity // trailing\n/* block\ncomment */ agent"
+    assert values(text) == [("", "entity"), ("", "agent")]
+
+
+@pytest.mark.parametrize("ch", list("='(),:;[]"))
+def test_escaped_metachar_in_local_part(ch):
+    tokens = list(tokenize(f"ex:na\\{ch}me"))
+    assert tokens[0].kind is TokenKind.NAME
+    assert tokens[0].value == ("ex", f"na{ch}me")
+
+
+def test_percent_encoding_is_kept_verbatim():
+    assert values("ex:a%20b") == [("ex", "a%20b")]
+
+
+def test_stray_dot_raises_with_position():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("ex:abc."))
+    assert (ctx.value.line, ctx.value.column) == (1, 7)
+
+
+def test_escaped_dot_is_kept():
+    assert values(r"ex:abc\.") == [("ex", "abc.")]
+
+
+def test_inner_dot_is_part_of_the_name():
+    assert values("ex:a.b") == [("ex", "a.b")]
+
+
+def test_langtag_only_after_a_string():
+    assert kinds('"a place"@en') == [TokenKind.STRING, TokenKind.LANGTAG]
+    assert values('"a place"@en')[1] == "en"
+    assert kinds("ex:a@b") == [TokenKind.NAME]
+    assert values("ex:a@b") == [("ex", "a@b")]
+
+
+def test_typed_literal_marker_vs_percent_in_name():
+    assert kinds('"1" %% xsd:int') == [
+        TokenKind.STRING,
+        TokenKind.TYPED,
+        TokenKind.NAME,
+    ]
+    assert kinds("ex:%41b") == [TokenKind.NAME]
+
+
+def test_marker_vs_negative_int():
+    assert kinds("-, -5, - 5") == [
+        TokenKind.MARKER,
+        TokenKind.COMMA,
+        TokenKind.INT,
+        TokenKind.COMMA,
+        TokenKind.MARKER,
+        TokenKind.INT,
+    ]
+    assert values("-5")[0] == -5
+
+
+def test_string_escapes_are_decoded():
+    assert values(r'"back\\slash and \"quote\""')[0] == 'back\\slash and "quote"'
+    assert values('"""a "quoted" word\nline two"""')[0] == 'a "quoted" word\nline two'
+    assert values(r'"tab\there"')[0] == "tab\there"
+
+
+def test_qname_literal_with_escape():
+    assert values(r"'ex:we\'ird'")[0] == ("ex", "we'ird")
+
+
+def test_bare_local_name_has_empty_prefix():
+    assert values("e1") == [("", "e1")]
+
+
+def test_line_and_column_tracking():
+    tokens = list(tokenize("entity(\n  ex:e1)"))
+    assert (tokens[0].line, tokens[0].column) == (1, 1)
+    assert (tokens[2].line, tokens[2].column) == (2, 3)
+    assert tokens[-1].kind is TokenKind.EOF
+
+
+@pytest.mark.parametrize(
+    ("text", "line", "column"),
+    [
+        ('"unterminated', 1, 1),
+        ('"""never closed', 1, 1),
+        ("<http://no-close", 1, 1),
+        ("'ex:open", 1, 1),
+        ("entity(\n  ex:e1, ^)", 2, 10),
+        ("ex:a:b", 1, 5),
+        ('"x" %', 1, 5),
+        ("ex:a\\zb", 1, 5),
+    ],
+)
+def test_malformed_input_reports_position(text, line, column):
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize(text))
+    assert (ctx.value.line, ctx.value.column) == (line, column)
+    assert f"line {line}, column {column}" in str(ctx.value)
+
+
+def test_unicode_names_and_strings():
+    assert values("ex:café") == [("ex", "café")]
+    assert values('"日本語"') == ["日本語"]
+
+
+def test_escaped_colon_at_end_of_local_part():
+    assert values(r"ex:a\:") == [("ex", "a:")]
+
+
+def test_unknown_string_escape_raises():
+    with pytest.raises(ProvNSyntaxError, match="unknown string escape"):
+        list(tokenize(r'"\q"'))
+
+
+def test_invalid_qname_literal_raises():
+    with pytest.raises(ProvNSyntaxError, match="invalid qualified name"):
+        list(tokenize("'not a qname'"))
+
+
+def test_invalid_language_tag_raises():
+    with pytest.raises(ProvNSyntaxError, match="invalid language tag"):
+        list(tokenize('"a"@'))

--- a/src/prov/tests/test_provn_lexer.py
+++ b/src/prov/tests/test_provn_lexer.py
@@ -2,6 +2,10 @@
 lexical productions). Table-driven: one case per token class and one per
 boundary that a hand-written lexer gets wrong."""
 
+import copy
+import pickle
+import time
+
 import pytest
 
 from prov.serializers.provn_lexer import ProvNSyntaxError, TokenKind, tokenize
@@ -214,3 +218,109 @@ def test_qname_literal_error_position_is_the_first_invalid_character():
     with pytest.raises(ProvNSyntaxError) as ctx:
         list(tokenize("'ex:bad name'"))
     assert (ctx.value.line, ctx.value.column) == (1, 8)
+
+
+def test_huge_integer_raises_instead_of_crashing():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("1" * 5000))
+    assert (ctx.value.line, ctx.value.column) == (1, 1)
+    assert "digits" in str(ctx.value)
+
+
+def test_provn_syntax_error_supports_pickle_and_deepcopy():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize('"unterminated'))
+    original = ctx.value
+
+    # Round-trips a value created immediately above, not external input.
+    restored = pickle.loads(pickle.dumps(original))  # nosec B301 - nosemgrep
+    assert (restored.line, restored.column, restored.message) == (
+        original.line,
+        original.column,
+        original.message,
+    )
+    assert str(restored) == str(original)
+
+    cloned = copy.deepcopy(original)
+    assert (cloned.line, cloned.column, cloned.message) == (
+        original.line,
+        original.column,
+        original.message,
+    )
+    assert str(cloned) == str(original)
+
+
+def test_line_comment_ends_at_cr_not_just_lf():
+    text = "entity(ex:a) // note\rentity(ex:b)"
+    assert values(text) == [
+        ("", "entity"),
+        "(",
+        ("ex", "a"),
+        ")",
+        ("", "entity"),
+        "(",
+        ("ex", "b"),
+        ")",
+    ]
+
+
+def test_crlf_and_lone_cr_each_count_as_one_line_break():
+    crlf_tokens = list(tokenize("a\r\nb"))
+    assert (crlf_tokens[1].line, crlf_tokens[1].column) == (2, 1)
+    cr_tokens = list(tokenize("a\rb"))
+    assert (cr_tokens[1].line, cr_tokens[1].column) == (2, 1)
+
+
+def test_long_run_of_trailing_dots_is_fast():
+    # 200_000 dots isn't large enough to expose the old O(n^2) back-off
+    # loop within a 1s bound on typical hardware (~0.5s pre-fix); 1_000_000
+    # matches the scale the regression was originally measured at (~7-9s
+    # pre-fix) and stays well under 1s with the linear regex-based fix.
+    text = "a" + "." * 1_000_000
+    start = time.perf_counter()
+    with pytest.raises(ProvNSyntaxError):
+        list(tokenize(text))
+    assert time.perf_counter() - start < 1.0
+
+
+@pytest.mark.parametrize("text", ["ex.:abc", "a.b.:c", "ex.:"])
+def test_prefix_cannot_end_in_a_dot(text):
+    dot_column = text.index(".") + 1
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize(text))
+    assert ctx.value.column >= dot_column
+
+
+def test_prefix_with_inner_dot_is_still_accepted():
+    assert values("a.b:c") == [("a.b", "c")]
+
+
+def test_qname_literal_trailing_dot_raises():
+    # Unlike the bare form, this used to succeed silently before _PN_LOCAL
+    # excluded a bare trailing '.'; now _QNAME_FULL simply doesn't match
+    # "ex:abc." and _split_qname reports the dot itself, consistent with
+    # test_qname_literal_error_position_is_the_first_invalid_character.
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("'ex:abc.'"))
+    assert (ctx.value.line, ctx.value.column) == (1, 8)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        chr(0x664) + chr(0x662),  # Arabic-Indic digits four, two
+        chr(0xFF14) + chr(0xFF12),  # fullwidth digits four, two
+    ],
+)
+def test_non_ascii_digits_are_names_not_integers(text):
+    # These are Unicode Nd but not [0-9]; the grammar's DIGIT is ASCII-only,
+    # so they are ordinary name characters, not an integer literal.
+    assert kinds(text) == [TokenKind.NAME]
+    assert values(text) == [("", text)]
+
+
+def test_iri_allows_non_breaking_space_but_rejects_control_characters():
+    nbsp = chr(0xA0)
+    assert values(f"<http://a/b{nbsp}c>") == [f"http://a/b{nbsp}c"]
+    with pytest.raises(ProvNSyntaxError, match="unterminated IRI"):
+        list(tokenize("<a\x01b>"))

--- a/src/prov/tests/test_provn_lexer.py
+++ b/src/prov/tests/test_provn_lexer.py
@@ -158,15 +158,59 @@ def test_escaped_colon_at_end_of_local_part():
 
 
 def test_unknown_string_escape_raises():
-    with pytest.raises(ProvNSyntaxError, match="unknown string escape"):
+    with pytest.raises(ProvNSyntaxError, match="unknown string escape") as ctx:
         list(tokenize(r'"\q"'))
+    assert (ctx.value.line, ctx.value.column) == (1, 2)
 
 
 def test_invalid_qname_literal_raises():
-    with pytest.raises(ProvNSyntaxError, match="invalid qualified name"):
+    with pytest.raises(ProvNSyntaxError, match="invalid qualified name") as ctx:
         list(tokenize("'not a qname'"))
+    assert (ctx.value.line, ctx.value.column) == (1, 5)
 
 
 def test_invalid_language_tag_raises():
     with pytest.raises(ProvNSyntaxError, match="invalid language tag"):
         list(tokenize('"a"@'))
+
+
+def test_prefix_only_name_has_empty_local():
+    # [52] permits "PN_PREFIX ':'" alone; the Recommendation's own example
+    # (section 3.6) is entity(bbc:).
+    tokens = list(tokenize("entity(bbc:)"))
+    assert [t.value for t in tokens[:4]] == [
+        ("", "entity"),
+        "(",
+        ("bbc", ""),
+        ")",
+    ]
+
+
+def test_escaped_hyphen_in_local_part():
+    # The Recommendation's own example (section 3.8) is entity(ex:\-).
+    assert values(r"ex:\-") == [("ex", "-")]
+
+
+def test_unterminated_block_comment_raises_with_position():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("entity(ex:e1) /* open"))
+    assert (ctx.value.line, ctx.value.column) == (1, 15)
+    assert "unterminated comment" in str(ctx.value)
+
+
+def test_string_escape_error_position_is_inside_the_literal():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize('"abc \\q def"'))
+    assert (ctx.value.line, ctx.value.column) == (1, 6)
+
+
+def test_string_escape_error_position_spans_lines_in_a_long_string():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize('"""ab\ncd \\q"""'))
+    assert (ctx.value.line, ctx.value.column) == (2, 4)
+
+
+def test_qname_literal_error_position_is_the_first_invalid_character():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        list(tokenize("'ex:bad name'"))
+    assert (ctx.value.line, ctx.value.column) == (1, 8)


### PR DESCRIPTION
Adds prov.serializers.provn_lexer, a hand-written tokeniser for PROV-N covering every lexical production of the Recommendation, with line and column tracking and table-driven tests for each token class and boundary case. First half of the PROV-N parser (#122); the parser itself follows in the next PR.

No public API change yet: ProvNSyntaxError becomes public with the parser.