### PR TITLE
Cache qualified-name resolution in NamespaceManager

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,9 +25,10 @@
 ### Performance
 
 - `NamespaceManager` caches string-to-`QualifiedName` resolutions per manager, cleared
-  whenever a namespace is added or the default namespace changes, so building or
-  deserialising a document no longer re-resolves the same identifier text for every
-  record that mentions it
+  whenever a namespace is added or the default namespace changes, so deserialising a
+  document no longer re-resolves the same identifier text for every record that mentions
+  it (PROV-O deserialisation about 9% faster on the benchmark suite; construction through
+  the API is unchanged, as its cost lies elsewhere)
 
 ### Fixes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,11 @@
 
 ### Performance
 
+- `NamespaceManager` caches string-to-`QualifiedName` resolutions per manager, cleared
+  whenever a namespace is added or the default namespace changes, so building or
+  deserialising a document no longer re-resolves the same identifier text for every
+  record that mentions it
+
 ### Fixes
 
 - PROV-N output escapes a leading `-` or `.` and a trailing `.` in a local part, as the

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -40,6 +40,10 @@ class NamespaceManager(dict[str, Namespace]):
         self.update(self._default_namespaces)
         self._namespaces: dict[str, Namespace] = {}
 
+        # String -> resolved QualifiedName. Cleared by every mutation that can
+        # change how a string resolves: add_namespace() and _set_default().
+        self._resolve_cache: dict[str, QualifiedName] = {}
+
         if default is not None:
             self.set_default_namespace(default)
         else:
@@ -91,8 +95,12 @@ class NamespaceManager(dict[str, Namespace]):
         Args:
             uri: The URI of the default namespace.
         """
-        self._default = Namespace("", uri)
-        self[""] = self._default
+        self._set_default(Namespace("", uri))
+
+    def _set_default(self, namespace: Namespace) -> None:
+        self._default = namespace
+        self[""] = namespace
+        self._resolve_cache.clear()
 
     def get_default_namespace(self) -> Namespace | None:
         """Return the default namespace, or ``None`` if none is set."""
@@ -142,6 +150,7 @@ class NamespaceManager(dict[str, Namespace]):
             namespace = new_namespace
 
         # Only now add the namespace to the registry
+        self._resolve_cache.clear()
         self._namespaces[prefix] = namespace
         self[prefix] = namespace
         self._uri_map[uri] = namespace
@@ -197,24 +206,30 @@ class NamespaceManager(dict[str, Namespace]):
             return None
         # Extract the URI string value if it is an identifier
         str_value = qname.uri if isinstance(qname, Identifier) else qname
+        cached = self._resolve_cache.get(str_value)
+        if cached is not None:
+            return cached
+        resolved = self._resolve_string(str_value, is_plain_str=isinstance(qname, str))
+        if resolved is None and self.parent:
+            # all attempts have failed so far
+            # now delegate this to the parent NamespaceManager
+            resolved = self.parent.valid_qualified_name(qname)
+        if resolved is not None:
+            self._resolve_cache[str_value] = resolved
+        return resolved
+
+    def _resolve_string(
+        self, str_value: str, is_plain_str: bool
+    ) -> QualifiedName | None:
         if str_value.startswith("_:"):
             # this is a blank node ID
             return None
-        elif ":" in str_value:
-            new_qname = self._resolve_prefixed_string(str_value)
-            if new_qname is not None:
-                return new_qname
-        elif self._default and isinstance(qname, str):
+        if ":" in str_value:
+            return self._resolve_prefixed_string(str_value)
+        if self._default and is_plain_str:
             # no colon in the identifier and a default namespace is defined,
             # create and return a qualified name in the default namespace
-            return self._default[qname]
-
-        if self.parent:
-            # all attempts have failed so far
-            # now delegate this to the parent NamespaceManager
-            return self.parent.valid_qualified_name(qname)
-
-        # Default to FAIL
+            return self._default[str_value]
         return None
 
     def _reconcile_qualified_name(self, qname: QualifiedName) -> QualifiedName:
@@ -225,8 +240,8 @@ class NamespaceManager(dict[str, Namespace]):
         if not prefix:
             # the namespace is a default namespace
             if self._default is None:
-                # no default namespace is defined, reused the one given
-                self._default = namespace
+                # no default namespace is defined, reuse the one given
+                self._set_default(namespace)
                 return qname  # no change, return the original
             elif self._default == namespace:
                 # the same default namespace is defined

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -40,8 +40,10 @@ class NamespaceManager(dict[str, Namespace]):
         self.update(self._default_namespaces)
         self._namespaces: dict[str, Namespace] = {}
 
-        # String -> resolved QualifiedName. Cleared by every mutation that can
-        # change how a string resolves: add_namespace() and _set_default().
+        # Plain str -> QualifiedName this manager resolved itself, never a
+        # result obtained by delegating to a parent. Cleared by every
+        # mutation that can change how a string resolves: add_namespace()
+        # and _set_default().
         self._resolve_cache: dict[str, QualifiedName] = {}
 
         if default is not None:
@@ -204,19 +206,33 @@ class NamespaceManager(dict[str, Namespace]):
         if not isinstance(qname, (str, Identifier)):
             # Only proceed with a string or URI value
             return None
-        # Extract the URI string value if it is an identifier
-        str_value = qname.uri if isinstance(qname, Identifier) else qname
-        cached = self._resolve_cache.get(str_value)
+
+        if not isinstance(qname, str):
+            # An Identifier resolves the same way a plain string does, except
+            # a colon-less value never falls back to the default namespace
+            # (see _resolve_string). It bypasses the cache entirely, both
+            # read and write, because the cache is keyed by string value only
+            # and would otherwise conflate the two.
+            resolved = self._resolve_string(qname.uri, is_plain_str=False)
+            if resolved is None and self.parent:
+                # all attempts have failed so far
+                # now delegate this to the parent NamespaceManager
+                resolved = self.parent.valid_qualified_name(qname)
+            return resolved
+
+        # Plain string input: served from, and written to, this manager's own cache
+        cached = self._resolve_cache.get(qname)
         if cached is not None:
             return cached
-        resolved = self._resolve_string(str_value, is_plain_str=isinstance(qname, str))
-        if resolved is None and self.parent:
-            # all attempts have failed so far
-            # now delegate this to the parent NamespaceManager
-            resolved = self.parent.valid_qualified_name(qname)
+        resolved = self._resolve_string(qname, is_plain_str=True)
         if resolved is not None:
-            self._resolve_cache[str_value] = resolved
-        return resolved
+            self._resolve_cache[qname] = resolved
+            return resolved
+        if self.parent:
+            # all attempts have failed so far; delegate to the parent, but do
+            # not cache a result this manager did not itself resolve
+            return self.parent.valid_qualified_name(qname)
+        return None
 
     def _resolve_string(
         self, str_value: str, is_plain_str: bool

--- a/src/prov/tests/test_namespace_cache.py
+++ b/src/prov/tests/test_namespace_cache.py
@@ -1,6 +1,6 @@
 """The resolve-once cache in NamespaceManager and its invalidation."""
 
-from prov.identifier import Namespace
+from prov.identifier import Identifier, Namespace
 from prov.model import NamespaceManager, ProvDocument
 
 
@@ -41,12 +41,34 @@ def test_implicit_default_from_a_prefixless_qualified_name_uses_the_setter():
     assert manager[""] is manager.get_default_namespace()
 
 
-def test_child_lookup_answered_by_parent_is_invalidated_by_child_change():
+def test_child_lookup_answered_by_parent_is_not_cached_in_the_child():
     document = ProvDocument()
     document.add_namespace("ex", "http://example.org/")
     bundle = document.bundle("ex:b")
     resolved = bundle.valid_qualified_name("ex:e1")
     assert resolved.uri == "http://example.org/e1"
+    assert bundle._namespaces._resolve_cache == {}
     bundle.add_namespace("ex", "http://shadow.org/")
     shadowed = bundle.valid_qualified_name("ex:e1")
     assert shadowed.uri == "http://shadow.org/e1"
+
+
+def test_identifier_input_bypasses_the_cache():
+    # A colon-less Identifier never falls back to the default namespace, so
+    # it must not be able to read (or plant) a cache entry keyed the same as
+    # the plain string that does.
+    manager = NamespaceManager(default="http://example.org/")
+    resolved = manager.valid_qualified_name("e1")
+    assert resolved.uri == "http://example.org/e1"
+    assert manager.valid_qualified_name(Identifier("e1")) is None
+
+
+def test_parent_answered_resolution_is_not_cached_in_the_child():
+    document = ProvDocument()
+    document.set_default_namespace("http://one.org/")
+    bundle = document.bundle("http://one.org/b")
+    resolved = bundle.valid_qualified_name("e1")
+    assert resolved.uri == "http://one.org/e1"
+    assert bundle._namespaces._resolve_cache == {}
+    document.set_default_namespace("http://two.org/")
+    assert bundle.valid_qualified_name("e1").uri == "http://two.org/e1"

--- a/src/prov/tests/test_namespace_cache.py
+++ b/src/prov/tests/test_namespace_cache.py
@@ -1,0 +1,52 @@
+"""The resolve-once cache in NamespaceManager and its invalidation."""
+
+from prov.identifier import Namespace
+from prov.model import NamespaceManager, ProvDocument
+
+
+def test_repeat_lookup_is_served_from_the_cache():
+    manager = NamespaceManager({"ex": "http://example.org/"})
+    first = manager.valid_qualified_name("ex:e1")
+    assert "ex:e1" in manager._resolve_cache
+    assert manager.valid_qualified_name("ex:e1") is first
+
+
+def test_unresolvable_names_are_not_cached():
+    manager = NamespaceManager()
+    assert manager.valid_qualified_name("zz:e1") is None
+    assert "zz:e1" not in manager._resolve_cache
+
+
+def test_adding_a_namespace_clears_the_cache():
+    manager = NamespaceManager({"ex": "http://example.org/"})
+    manager.valid_qualified_name("ex:e1")
+    manager.add_namespace(Namespace("other", "http://other.org/"))
+    assert manager._resolve_cache == {}
+
+
+def test_changing_the_default_clears_the_cache_and_re_resolves():
+    manager = NamespaceManager(default="http://one.org/")
+    first = manager.valid_qualified_name("e1")
+    manager.set_default_namespace("http://two.org/")
+    second = manager.valid_qualified_name("e1")
+    assert first.uri == "http://one.org/e1"
+    assert second.uri == "http://two.org/e1"
+
+
+def test_implicit_default_from_a_prefixless_qualified_name_uses_the_setter():
+    manager = NamespaceManager()
+    qname = Namespace("", "http://implicit.org/")["e1"]
+    manager.valid_qualified_name(qname)
+    assert manager.get_default_namespace().uri == "http://implicit.org/"
+    assert manager[""] is manager.get_default_namespace()
+
+
+def test_child_lookup_answered_by_parent_is_invalidated_by_child_change():
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    bundle = document.bundle("ex:b")
+    resolved = bundle.valid_qualified_name("ex:e1")
+    assert resolved.uri == "http://example.org/e1"
+    bundle.add_namespace("ex", "http://shadow.org/")
+    shadowed = bundle.valid_qualified_name("ex:e1")
+    assert shadowed.uri == "http://shadow.org/e1"


### PR DESCRIPTION
Adds a per-manager cache of string-to-QualifiedName resolutions to NamespaceManager.valid_qualified_name(), cleared whenever a namespace is added or the default namespace changes. Construction through the API does not move measurably (test_construct: -0.5%); the measured benefit is on deserialisation, where the same identifier text recurs across many records: RDF deserialisation is about 9.2% faster, JSON-LD about 4.0% faster, and JSON about 3.4% faster. The two places that set the default namespace now go through one private method, `_set_default()`, so the cache has a single invalidation point.

Benchmarks at N=100000 (M2 Max, Python 3.12):

```
benchmark                                                      baseline    current   change
benchmarks/test_bench.py::test_construct                         0.8748     0.8706   -0.5%
benchmarks/test_bench.py::test_deserialize[json]                 1.3016     1.2575   -3.4%
benchmarks/test_bench.py::test_deserialize[jsonld]               1.7024     1.6346   -4.0%
benchmarks/test_bench.py::test_deserialize[provn]                4.6734     4.6353   -0.8%
benchmarks/test_bench.py::test_deserialize[rdf]                 10.4146     9.4523   -9.2%
benchmarks/test_bench.py::test_deserialize[xml]                  2.3675     2.3639   -0.2%
```

Profiling `build_document(100000)` with cProfile shows `valid_qualified_name` resolves 400014 candidates but only 37575 fall through to string resolution, a 90.6% cache hit rate on the path this PR caches. The uncached cost dominates elsewhere for construction. `_reconcile_qualified_name`, the path for values that arrive as a `QualifiedName` already such as repeated attribute values, accounts for 275000 calls and 0.34s cumulative time on its own, and `QualifiedName`/`Identifier` hashing plus attribute coercion in `records.py` together account for a larger share of construction time than string-based qname resolution does. The cache works as designed; string resolution is just not the bottleneck for `test_construct` at this record mix. Closing that gap is the job of the next two performance PRs in this track.

No public API change; equality and hash semantics unchanged.
