### PR TITLE
prov.dot endpoint warning and PROV-O attribute keys with metacharacters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -53,6 +53,14 @@
 - PROV-N input accepts a bare, unprefixed local name that starts with a digit (for example
   `entity(4567)`), as `PN_LOCAL` allows; the lexer previously read it as an integer literal
   and the parser rejected it as an identifier
+- `prov.dot` warns with `ProvWarning` when a relation's endpoint is unset (it is drawn to a
+  blank node, as before) or when a relation has too few endpoints to draw, instead of
+  staying silent, matching what `prov_to_graph()` does since 3.1.1
+- PROV-O decoding resolves attribute keys against the namespaces declared in the RDF
+  source, so a key whose local part ends in a PROV-N metacharacter (`= ' , : ; [ ]`) under
+  a namespace no identifier uses now reads back; the last generation-time exclusion in the
+  round-trip property test is lifted
+  ([#341](https://github.com/trungdong/prov/issues/341))
 
 ### Tests
 

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -67,16 +67,6 @@ the same one OpenXML and SQL Server use, and reverses it on read, so such names 
 One consequence is that a third-party document whose attribute name already looks like an
 `_xHHHH_` escape is unescaped on read.
 
-### Some attribute keys can fail to round-trip through RDF (RDF, open bug)
-
-An attribute key whose local part ends in one of `= ' , : ; [ ]` can fail to decode from
-PROV-O ([#341](https://github.com/trungdong/prov/issues/341)). rdflib cannot split such an
-IRI into namespace and local part unless another identifier in the same namespace has
-already registered it during decoding, so the failure depends on decode order rather than
-being universal. Attribute values are unaffected, and PROV-N, PROV-JSON and PROV-XML
-round-trip these keys. Unlike the same-identifier limitation, this one remains open for a
-fix. The issue lists the exact conditions.
-
 ## Component 1: Entities and Activities
 
 | Concept (PROV-DM §) | Model class | Factory / alias | PROV-N keyword | JSON | XML | RDF | JSON-LD |

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -13,6 +13,7 @@ References:
 """
 
 import typing
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from html import escape, unescape
@@ -58,6 +59,7 @@ from prov.model import (
     ProvEntity,
     ProvException,
     ProvRecord,
+    ProvWarning,
     sorted_attributes,
 )
 
@@ -458,6 +460,18 @@ def _add_relation(state: _DotRenderState, dot: DotContainer, rec: ProvRecord) ->
         strict=False,
     )
     inferred_types = list(map(INFERRED_ELEMENT_CLASS.get, attr_names))
+    unset = [
+        str(attr_name)
+        for attr_name, node in zip(attr_names[:2], nodes[:2], strict=False)
+        if node is None
+    ]
+    if unset:
+        warnings.warn(
+            f"{rec!r} has no value for {', '.join(unset)}; drawing the "
+            "relation to a blank node",
+            ProvWarning,
+            stacklevel=4,
+        )
     other_attributes = [
         (attr_name, value)
         for attr_name, value in rec.attributes
@@ -467,7 +481,12 @@ def _add_relation(state: _DotRenderState, dot: DotContainer, rec: ProvRecord) ->
     add_nary_elements = len(nodes) > 2 and state.show_nary
     style = DOT_PROV_STYLE[rec.get_type()]
     if len(nodes) < 2:  # too few elements for a relation?
-        return  # cannot draw this
+        warnings.warn(
+            f"Skipping {rec!r}: it has fewer than two element endpoints",
+            ProvWarning,
+            stacklevel=4,
+        )
+        return
 
     if add_nary_elements or add_attribute_annotation:
         formal = list(zip(attr_names, nodes, inferred_types, strict=False))

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -1583,7 +1583,9 @@ class ProvRDFSerializer(Serializer):
         # not "prov:startTime"/"prov:endTime" -- the fall-through-then-
         # reconcile mechanism described here is otherwise unchanged.
         if str(pred_new) in [val.uri for val in state.formal_attributes[subj]]:
-            qname_key = self.document.mandatory_valid_qname(pred_new)  # type: ignore[union-attr]
+            qname_key = self.document.valid_qualified_name(  # type: ignore[union-attr]
+                str(pred_new)
+            ) or self._resolve_iri(str(pred_new), graph)
             state.formal_attributes[subj][qname_key] = obj1
             state.unique_sets[subj][qname_key].append(obj1)
             if len(state.unique_sets[subj][qname_key]) > 1:
@@ -1591,7 +1593,15 @@ class ProvRDFSerializer(Serializer):
                 # by walking every combination in _emit_decoded_records().
                 state.formal_attributes[subj][qname_key] = None
         elif "qualified" not in str(pred_new) and "asInBundle" not in str(pred_new):
-            state.other_attributes.setdefault(subj, []).append((str(pred_new), obj1))
+            key: pm.QualifiedNameCandidate = pred_new
+            if isinstance(pred_new, URIRef):
+                # Resolve against the graph's bindings so a key under a
+                # namespace no identifier has registered yet still splits
+                # at the declared namespace, colon or not (#341).
+                key = self.document.valid_qualified_name(  # type: ignore[union-attr]
+                    str(pred_new)
+                ) or self._resolve_iri(str(pred_new), graph)
+            state.other_attributes.setdefault(subj, []).append((key, obj1))
 
     def _emit_decoded_records(
         self, bundle: pm.ProvBundle, state: "_DecodeState"

--- a/src/prov/tests/strategies.py
+++ b/src/prov/tests/strategies.py
@@ -98,55 +98,6 @@ attr_values = st.one_of(
 )
 
 
-# Attribute keys draw from `local_part` too, but with their *trailing*
-# character restricted -- the failing shape found for #341 is an attribute
-# key whose local part ends in one of `= ' , : ; [ ]`, decoded in a
-# namespace that no *other*, cleanly-splitting qualified name has already
-# registered by that point in decoding. Two separate weaknesses combine to
-# cause it:
-#
-# 1. rdflib's ``compute_qname()`` raises when a #223 metacharacter is the
-#    very last character of an IRI, since nothing follows it to serve as a
-#    local part. Decoding an *identifier* tolerates this: ``_resolve_iri``
-#    falls back to splitting at the last "/" or "#" itself whenever
-#    ``compute_qname()`` raises, so the true namespace still gets
-#    registered from decoding that identifier.
-# 2. Decoding an attribute *key* has no such fallback: its predicate is
-#    resolved via ``mandatory_valid_qname``, reached from
-#    ``ProvRecord.add_attributes`` while emitting decoded records
-#    (``ProvRDFSerializer._emit_decoded_records``), which only matches an
-#    *already-registered* namespace. So a key ending in one of those seven
-#    characters -- every #223 metacharacter except `(` and `)` -- fails
-#    outright unless some other qualified name under the same namespace has
-#    already been decoded from an IRI that splits cleanly, registering the
-#    true namespace first.
-#
-# A qualified name whose own local part carries the metacharacter
-# *mid-string* (e.g. "http://example.org/e:0") does not help: rdflib
-# mis-splits it into an over-narrow namespace ("http://example.org/e:")
-# instead of raising, so it never registers the true one -- but it does no
-# active harm either, since a clean sibling elsewhere in the same namespace
-# still rescues the key regardless. This excludes only the shape that
-# actually fails: identifiers, mid-string occurrences in other keys, and
-# QualifiedName *values* are all unaffected and keep full #223/#294
-# coverage. `(` and `)` are unaffected too -- rdflib splits them correctly
-# regardless of position -- so they stay reachable as key endings. Excluding
-# trailing-metacharacter key endings entirely is slightly more conservative
-# than the true rule (such a key is actually safe whenever its namespace
-# happens to already be registered), but the generator cannot guarantee that
-# in general, so this is a generation-validity narrowing, not a serializer
-# change.
-_KEY_SAFE_ENDING = string.ascii_lowercase + string.digits + "()"
-
-attribute_key_part = st.builds(
-    lambda body, ending: body + ending,
-    body=st.text(
-        alphabet=string.ascii_lowercase + string.digits + "='(),:;[]", max_size=7
-    ),
-    ending=st.text(alphabet=_KEY_SAFE_ENDING, min_size=1, max_size=1),
-)
-
-
 def _attribute_dict(draw) -> list[tuple[str, object]]:
     """Draw a list of ``(ex:<key>, value)`` other-attribute pairs.
 
@@ -154,7 +105,7 @@ def _attribute_dict(draw) -> list[tuple[str, object]]:
     drawn (possibly differently-typed) value: mixed-datatype attribute sets
     now round-trip through RDF with their asserted datatypes intact (#218).
     """
-    keys = draw(st.lists(attribute_key_part, min_size=0, max_size=4, unique=True))
+    keys = draw(st.lists(local_part, min_size=0, max_size=4, unique=True))
     pairs: list[tuple[str, object]] = []
     for key in keys:
         name = f"ex:k{key}"

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -226,3 +226,29 @@ def test_quoted_label_escapes_double_quote():
 
     assert 'label="ex:e\\"1"' in dot_text
     assert len(dot.create(format="svg")) > 0
+
+
+def test_unset_endpoint_is_drawn_to_a_blank_node_with_a_warning():
+    from prov.model import ProvWarning
+
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.generation(entity="ex:e1", activity=None)
+    with pytest.warns(ProvWarning, match=r"Generation.*prov:activity") as record:
+        dot = prov_to_dot(document)
+    assert sum(issubclass(w.category, ProvWarning) for w in record) == 1
+    assert len(dot.get_edges()) == 1
+
+
+def test_complete_relation_draws_without_warning():
+    import warnings
+
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.entity("ex:e1")
+    document.activity("ex:a1")
+    document.wasGeneratedBy("ex:e1", "ex:a1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        prov_to_dot(document)

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -1253,3 +1253,25 @@ def test_unmapped_subject_still_warns_and_is_named():
     message = str(user_warnings[0].message)
     assert "http://example.org/orphan" in message
     assert "http://example.org/e1" not in message
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda d: d.entity("ex:e0", {"ex2:k:": ""}),
+        lambda d: d.entity("ex:e0", {"ex2:k=": ""}),
+        lambda d: (
+            d.entity("ex:e:0", {"ex:k:": ""}),
+            d.activity("ex:a:0"),
+            d.agent("ex:g'0"),
+        ),
+    ],
+    ids=["key-colon-unshared-ns", "key-equals-unshared-ns", "issue-341-falsifier"],
+)
+def test_metachar_attribute_keys_round_trip_through_provo(build):
+    document = ProvDocument()
+    document.add_namespace("ex", "http://example.org/")
+    document.add_namespace("ex2", "http://example2.org/")
+    build(document)
+    content = document.serialize(format="rdf")
+    assert ProvDocument.deserialize(content=content, format="rdf") == document


### PR DESCRIPTION
Two follow-ups from 3.1.1. prov.dot now warns with ProvWarning when it draws a relation whose endpoint is unset (the blank-node rendering is unchanged) or skips one with too few endpoints, matching prov_to_graph(). The PROV-O decoder resolves extra attribute keys through the same graph-binding-aware resolver identifiers already use, so a key whose local part ends in a PROV-N metacharacter under a namespace no identifier has registered yet reads back; the last generation-time exclusion in the Hypothesis round-trip test is lifted and the conformance page's caveat removed. Closes #341 and #434.