### PR TITLE
Strict PROV-N output option and prov-convert input format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,9 @@
   and column and resumes at the next statement
 - `prov.serializers.provn.ProvNSyntaxError` (a `ProvException`) reports the line, column
   and expectation of every syntax error
+- `get_provn(strict=True)` and `serialize(format="provn", strict=True)` write `prov:mentionOf`
+  instead of the bare `mentionOf` keyword, so the output parses under the strict profile;
+  the default output is unchanged
 
 ### Performance
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@
 - `get_provn(strict=True)` and `serialize(format="provn", strict=True)` write `prov:mentionOf`
   instead of the bare `mentionOf` keyword, so the output parses under the strict profile;
   the default output is unchanged
+- `prov-convert` gains `-i/--input-format`, so it reads PROV-N (or any other registered
+  format), not only PROV-JSON
 
 ### Performance
 

--- a/docs/howto/cli.md
+++ b/docs/howto/cli.md
@@ -6,28 +6,25 @@ renders it as an image. `prov-compare` checks two documents for equivalence. Bot
 
 ## `prov-convert`
 
-Convert a PROV-JSON document to PROV-N, PROV-XML, PROV-O (RDF), PROV-JSONLD, or any image
-format Graphviz supports.
+Convert a PROV document between PROV-JSON, PROV-N, PROV-XML, PROV-O (RDF) and PROV-JSONLD,
+or render it as any image format Graphviz supports.
 
 ### Synopsis
 
 ```bash
-prov-convert [-h] [-f FORMAT] [-V] [infile] [outfile]
+prov-convert [-h] [-i INPUT_FORMAT] [-f FORMAT] [-V] [infile] [outfile]
 ```
 
 ### Options
 
 | Flag | Argument | Default | Meaning |
 | --- | --- | --- | --- |
+| `-i`, `--input-format` | `INPUT_FORMAT` | `json` | Input format: `json`, `xml`, `rdf`, `jsonld` or `provn` |
 | `-f`, `--format` | `FORMAT` | `json` | Output format: `json`, `xml`, `rdf`, `jsonld`, `provn`, or any Graphviz output format such as `svg`, `pdf` or `png` |
 | `-V`, `--version` | | | Print the version and exit |
 | `-h`, `--help` | | | Print usage and exit |
-| `infile` | | stdin | Input file, always read as PROV-JSON |
+| `infile` | | stdin | Input file, read in `--input-format` |
 | `outfile` | | stdout | Output file, written in `--format` |
-
-There is no flag for the input format. The input is always read as PROV-JSON. To convert
-from another format, load the document in Python and serialize it with
-{py:meth}`~prov.model.ProvDocument.serialize`, as the format guides show.
 
 Image formats need the `dot` extra and a local Graphviz install. See {doc}`graphics`.
 
@@ -37,6 +34,12 @@ Convert a PROV-JSON file to PROV-N:
 
 ```bash
 prov-convert -f provn document.json document.provn
+```
+
+Convert a PROV-N file to PROV-JSON:
+
+```bash
+prov-convert -i provn -f json document.provn document.json
 ```
 
 Convert a PROV-JSON file to an SVG diagram:
@@ -80,8 +83,8 @@ prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] [file1] [file2]
 
 | Flag | Argument | Default | Meaning |
 | --- | --- | --- | --- |
-| `-f`, `--format1` | `FORMAT1` | `json` | Format of `file1`: `json`, `xml`, `rdf` or `jsonld` |
-| `-F`, `--format2` | `FORMAT2` | `json` | Format of `file2`: `json`, `xml`, `rdf` or `jsonld` |
+| `-f`, `--format1` | `FORMAT1` | `json` | Format of `file1`: `json`, `xml`, `rdf`, `jsonld` or `provn` |
+| `-F`, `--format2` | `FORMAT2` | `json` | Format of `file2`: `json`, `xml`, `rdf`, `jsonld` or `provn` |
 | `-V`, `--version` | | | Print the version and exit |
 | `-h`, `--help` | | | Print usage and exit |
 | `file1`, `file2` | | | The two files to compare |

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -507,8 +507,15 @@ class ProvBundle:
         """
         raise ProvException("A PROV bundle does not contain sub-bundles")
 
-    def get_provn(self, _indent_level: int = 0) -> str:
-        """Return the PROV-N representation of the bundle."""
+    def get_provn(self, _indent_level: int = 0, strict: bool = False) -> str:
+        """Return the PROV-N representation of the bundle.
+
+        Args:
+            _indent_level: Indentation level for nested bundles.
+            strict: Write ``prov:mentionOf`` instead of the bare
+                ``mentionOf`` keyword so the output parses under the strict
+                PROV-N profile.
+        """
         indentation = "" + ("  " * _indent_level)
         newline = "\n" + ("  " * (_indent_level + 1))
 
@@ -538,10 +545,13 @@ class ProvBundle:
             lines.append("")
 
         #  adding all the records
-        lines.extend([record.get_provn() for record in self._records])
+        lines.extend([record.get_provn(strict=strict) for record in self._records])
         if self.is_document():
             # Print out bundles
-            lines.extend(bundle.get_provn(_indent_level + 1) for bundle in self.bundles)
+            lines.extend(
+                bundle.get_provn(_indent_level + 1, strict=strict)
+                for bundle in self.bundles
+            )
         provn_str = newline.join(lines) + "\n"
 
         #  closing the structure

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -958,8 +958,14 @@ class ProvRecord:
     def __str__(self) -> str:
         return self.get_provn()
 
-    def get_provn(self) -> str:
-        """Return the PROV-N representation of the record."""
+    def get_provn(self, strict: bool = False) -> str:
+        """Return the PROV-N representation of the record.
+
+        Args:
+            strict: Write ``prov:mentionOf`` instead of the bare
+                ``mentionOf`` keyword so the output parses under the strict
+                PROV-N profile.
+        """
         items = []
 
         # Generating identifier
@@ -1007,11 +1013,13 @@ class ProvRecord:
             # .format(), not an f-string: the nested string literals reuse the
             # same quote character, which f-strings only allow from py3.12 (PEP 701)
             items.append("[{}]".format(", ".join(extra)))
-        prov_n = "{}({}{})".format(
-            PROV_N_MAP[self.get_type()],
-            relation_id,
-            ", ".join(items),
-        )
+        keyword = PROV_N_MAP[self.get_type()]
+        if strict and self.get_type() == PROV_MENTION:
+            # The Recommendation grammar has no Mention; PROV-Links writes it
+            # as prov:mentionOf. The default keeps the bare keyword ProvToolbox
+            # reads (#248).
+            keyword = "prov:mentionOf"
+        prov_n = "{}({}{})".format(keyword, relation_id, ", ".join(items))
         return prov_n
 
     def is_element(self) -> bool:

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -101,7 +101,7 @@ USAGE
             dest="format1",
             action="store",
             default="json",
-            help="File 1's format: json, xml, rdf or jsonld",
+            help="File 1's format: json, xml, rdf, jsonld or provn",
         )
         parser.add_argument(
             "-F",
@@ -109,7 +109,7 @@ USAGE
             dest="format2",
             action="store",
             default="json",
-            help="File 2's format: json, xml, rdf or jsonld",
+            help="File 2's format: json, xml, rdf, jsonld or provn",
         )
         parser.add_argument(
             "-V", "--version", action="version", version=program_version_message

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-convert -- Convert PROV-JSON to RDF, PROV-N, PROV-XML, or graphical formats (SVG, PDF, PNG)
+convert -- Convert a PROV document between PROV-JSON, PROV-N, PROV-XML, PROV-O, PROV-JSONLD and graphical formats
 
 @author:     Trung Dong Huynh
 
@@ -84,30 +84,41 @@ class CLIError(Exception):
         return self.msg
 
 
-def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> None:
+def convert_file(
+    infile: io.FileIO,
+    outfile: io.FileIO,
+    output_format: str,
+    input_format: str = "json",
+) -> None:
     """Read a PROV document from ``infile`` and write it to ``outfile`` in ``output_format``.
 
-    ``infile`` is always read as PROV-JSON, the default format of
-    :meth:`~prov.model.ProvDocument.deserialize`. For
-    ``output_format``, ``"provn"`` is written directly via
+    ``infile`` is read in ``input_format`` (default PROV-JSON) through
+    :meth:`~prov.model.ProvDocument.deserialize`. For ``output_format``,
+    ``"provn"`` is written directly via
     :meth:`~prov.model.ProvDocument.get_provn`, a name in
     :data:`GRAPHVIZ_SUPPORTED_FORMATS` is rendered through
     :func:`~prov.dot.prov_to_dot` and Graphviz, and any other format is
     delegated to :meth:`~prov.model.ProvDocument.serialize`.
 
     Args:
-        infile: File-like object to read the source document from.
+        infile: File-like object (opened in binary mode) to read the source
+            document from.
         outfile: File-like object (opened in binary mode) to write the
             converted output to.
         output_format: Target format name (e.g. ``"json"``, ``"xml"``,
             ``"rdf"``, ``"jsonld"``, ``"provn"``, or a Graphviz output format such as
             ``"svg"``/``"pdf"``/``"png"``).
+        input_format: Source format name, any registered serializer format.
 
     Raises:
-        CLIError: If ``output_format`` is not ``"provn"``, not a Graphviz
+        CLIError: If ``input_format`` is not a registered serializer format,
+            or if ``output_format`` is not ``"provn"``, not a Graphviz
             format, and not a registered serializer format.
     """
-    prov_doc = ProvDocument.deserialize(infile)
+    try:
+        prov_doc = ProvDocument.deserialize(infile, format=input_format)
+    except serializers.DoNotExist as e:
+        raise CLIError(f'Input format "{input_format}" is not supported.') from e
 
     # Formats not supported by prov.serializers
     if output_format == "provn":
@@ -132,9 +143,9 @@ def convert_file(infile: io.FileIO, outfile: io.FileIO, output_format: str) -> N
 def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     """Run the ``prov-convert`` command-line tool.
 
-    Parses ``-f/--format``, an optional input file (default stdin), and an
-    optional output file (default stdout), then converts between them via
-    :func:`convert_file`.
+    Parses ``-f/--format``, ``-i/--input-format``, an optional input file
+    (default stdin), and an optional output file (default stdout), then
+    converts between them via :func:`convert_file`.
 
     Args:
         argv: Extra command-line arguments. If not ``None``, they are
@@ -178,6 +189,14 @@ USAGE
             description=program_license, formatter_class=RawDescriptionHelpFormatter
         )
         parser.add_argument(
+            "-i",
+            "--input-format",
+            dest="input_format",
+            action="store",
+            default="json",
+            help="input format: json, xml, rdf, jsonld or provn",
+        )
+        parser.add_argument(
             "-f",
             "--format",
             dest="format",
@@ -185,9 +204,11 @@ USAGE
             default="json",
             help="output format: json, xml, rdf, jsonld, provn, or a Graphviz output format (e.g. svg, pdf, png)",
         )
-        parser.add_argument("infile", nargs="?", type=FileType("r"), default=sys.stdin)
         parser.add_argument(
-            "outfile", nargs="?", type=FileType("wb"), default=sys.stdout
+            "infile", nargs="?", type=FileType("rb"), default=sys.stdin.buffer
+        )
+        parser.add_argument(
+            "outfile", nargs="?", type=FileType("wb"), default=sys.stdout.buffer
         )
         parser.add_argument(
             "-V", "--version", action="version", version=program_version_message
@@ -197,7 +218,12 @@ USAGE
         try:
             # Process arguments
             args = parser.parse_args()
-            convert_file(args.infile, args.outfile, args.format.lower())
+            convert_file(
+                args.infile,
+                args.outfile,
+                args.format.lower(),
+                args.input_format.lower(),
+            )
         finally:
             if args:
                 if args.infile:

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -52,13 +52,16 @@ def _external_stacklevel() -> int:
 class ProvNSerializer(Serializer):
     """PROV-N serializer and deserializer for ProvDocument."""
 
-    def serialize(self, stream: io.IOBase, **args: Any) -> None:
+    def serialize(self, stream: io.IOBase, strict: bool = False, **args: Any) -> None:
         """Serialize ``self.document`` to `PROV-N <http://www.w3.org/TR/prov-n/>`_.
 
         Args:
             stream: Stream to write the output to. Text streams receive the
                 PROV-N text directly; other (binary) streams receive it
                 UTF-8-encoded.
+            strict: Write ``prov:mentionOf`` instead of the bare
+                ``mentionOf`` keyword so the output parses under the strict
+                PROV-N profile.
             **args: Unused; accepted for interface compatibility with
                 :meth:`Serializer.serialize`.
 
@@ -68,7 +71,7 @@ class ProvNSerializer(Serializer):
         if self.document is None:
             raise Exception("No document to serialize")
 
-        provn_content = self.document.get_provn()
+        provn_content = self.document.get_provn(strict=strict)
         stream.write(
             provn_content if _is_text_stream(stream) else provn_content.encode("utf-8")
         )

--- a/src/prov/tests/test_provn_corpus.py
+++ b/src/prov/tests/test_provn_corpus.py
@@ -320,7 +320,7 @@ def _param(subdir: str, excluded: dict[str, str] | None = None):
 def test_prov_n_spec_examples_parse_strictly_and_round_trip(path):
     document = ProvDocument.deserialize(str(path), format="provn", profile="strict")
     reloaded = ProvDocument.deserialize(
-        content=document.get_provn(), format="provn", profile="default"
+        content=document.get_provn(strict=True), format="provn", profile="strict"
     )
     assert reloaded == document
 
@@ -329,7 +329,7 @@ def test_prov_n_spec_examples_parse_strictly_and_round_trip(path):
 def test_prov_dm_spec_examples_parse_strictly_and_round_trip(path):
     document = ProvDocument.deserialize(str(path), format="provn", profile="strict")
     reloaded = ProvDocument.deserialize(
-        content=document.get_provn(), format="provn", profile="default"
+        content=document.get_provn(strict=True), format="provn", profile="strict"
     )
     assert reloaded == document
 

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -200,3 +200,43 @@ def test_mention_bare_keyword_no_prefix():
     # would still satisfy the positive assertion. Do not remove this as dead
     # weight.
     assert "prov:mentionOf" not in provn
+
+
+def _mention_doc():
+    document = _doc()
+    bundle = document.bundle("ex:b")
+    bundle.entity("ex:e0")
+    document.entity("ex:e1")
+    document.mention("ex:e1", "ex:e0", "ex:b")
+    return document
+
+
+def test_default_output_keeps_bare_mention_keyword():
+    assert "\n  mentionOf(ex:e1, ex:e0, ex:b)" in _mention_doc().get_provn()
+
+
+def test_strict_output_writes_prefixed_mention_keyword():
+    provn = _mention_doc().get_provn(strict=True)
+    assert "prov:mentionOf(ex:e1, ex:e0, ex:b)" in provn
+    assert "\n  mentionOf(" not in provn
+
+
+def test_strict_output_parses_under_strict_profile():
+    document = _mention_doc()
+    reloaded = ProvDocument.deserialize(
+        content=document.get_provn(strict=True), format="provn", profile="strict"
+    )
+    assert reloaded == document
+
+
+def test_serialize_strict_matches_get_provn_strict():
+    document = _mention_doc()
+    assert document.serialize(format="provn", strict=True) == document.get_provn(
+        strict=True
+    )
+
+
+def test_strict_flag_changes_nothing_without_a_mention():
+    document = _doc()
+    document.entity("ex:e1", {"ex:k": "v"})
+    assert document.get_provn(strict=True) == document.get_provn()

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -141,7 +141,7 @@ def test_convert_file_raises_cli_error_for_unsupported_format(infile, tmp_path):
 
 
 def test_convert_missing_input_file_exits_2(infile, tmp_path, monkeypatch):
-    # FileType('r') fails to open a nonexistent path *inside argparse*,
+    # FileType('rb') fails to open a nonexistent path *inside argparse*,
     # which calls parser.error() -> sys.exit(2); that SystemExit
     # propagates straight out of main() without being caught by the
     # `except Exception` handler.
@@ -158,7 +158,11 @@ def test_convert_missing_input_file_exits_2(infile, tmp_path, monkeypatch):
 
 def test_convert_version_exits_0(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["prov-convert", "--version"])
-    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    # argparse's --version action exits before argument parsing reaches
+    # infile/outfile, but their defaults (sys.stdin.buffer/sys.stdout.buffer)
+    # are still evaluated when the arguments are added, so stdout needs a
+    # .buffer attribute here too.
+    monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(io.BytesIO()))
     with pytest.raises(SystemExit) as ctx:
         convert_main()
     assert ctx.value.code == 0
@@ -182,7 +186,7 @@ def test_convert_closes_files_even_when_conversion_fails(infile, tmp_path, monke
     outfile = tmp_path / "doc.xml"
     captured = {}
 
-    def spy_convert_file(in_stream, out_stream, output_format):
+    def spy_convert_file(in_stream, out_stream, output_format, input_format="json"):
         captured["infile"] = in_stream
         captured["outfile"] = out_stream
         raise RuntimeError("boom")
@@ -195,6 +199,57 @@ def test_convert_closes_files_even_when_conversion_fails(infile, tmp_path, monke
     assert rc == 2
     assert captured["infile"].closed
     assert captured["outfile"].closed
+
+
+@pytest.fixture
+def provn_infile(tmp_path):
+    path = tmp_path / "doc.provn"
+    primer_example().serialize(str(path), format="provn")
+    return path
+
+
+def test_convert_from_provn(provn_infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prov-convert", "-i", "provn", "-f", "json", str(provn_infile), str(outfile)],
+    )
+    assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
+
+
+def test_convert_from_xml(tmp_path, monkeypatch):
+    pytest.importorskip("lxml")
+    infile = tmp_path / "doc.xml"
+    primer_example().serialize(str(infile), format="xml")
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-i", "xml", str(infile), str(outfile)]
+    )
+    assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
+
+
+def test_convert_unknown_input_format_exits_2(infile, tmp_path, monkeypatch, capsys):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-i", "nope", str(infile), str(outfile)]
+    )
+    assert convert_main() == 2
+    assert "nope" in capsys.readouterr().err
+
+
+def test_convert_reads_provn_from_stdin(provn_infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "doc.json"
+    monkeypatch.setattr(sys, "argv", ["prov-convert", "-i", "provn", "-f", "json"])
+    monkeypatch.setattr(
+        sys, "stdin", io.TextIOWrapper(io.BytesIO(provn_infile.read_bytes()))
+    )
+    with outfile.open("wb") as out:
+        monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(out))
+        assert convert_main() == 0
+    assert ProvDocument.deserialize(str(outfile), format="json") == primer_example()
 
 
 @pytest.fixture
@@ -213,6 +268,21 @@ def test_equivalent_documents_return_0(compare_files, monkeypatch):
         sys,
         "argv",
         ["prov-compare", "-f", "json", "-F", "xml", str(json_file), str(xml_file)],
+    )
+    rc = compare_main()
+    assert rc == 0
+
+
+def test_compare_provn_to_json_returns_0(tmp_path, monkeypatch):
+    provn_file = tmp_path / "doc.provn"
+    json_file = tmp_path / "doc.json"
+    doc = primer_example()
+    doc.serialize(str(provn_file), format="provn")
+    doc.serialize(str(json_file), format="json")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prov-compare", "-f", "provn", "-F", "json", str(provn_file), str(json_file)],
     )
     rc = compare_main()
     assert rc == 0


### PR DESCRIPTION
Two additions on top of the parser. get_provn(strict=True) and serialize(format="provn", strict=True) write prov:mentionOf instead of the bare mentionOf keyword so the output parses under the strict profile; the default output is unchanged byte for byte. prov-convert gains -i/--input-format and reads its input in binary, so PROV-N, PROV-XML, PROV-O and PROV-JSONLD inputs work; previously it read PROV-JSON only. prov-compare's --format1/--format2 help text now lists provn alongside the other formats, and a new test compares a PROV-N file against its PROV-JSON equivalent.