### PR TITLE
Precomputed hashes and __slots__ on identifier and literal classes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,11 @@
   document no longer re-resolves the same identifier text for every record that mentions
   it (PROV-O deserialisation about 9% faster on the benchmark suite; construction through
   the API is unchanged, as its cost lies elsewhere)
+- `Identifier`, `QualifiedName`, `Namespace` and `Literal` declare `__slots__` and
+  `QualifiedName` stores its hash at construction, cutting the cost of the many hash
+  lookups a record's attributes require; the `__slots__` memory saving is offset by the
+  stored hash value each `Identifier`/`QualifiedName` now retains, so overall memory per
+  record is essentially unchanged
 
 ### Fixes
 

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -65,6 +65,8 @@ class Identifier:
     # TODO: make Identifier an "abstract" base class and move xsd:anyURI
     # into a subclass
 
+    __slots__ = ("_hash", "_uri")
+
     def __init__(self, uri: str):
         """Create an identifier for the given URI.
 
@@ -73,6 +75,7 @@ class Identifier:
                 already one.
         """
         self._uri: str = str(uri)  # Ensure this is a unicode string
+        self._hash = hash((self._uri, self.__class__))
 
     @property
     def uri(self) -> str:
@@ -86,7 +89,7 @@ class Identifier:
         return self.uri == other.uri if isinstance(other, Identifier) else False
 
     def __hash__(self) -> int:
-        return hash((self.uri, self.__class__))
+        return self._hash
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self._uri}>"
@@ -107,6 +110,8 @@ class QualifiedName(Identifier):
     hashing, and retrieval of individual components (namespace or local part).
     """
 
+    __slots__ = ("_localpart", "_namespace", "_str")
+
     def __init__(self, namespace: Namespace, localpart: str):
         """
         Initializes a new qualified name with the provided namespace and localpart
@@ -124,6 +129,7 @@ class QualifiedName(Identifier):
         self._str = (
             ":".join([namespace.prefix, localpart]) if namespace.prefix else localpart
         )
+        self._hash = hash(self._uri)
 
     @property
     def namespace(self) -> Namespace:
@@ -142,7 +148,7 @@ class QualifiedName(Identifier):
         return f"<{self.__class__.__name__}: {self._str}>"
 
     def __hash__(self) -> int:
-        return hash(self.uri)
+        return self._hash
 
     def provn_bare_representation(self) -> str:
         """Return the ``prefix:local`` PROV-N form used at IDENTIFIER positions.
@@ -168,6 +174,8 @@ class QualifiedName(Identifier):
 
 class Namespace:
     """PROV Namespace."""
+
+    __slots__ = ("_cache", "_prefix", "_uri")
 
     def __init__(self, prefix: str, uri: str):
         """Create a namespace with the given prefix and URI.

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -395,6 +395,8 @@ class Literal:
     PROV-JSON/PROV-XML rules for language-tagged strings.
     """
 
+    __slots__ = ("_datatype", "_langtag", "_value")
+
     def __init__(
         self,
         value: Any,

--- a/src/prov/tests/test_identifier_slots.py
+++ b/src/prov/tests/test_identifier_slots.py
@@ -1,0 +1,52 @@
+"""__slots__ and precomputed hashes on Identifier, QualifiedName, Namespace
+and Literal: no __dict__, unchanged equality, copy and pickle intact."""
+
+import copy
+import pickle
+
+import pytest
+
+from prov.constants import XSD_INT
+from prov.identifier import Identifier, Namespace
+from prov.model import Literal
+
+NS = Namespace("ex", "http://example.org/")
+OBJECTS = [
+    Identifier("http://example.org/id"),
+    NS,
+    NS["e1"],
+    Literal("1", XSD_INT),
+    Literal("un lieu", langtag="fr"),
+]
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_no_instance_dict(obj):
+    assert not hasattr(obj, "__dict__")
+    with pytest.raises(AttributeError):
+        obj.undeclared = 1
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_copy_and_pickle_preserve_equality(obj):
+    assert copy.copy(obj) == obj
+    assert copy.deepcopy(obj) == obj
+
+    # Round-trips a value created immediately above, not external input.
+    assert pickle.loads(pickle.dumps(obj)) == obj  # nosec B301 - nosemgrep
+
+
+def test_qualified_name_hash_is_stored_and_uri_based():
+    qname = NS["e1"]
+    assert hash(qname) == hash(qname.uri)
+    assert qname._hash == hash(qname)
+
+
+def test_identifier_hash_unchanged():
+    ident = Identifier("http://example.org/e1")
+    assert hash(ident) == hash((ident.uri, Identifier))
+    assert hash(ident) != hash(NS["e1"])  # class-distinguished, as before
+
+
+def test_namespace_cache_still_interns_qualified_names():
+    assert NS["e1"] is NS["e1"]


### PR DESCRIPTION
QualifiedName and Identifier compute their hash once at construction, and Identifier, QualifiedName, Namespace and Literal declare __slots__. Equality, hashing semantics and every public attribute are unchanged; copy, deepcopy and pickle are covered by tests.

Benchmarks at N=100000 (measured locally, second of two runs):

```
benchmark                                                      baseline    current   change
benchmarks/test_bench.py::test_construct                         0.8675     0.8281   -4.5%
benchmarks/test_bench.py::test_equality                          0.6247     0.5744   -8.1%
benchmarks/test_bench.py::test_unified                           1.3970     1.3305   -4.8%
```

Traced heap after build_document(100000): before 132.7 MB, after 133.1 MB. The __slots__ change removes each instance's __dict__, but the stored hash value that QualifiedName and Identifier now retain permanently offsets that saving, since CPython's compact per-class instance dicts (3.11+) are already cheap and a boxed 64-bit hash costs roughly as much as they did. Net memory per record is essentially flat rather than lower; time improves because hashing, which construction and equality both do repeatedly, is now a slot read instead of a function call.