### PR TITLE
planning: 3.2.1 point release spec and plan

### DIFF
--- a/planning/plans/2026-09-12-release-3.2.1.md
+++ b/planning/plans/2026-09-12-release-3.2.1.md
@@ -1,0 +1,1110 @@
+# Release 3.2.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship prov 3.2.1, a point release correcting five things a by-eye verification of the 3.2.0 PROV-N parser found: the `default` profile's shorthand keywords, the lenient profile's warning count, the PROV-XML reader's handling of a nested reference, the PROV-JSONLD reader's rejection of an array-valued Membership `entity`, and the PROV-N spelling of booleans.
+
+**Architecture:** Every task is a fix with tests, a changelog line and, where a shipped document describes the behaviour, the matching doc edit. No public names change. Each task is one focused PR off `main`, merged on green CI, in the order given; Task 6 stamps the release and Task 7 publishes it by the runbook in `docs/releasing.md`.
+
+**Tech Stack:** Python 3.10+, `uv`, pytest, mypy `--strict`, ruff, lxml, Sphinx/MyST, GitHub Actions, `gh` CLI, Codacy CLI.
+
+**Spec:** `planning/specs/2026-09-12-release-3.2.1-design.md`. Findings source: `~/projects/ProvPy/prov-verification/findings.md` (outside the repository).
+
+## Global Constraints
+
+- **Point release only.** No new public names, no signature changes on public methods, no dependency or Python-floor changes. `ADDITIONAL_N_MAP` in `prov/constants.py` is public (frozen by `test_public_api.py`) and stays.
+- **Branching and PRs.** Every task branches from up-to-date `origin/main`, opens one PR, and merges only on green CI (`gh pr checks <n> --watch`). Merge with `gh pr merge <n> --merge --delete-branch`; never squash. Confirm the repo and branch before every git command.
+- **Suite invariant.** Baseline on `main` @ 84e363d: **2439 passed, 26 skipped, 191 xfailed** (`uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx`). Each task states its expected delta. A skip or xfail that is new, gone, or unexplained is a regression.
+- **Every code task adds its `HISTORY.md` bullet** under `## 3.2.1 (unreleased)` › `### Fixes`, which Task 1 creates. British English, one bullet per behaviour change, no plan or task references.
+- **Quality gates per code PR:** `uv run mypy src`, `uv run ruff check src/ benchmarks/`, `uv run ruff format --check src/ benchmarks/`, full suite green, `codacy-analysis analyze --files <changed files>` reporting `0 issues found` (Markdown files included).
+- **Commit and PR text.** No AI attribution lines. Paragraphs unwrapped (one line each). British English, no em dashes. Shipped docs describe the change by release, never by task.
+- **Code comments** stay present-state; no history of the 3.2.0 behaviour in comments beyond what prevents a regression.
+
+**User decisions (already made):**
+- All nine shorthand keywords leave the `default` profile, including `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource`.
+- The XML reader descends into a nested `prov:ref` child with a `ProvWarning`; it raises `ProvXMLException` only when neither a reference nor text is present.
+- PROV-N booleans are written `"true"`/`"false"`.
+- The memory figure (about 4 KiB per statement) goes into `docs/howto/provn.md`.
+- The 3.2.0 GitHub release body is not edited; the 3.2.1 notes carry the correction.
+- The findings are not filed as GitHub issues.
+
+---
+
+## PR map
+
+| PR | Task | Branch |
+|---|---|---|
+| A | 0 | `planning/release-3.2.1` |
+| B | 1 | `fix/provn-default-profile` |
+| C | 2 | `fix/provn-lenient-resync` |
+| D | 3 | `fix/xml-nested-reference` |
+| E | 4 | `fix/jsonld-membership-array` |
+| F | 5 | `fix/provn-boolean-words` |
+| G | 6 | `release/3.2.1` |
+| – | 7 | release operations on `main` |
+
+---
+
+### Task 0: Land the spec and this plan
+
+**Goal:** `main` contains the approved spec and this plan, so every later branch starts from a `main` that carries both.
+
+**Files:**
+- Create: `planning/specs/2026-09-12-release-3.2.1-design.md` (already written)
+- Create: `planning/plans/2026-09-12-release-3.2.1.md` (this file)
+
+**Acceptance Criteria:**
+- [ ] Both files are on `main` via a merged PR
+- [ ] `codacy-analysis analyze --files planning/specs/2026-09-12-release-3.2.1-design.md planning/plans/2026-09-12-release-3.2.1.md` reports `0 issues found`
+- [ ] `planning/plans/2026-09-12-release-3.2.1.md.tasks.json` is not committed (gitignored)
+
+**Verify:** `gh pr view <n> --json state --jq .state` → `MERGED`
+
+**Steps:**
+
+- [ ] **Step 1: Branch and run the Markdown gate**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only
+git switch -c planning/release-3.2.1
+codacy-analysis analyze --files planning/specs/2026-09-12-release-3.2.1-design.md planning/plans/2026-09-12-release-3.2.1.md
+```
+
+Expected: `0 issues found`. Fix any markdownlint finding (line length is not enforced; list indentation and heading spacing are).
+
+- [ ] **Step 2: Commit and open the PR**
+
+```bash
+git add planning/specs/2026-09-12-release-3.2.1-design.md planning/plans/2026-09-12-release-3.2.1.md
+git commit -m "docs(planning): spec and plan for the 3.2.1 point release"
+git push -u origin planning/release-3.2.1
+gh pr create --title "planning: 3.2.1 point release spec and plan" --body "Design spec and implementation plan for 3.2.1, the point release that corrects what the by-eye verification of the 3.2.0 PROV-N parser found: the default profile's shorthand keywords, the lenient profile's warning count, the PROV-XML reader's handling of a nested reference, the PROV-JSONLD reader's rejection of an array-valued Membership entity, and the PROV-N boolean spelling.
+
+Planning documents only; no code changes."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 1: `default` profile accepts only the bare `mentionOf` extension
+
+**Goal:** The nine shorthand keywords are unknown keywords in every profile; a bare `mentionOf` under `strict` names the strict spelling and the `default` profile in its message; every document that says otherwise is corrected; `HISTORY.md` gains the 3.2.1 section.
+
+**Files:**
+- Modify: `src/prov/serializers/provn_parser.py` (module docstring lines 9-17; `_SHORTHAND` block lines 93-104; `_looks_like_statement_start`; `_classify`; `_expression`; the `PROV` import)
+- Modify: `src/prov/serializers/provn.py:52-56` (`deserialize()` docstring)
+- Modify: `src/prov/tests/test_provn.py:317-321`
+- Modify: `src/prov/tests/test_provn_profiles.py:46-90`
+- Modify: `docs/howto/provn.md:64`
+- Modify: `docs/explanation/architecture.md:95-99`
+- Modify: `HISTORY.md` (new section at the top)
+
+**Acceptance Criteria:**
+- [ ] `parse("person(ex:x)")` raises `ProvNSyntaxError` matching `unknown statement keyword 'person'` under `strict` and `default`, and is skipped with a `ProvWarning` under `lenient`, for all nine keywords
+- [ ] Under `strict`, `mentionOf(ex:e1, ex:e0, ex:b)` raises with a message containing `unknown statement keyword 'mentionOf'`, `prov:mentionOf` and `profile='default'`
+- [ ] `default` still reads bare `mentionOf` to a `ProvMention` (existing `test_default_is_the_default_profile`)
+- [ ] The name `_SHORTHAND` no longer appears under `src/`
+- [ ] No shipped document says the shorthand keywords are accepted or that `prov` or ProvToolbox write them
+- [ ] Suite: baseline minus the 3 removed tests' cases (6 + 3 + 1 = 10 cases) plus the new ones (18 + 9 + 1 = 28), all passing; skips and xfails unchanged
+
+**Verify:** `uv run pytest src/prov/tests/test_provn.py src/prov/tests/test_provn_profiles.py src/prov/tests/test_provn_corpus.py -q` → all pass; `grep -rn _SHORTHAND src/` → no output.
+
+**Steps:**
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c fix/provn-default-profile
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `src/prov/tests/test_provn_profiles.py`, delete everything from the `@pytest.mark.parametrize(("keyword", "base", "asserted"), ...` decorator (line 46) through the end of `test_shorthand_equals_xml_decoding` (line 90) and put this in its place:
+
+```python
+SHORTHAND_KEYWORDS = [
+    "person",
+    "organization",
+    "softwareAgent",
+    "collection",
+    "emptyCollection",
+    "plan",
+    "wasRevisionOf",
+    "wasQuotedFrom",
+    "hadPrimarySource",
+]
+
+
+def _shorthand_statement(keyword):
+    derivation = keyword in ("wasRevisionOf", "wasQuotedFrom", "hadPrimarySource")
+    return f"{keyword}(ex:e2, ex:e1)" if derivation else f"{keyword}(ex:x)"
+
+
+@pytest.mark.parametrize("keyword", SHORTHAND_KEYWORDS)
+@pytest.mark.parametrize("profile", ["strict", "default"])
+def test_typed_shorthand_keywords_are_unknown(keyword, profile):
+    # PROV-XML has typed elements such as <prov:person>; PROV-N has no such
+    # keywords, and neither prov nor ProvToolbox writes them.
+    with pytest.raises(
+        ProvNSyntaxError, match=f"unknown statement keyword '{keyword}'"
+    ):
+        parse(_shorthand_statement(keyword), profile=profile)
+
+
+@pytest.mark.parametrize("keyword", SHORTHAND_KEYWORDS)
+def test_lenient_skips_a_typed_shorthand_keyword(keyword):
+    with pytest.warns(ProvWarning, match=f"unknown statement keyword '{keyword}'"):
+        doc = parse(f"{_shorthand_statement(keyword)}\nentity(ex:e9)", profile="lenient")
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e9"]
+```
+
+In `src/prov/tests/test_provn.py`, replace `test_strict_rejects_bare_mention_and_shorthand` (lines 317-321) with:
+
+```python
+def test_strict_rejects_bare_mention_with_a_hint():
+    with pytest.raises(ProvNSyntaxError) as ctx:
+        parse("mentionOf(ex:e1, ex:e0, ex:b)")
+    assert "unknown statement keyword 'mentionOf'" in ctx.value.message
+    assert "prov:mentionOf" in ctx.value.message
+    assert "profile='default'" in ctx.value.message
+```
+
+(`parse()` in `test_provn.py` uses the `strict` profile; the test it replaces relied on the same.)
+
+- [ ] **Step 3: Run the tests to see them fail**
+
+```bash
+uv run pytest src/prov/tests/test_provn_profiles.py -q -k "shorthand" ; uv run pytest src/prov/tests/test_provn.py -q -k "hint"
+```
+
+Expected: the `default`-profile shorthand cases fail (no exception raised), the `lenient` cases fail (no warning), the hint test fails on the `prov:mentionOf` assertion.
+
+- [ ] **Step 4: Change the parser**
+
+In `src/prov/serializers/provn_parser.py`:
+
+Replace the `Profiles:` list in the module docstring (lines 9-17) with:
+
+```python
+Profiles:
+
+- ``strict``: the Recommendation grammar only.
+- ``default``: also the bare ``mentionOf`` keyword that ``prov`` and
+  ProvToolbox write (the Recommendation grammar has no Mention production;
+  PROV-Links spells it ``prov:mentionOf``), and the ``-`` marker where the
+  grammar has a plain identifier (see ``_STRICT_REQUIRED_LEADING``).
+- ``lenient``: as ``default``; a statement that fails to parse, including
+  one the model rejects, is skipped and parsing resumes at the next
+  statement. Tokenisation errors are fatal in every profile.
+```
+
+Delete the `_SHORTHAND` table and its comment (lines 93-104, from `# default-profile shorthand keyword` to the closing `}`).
+
+Remove `PROV,` from the `from prov.constants import (` list; `_SHORTHAND` was its only user (`uv run ruff check src/` confirms with F401 if it is left).
+
+In `_looks_like_statement_start`, delete the line `or local in _SHORTHAND`.
+
+Replace `_classify` and the first two lines of `_expression`'s body with:
+
+```python
+    def _classify(self, token: Token) -> tuple[QualifiedName, tuple[int, ...], bool]:
+        """Return (record type, arities, is_element) for a keyword token."""
+        prefix, local = token.value
+        extensions = self.profile != "strict"
+        if (prefix, local) == ("prov", "mentionOf") or (
+            extensions and (prefix, local) == ("", "mentionOf")
+        ):
+            return (*_MENTION, False)
+        if prefix:
+            raise self._error(
+                f"extensibility expression '{token.text}(...)' is not supported", token
+            )
+        if local in _ELEMENTS:
+            return (*_ELEMENTS[local], True)
+        if local in _RELATIONS:
+            return (*_RELATIONS[local], False)
+        if local == "mentionOf":
+            # Only reachable under strict; default and lenient matched above.
+            raise self._error(
+                "unknown statement keyword 'mentionOf' under the strict profile: "
+                "write 'prov:mentionOf', or parse with profile='default' to accept "
+                "the bare keyword",
+                token,
+            )
+        raise self._error(f"unknown statement keyword '{local}'", token)
+
+    def _expression(self, bundle: ProvBundle) -> None:
+        keyword = self._expect(TokenKind.NAME, "a statement keyword")
+        rec_type, arities, is_element = self._classify(keyword)
+```
+
+At the end of `_expression`, delete the two lines:
+
+```python
+        if asserted_type is not None:
+            record.add_asserted_type(asserted_type)
+```
+
+and change `record = bundle.new_record(...)` to `bundle.new_record(...)` (the result is no longer used).
+
+In `src/prov/serializers/provn.py`, replace the `profile:` entry of the `deserialize()` docstring (lines 52-56) with:
+
+```python
+            profile: ``"strict"`` (the Recommendation grammar only),
+                ``"default"`` (plus the bare ``mentionOf`` keyword that
+                ``prov`` and ProvToolbox write) or ``"lenient"`` (as
+                ``default``, skipping any statement that fails to parse with
+                a :class:`~prov.model.ProvWarning`).
+```
+
+- [ ] **Step 5: Run the parser tests**
+
+```bash
+uv run pytest src/prov/tests/test_provn.py src/prov/tests/test_provn_profiles.py src/prov/tests/test_provn_corpus.py -q
+uv run ruff check src/ && uv run mypy src
+```
+
+Expected: all pass; ruff clean (if `PROV` is reported unused in `test_provn_profiles.py`, remove that import too); mypy clean.
+
+- [ ] **Step 6: Update the documents**
+
+`docs/howto/provn.md` line 64, the `default` row of the profile table:
+
+```markdown
+| `default` | The grammar plus the bare `mentionOf` keyword that `prov` and ProvToolbox write. The Recommendation has no Mention production; PROV-Links spells it `prov:mentionOf`. |
+```
+
+`docs/explanation/architecture.md`, the sentence starting "The profile selects which keyword table is consulted" (lines 95-98), becomes:
+
+```markdown
+The three profiles share one parser. The profile selects whether the bare `mentionOf`
+keyword that `prov` and ProvToolbox write is accepted alongside the Recommendation's
+keywords, and whether a required-position check rejects `-` where the grammar demands an
+identifier. The `lenient` profile adds panic-mode error
+```
+
+(keep the rest of the paragraph as it is).
+
+`HISTORY.md`: insert above `## 3.2.0 (2026-09-12)`:
+
+```markdown
+## 3.2.1 (unreleased)
+
+3.2.1 is a point release that corrects what a by-eye verification of the 3.2.0 PROV-N
+parser against ProvToolbox and PLEAD documents found: the `default` profile, the
+lenient profile's warnings, the PROV-XML and PROV-JSONLD readers on ProvToolbox output,
+and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
+
+### Fixes
+
+- The `default` PROV-N profile no longer accepts the typed-element and derivation
+  shorthand keywords `person`, `organization`, `softwareAgent`, `collection`,
+  `emptyCollection`, `plan`, `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource`.
+  3.2.0 described them as keywords `prov` and ProvToolbox write; neither does, and
+  ProvToolbox's reader rejects them. `default` is now the Recommendation grammar plus the
+  bare `mentionOf` keyword, which both tools write. A shorthand keyword raises
+  `ProvNSyntaxError` under `strict` and `default` and is skipped with a `ProvWarning`
+  under `lenient`
+- Under the `strict` PROV-N profile, the error for a bare `mentionOf` says that
+  `prov:mentionOf` is the strict spelling and that the `default` profile accepts the bare
+  keyword
+
+```
+
+- [ ] **Step 7: Full gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run ruff format --check src/ benchmarks/
+codacy-analysis analyze --files src/prov/serializers/provn_parser.py src/prov/serializers/provn.py src/prov/tests/test_provn.py src/prov/tests/test_provn_profiles.py docs/howto/provn.md docs/explanation/architecture.md HISTORY.md
+git add -A src docs HISTORY.md
+git commit -m "fix(provn): the default profile accepts only the bare mentionOf extension"
+git push -u origin fix/provn-default-profile
+gh pr create --title "fix(provn): the default profile accepts only the bare mentionOf extension" --body "3.2.0's default PROV-N profile accepted nine shorthand keywords (person, organization, softwareAgent, collection, emptyCollection, plan, wasRevisionOf, wasQuotedFrom, hadPrimarySource) described as keywords prov and ProvToolbox write. Neither writes them: prov's writer emits the base keyword with a prov:type attribute, ProvToolbox's writer does the same, and ProvToolbox 2.0.4's reader discards or fails on every one of them. The list came from ADDITIONAL_N_MAP, a PROV-XML convention for typed elements, not a PROV-N one.
+
+This removes the shorthand table, so default is the Recommendation grammar plus the bare mentionOf keyword both tools do write. The strict-profile error for a bare mentionOf now names prov:mentionOf and the default profile. The how-to, the architecture page, two docstrings and HISTORY.md are corrected; HISTORY.md gains the 3.2.1 section.
+
+Suite: 2457 passed, 26 skipped, 191 xfailed (10 shorthand cases removed, 28 added)."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+Expected suite: 2457 passed, 26 skipped, 191 xfailed.
+
+---
+
+### Task 2: `lenient` warns once per skipped statement
+
+**Goal:** Resynchronisation stops at any name followed by `(`, so consecutive unparsable statements each produce their own `ProvWarning`.
+
+**Files:**
+- Modify: `src/prov/serializers/provn_parser.py` (`_looks_like_statement_start`, `_resync` docstring)
+- Modify: `src/prov/tests/test_provn_profiles.py` (two new tests after `test_lenient_warns_once_per_bad_statement`)
+- Modify: `docs/explanation/architecture.md:99-101` (synchronisation point sentence)
+- Modify: `HISTORY.md` (one bullet under 3.2.1 › Fixes)
+
+**Acceptance Criteria:**
+- [ ] `foo(ex:e2)\nbar(ex:e3)` under `lenient` yields two warnings naming lines 4 and 5 and keywords `foo` and `bar`
+- [ ] Two adjacent `provext:hadMember(...)` statements yield two warnings; the entities around them survive
+- [ ] Every existing `test_lenient_*` test passes unchanged
+- [ ] Suite: Task 1 count plus 2
+
+**Verify:** `uv run pytest src/prov/tests/test_provn_profiles.py -q` → all pass, including the two new tests.
+
+**Steps:**
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c fix/provn-lenient-resync
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append after `test_lenient_warns_once_per_bad_statement` in `src/prov/tests/test_provn_profiles.py`:
+
+```python
+def test_lenient_warns_for_each_of_two_adjacent_unknown_statements():
+    body = "entity(ex:e1)\nfoo(ex:e2)\nbar(ex:e3)\nentity(ex:e4)"
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert [str(w.message) for w in caught] == [
+        "PROV-N statement skipped: line 4, column 1: unknown statement keyword 'foo'",
+        "PROV-N statement skipped: line 5, column 1: unknown statement keyword 'bar'",
+    ]
+    assert sorted(str(r.identifier) for r in records(doc)) == ["ex:e1", "ex:e4"]
+
+
+def test_lenient_warns_for_each_of_two_adjacent_extensibility_expressions():
+    # ProvToolbox's summary documents write runs of provext: statements; each
+    # must be reported, not only the first of a run.
+    body = (
+        "prefix provext <http://openprovenance.org/prov/extension#>\n"
+        "entity(ex:e1)\n"
+        "provext:hadMember(ex:c, ex:e1)\n"
+        "provext:hadMember(ex:c, ex:e2)\n"
+        "entity(ex:e2)"
+    )
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert [str(w.message) for w in caught] == [
+        "PROV-N statement skipped: line 5, column 1: extensibility expression "
+        "'provext:hadMember(...)' is not supported",
+        "PROV-N statement skipped: line 6, column 1: extensibility expression "
+        "'provext:hadMember(...)' is not supported",
+    ]
+    assert sorted(str(r.identifier) for r in records(doc)) == ["ex:e1", "ex:e2"]
+```
+
+- [ ] **Step 3: Run them to see them fail**
+
+```bash
+uv run pytest src/prov/tests/test_provn_profiles.py -q -k "adjacent"
+```
+
+Expected: both fail with one warning captured instead of two.
+
+- [ ] **Step 4: Change the resync boundary**
+
+In `src/prov/serializers/provn_parser.py`, replace `_looks_like_statement_start` with:
+
+```python
+    def _looks_like_statement_start(self, token: Token) -> bool:
+        """A NAME immediately followed by '(' opens a statement.
+
+        No production puts '(' after a name inside a statement body
+        (arguments and attribute values are followed by ',', ']' or ')'),
+        so the pair marks a boundary whatever the name is: a keyword, an
+        unknown keyword or a prefixed extensibility expression. Testing the
+        name against the keyword tables instead would run a skip through
+        every following statement the tables do not know, reporting a run
+        of bad statements as one.
+        """
+        return self._peek().kind is TokenKind.LPAREN
+```
+
+In `_resync`'s docstring, change "so a statement keyword immediately followed by ``(`` is trusted at any depth" to "so a name immediately followed by ``(`` is trusted at any depth".
+
+- [ ] **Step 5: Run the parser tests and gates**
+
+```bash
+uv run pytest src/prov/tests/test_provn.py src/prov/tests/test_provn_profiles.py src/prov/tests/test_provn_corpus.py -q
+uv run ruff check src/ && uv run mypy src
+```
+
+Expected: all pass (the `_lenient_resync_*` tests included), ruff and mypy clean.
+
+- [ ] **Step 6: Documents**
+
+`docs/explanation/architecture.md`, in the profile paragraph, change "reaches a synchronisation point (a statement keyword followed by `(`, or a structural keyword such as `endBundle` at the statement's own bracket depth)" to "reaches a synchronisation point (any name followed by `(`, or a structural keyword such as `endBundle` at the statement's own bracket depth)".
+
+`HISTORY.md`, add under 3.2.1 › Fixes:
+
+```markdown
+- The `lenient` PROV-N profile warns once for every skipped statement. Consecutive
+  unparsable statements, such as a run of `provext:` extensibility expressions, were
+  skipped as one with a single `ProvWarning` naming only the first; resynchronisation
+  now stops at any name followed by `(`, not only at a keyword the parser knows
+```
+
+- [ ] **Step 7: Full gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run ruff format --check src/ benchmarks/
+codacy-analysis analyze --files src/prov/serializers/provn_parser.py src/prov/tests/test_provn_profiles.py docs/explanation/architecture.md HISTORY.md
+git add -A src docs HISTORY.md
+git commit -m "fix(provn): lenient resync stops at any name followed by '('"
+git push -u origin fix/provn-lenient-resync
+gh pr create --title "fix(provn): lenient profile warns once per skipped statement" --body "Under the lenient profile, resynchronisation after a failed statement stopped only at a keyword the parser's tables know. A following statement with an unknown keyword, or a prefixed extensibility expression such as provext:hadMember(...), was swallowed into the same skip, so a run of bad statements produced one ProvWarning naming only the first. On the PLEAD corpus, 39 of 101 files using provext: statements under-reported their skips; the surviving records were correct.
+
+Resynchronisation now stops at any name immediately followed by '(', which no grammar production places inside a statement body. Two tests pin the per-statement warnings for adjacent unknown keywords and adjacent extensibility expressions; the existing resync tests are unchanged.
+
+Suite: 2459 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 3: PROV-XML reader resolves a nested reference and never mints one from whitespace
+
+**Goal:** A reference-valued formal attribute element without `prov:ref` takes the reference from its single `prov:ref` child with a `ProvWarning`, keeps non-blank text as before, and otherwise raises `ProvXMLException`.
+
+**Files:**
+- Modify: `src/prov/serializers/provxml.py` (`_extract_attributes` plain-text branch, lines 632-639; new helper `_nested_reference` after `_extract_attributes`)
+- Modify: `src/prov/tests/test_xml.py` (three new tests at the end)
+- Modify: `HISTORY.md` (one bullet)
+
+**Acceptance Criteria:**
+- [ ] ProvToolbox's `<entity><entity prov:ref="ex:e1"/></entity>` inside `hadMember` decodes to a membership whose entity is `ex:e1`, with one `ProvWarning` whose message contains `nested`
+- [ ] `<entity>   </entity>` inside `hadMember` raises `ProvXMLException` matching `no prov:ref`
+- [ ] `<entity>ex:e1</entity>` inside `hadMember` decodes to entity `ex:e1` without a warning
+- [ ] XML round-trip fixtures unchanged; suite: Task 2 count plus 3
+
+**Verify:** `uv run --extra xml pytest src/prov/tests/test_xml.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c fix/xml-nested-reference
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `src/prov/tests/test_xml.py`:
+
+```python
+def _membership_xml(entity_element: str) -> str:
+    return f"""<document xmlns="http://www.w3.org/ns/prov#"
+        xmlns:prov="http://www.w3.org/ns/prov#"
+        xmlns:ex="http://example.org/">
+      <entity prov:id="ex:c"/>
+      <entity prov:id="ex:e1"/>
+      <hadMember>
+        <collection prov:ref="ex:c"/>
+        {entity_element}
+      </hadMember>
+    </document>"""
+
+
+def test_nested_reference_child_is_used_with_a_warning():
+    # ProvToolbox 2.0.4 wraps a hadMember's member in an extra <entity>
+    # element; the schema puts prov:ref on the element itself.
+    xml_string = _membership_xml('<entity>\n          <entity prov:ref="ex:e1"/>\n        </entity>')
+    with pytest.warns(prov.ProvWarning, match="nested"):
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+    (membership,) = document.get_records(prov.ProvMembership)
+    (member,) = membership.get_attribute(PROV["entity"])
+    assert str(member) == "ex:e1"
+
+
+def test_blank_reference_element_without_ref_raises():
+    xml_string = _membership_xml("<entity>   </entity>")
+    with pytest.raises(ProvXMLException, match="no prov:ref"):
+        prov.ProvDocument.deserialize(content=xml_string, format="xml")
+
+
+def test_reference_given_as_element_text_still_decodes():
+    xml_string = _membership_xml("<entity>ex:e1</entity>")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+    (membership,) = document.get_records(prov.ProvMembership)
+    (member,) = membership.get_attribute(PROV["entity"])
+    assert str(member) == "ex:e1"
+```
+
+- [ ] **Step 3: Run them to see them fail**
+
+```bash
+uv run --extra xml pytest src/prov/tests/test_xml.py -q -k "reference"
+```
+
+Expected: the first fails (no warning, member is a percent-encoded blank), the second fails (no exception), the third passes already.
+
+- [ ] **Step 4: Change the reader**
+
+In `src/prov/serializers/provxml.py`, `_extract_attributes`, replace the block
+
+```python
+        if not subel.attrib:
+            # A plain-text attribute value (no xsi:type/xml:lang/prov:ref):
+            ...
+            _v = subel.text if subel.text is not None else ""
+```
+
+with
+
+```python
+        if not subel.attrib:
+            if _t in PROV_ATTRIBUTE_QNAMES:
+                _v = _nested_reference(subel, _t)
+            else:
+                # A plain-text attribute value (no xsi:type/xml:lang/prov:ref):
+                # lxml reports an empty element's .text as None rather than ""
+                # (e.g. <ex:k0></ex:k0>), which would otherwise make the
+                # attribute vanish entirely once None reaches record
+                # construction. Coalesce back to the empty string (#224). This
+                # does not affect optional formal attributes that are absent
+                # from the XML altogether: those never enter this loop.
+                _v = subel.text if subel.text is not None else ""
+```
+
+Add the helper immediately after `_extract_attributes`:
+
+```python
+def _nested_reference(
+    subel: etree._Element, attr: prov.identifier.QualifiedName
+) -> prov.identifier.QualifiedName | str:
+    """Value of a reference-valued formal attribute element with no ``prov:ref``.
+
+    PROV-XML puts the reference on the element itself
+    (``<prov:entity prov:ref="ex:e1"/>``). ProvToolbox 2.0.4 writes a
+    ``hadMember`` member inside a wrapper,
+    ``<entity><entity prov:ref="ex:e1"/></entity>``; the single child's
+    reference is taken, with a warning. Non-blank text is returned as the
+    reference. A blank element with no reference anywhere has no value.
+
+    Raises:
+        ProvXMLException: If ``subel`` has neither a ``prov:ref`` child nor
+            text.
+
+    Warns:
+        ProvWarning: When the reference is taken from a nested child.
+    """
+    ref = _ns_prov("ref")
+    children = list(subel)
+    if len(children) == 1 and ref in children[0].attrib:
+        warnings.warn(
+            f"The element '{attr}' carries its prov:ref on a nested "
+            f"<{etree.QName(children[0]).localname}> child rather than on "
+            "itself; the nested reference is used. The shape is not "
+            "PROV-XML schema-valid (ProvToolbox writes it for hadMember).",
+            prov.model.ProvWarning,
+            stacklevel=3,
+        )
+        return xml_qname_to_QualifiedName(children[0], children[0].attrib[ref])
+    if subel.text is not None and subel.text.strip():
+        return subel.text
+    raise ProvXMLException(
+        f"The reference element '{attr}' has no prov:ref attribute and no "
+        "reference text."
+    )
+```
+
+Update `_extract_attributes`'s docstring: under `Warns:` add `ProvWarning: When a reference-valued attribute's prov:ref sits on a nested child element (see _nested_reference).`; under `Raises:` add `or if a reference-valued attribute element carries neither a prov:ref nor text.`
+
+- [ ] **Step 5: Run the XML tests and gates**
+
+```bash
+uv run --extra xml pytest src/prov/tests/test_xml.py src/prov/tests/test_statements.py src/prov/tests/test_examples.py -q
+uv run ruff check src/ && uv run mypy src
+```
+
+Expected: all pass; mypy may need `children[0].attrib[ref]` typed as `str` (lxml stubs return `str`); if it reports `bytes | str`, wrap with `str(...)`.
+
+- [ ] **Step 6: Changelog**
+
+`HISTORY.md`, under 3.2.1 › Fixes:
+
+```markdown
+- The PROV-XML deserializer no longer turns a reference element that has no `prov:ref`
+  into an identifier made of its whitespace. ProvToolbox writes a `hadMember` member as
+  `<entity><entity prov:ref="..."/></entity>`; the nested reference is now used, with a
+  `ProvWarning`, and a reference element with neither a `prov:ref` nor text raises
+  `ProvXMLException`
+```
+
+- [ ] **Step 7: Full gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run ruff format --check src/ benchmarks/
+codacy-analysis analyze --files src/prov/serializers/provxml.py src/prov/tests/test_xml.py HISTORY.md
+git add -A src HISTORY.md
+git commit -m "fix(xml): resolve a nested prov:ref child instead of minting an identifier from whitespace"
+git push -u origin fix/xml-nested-reference
+gh pr create --title "fix(xml): resolve a nested prov:ref instead of minting an identifier from whitespace" --body "ProvToolbox 2.0.4 writes a hadMember's member as <entity><entity prov:ref=\"...\"/></entity>, where the PROV-XML schema has a single <prov:entity prov:ref=\"...\"/>. prov's XML reader took the outer element's whitespace text and URL-encoded it into an identifier, producing hadMember(c, %0A%20%20...) with no warning.
+
+A reference-valued formal attribute element without prov:ref now takes the reference from its single prov:ref child with a ProvWarning, keeps non-blank text as before, and raises ProvXMLException when it has neither. prov's own XML output always sets prov:ref, so the round-trip fixtures are unchanged.
+
+Suite: 2462 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 4: PROV-JSONLD reader accepts an array-valued Membership `entity`
+
+**Goal:** A `Membership` statement whose `entity` is an array decodes to one `ProvMembership` per element, as the submission's section 4.18 allows; every other formal attribute keeps the single-value rule.
+
+**Files:**
+- Modify: `src/prov/serializers/provjsonld.py` (`decode_jsonld_statement`, the `from prov.constants import (` list)
+- Modify: `src/prov/tests/test_jsonld.py` (three new tests after `test_deserialize_malformed`)
+- Modify: `HISTORY.md` (one bullet)
+
+**Acceptance Criteria:**
+- [ ] `{"@type": "Membership", "collection": "ex:c", "entity": ["ex:e1", "ex:e2"]}` decodes to a document equal to one with `hadMember("ex:c", "ex:e1")` and `hadMember("ex:c", "ex:e2")`
+- [ ] `"entity": ["ex:e1"]` (ProvToolbox's shape) decodes to one membership
+- [ ] `"entity": []` raises `ProvJSONLDException` matching `empty`
+- [ ] The existing `Generation` array case in `test_deserialize_malformed` still raises with `single`
+- [ ] Suite: Task 3 count plus 3
+
+**Verify:** `uv run pytest src/prov/tests/test_jsonld.py src/prov/tests/test_jsonld_schema.py src/prov/tests/test_jsonld_semantics.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c fix/jsonld-membership-array
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append after `test_deserialize_malformed` in `src/prov/tests/test_jsonld.py`:
+
+```python
+def _membership_payload(entities) -> str:
+    return json.dumps(
+        {
+            "@context": [{"ex": EX_URI}, JSONLD_CONTEXT_URL],
+            "@graph": [
+                {"@type": "Entity", "@id": "ex:c"},
+                {"@type": "Membership", "collection": "ex:c", "entity": entities},
+            ],
+        }
+    )
+
+
+def test_deserialize_membership_entity_array_gives_one_record_per_member():
+    # Submission 4.18: "a single entity or an array of them"; PROV-DM's
+    # hadMember is binary, so the array fans out.
+    doc = ProvDocument.deserialize(content=_membership_payload(["ex:e1", "ex:e2"]), format="jsonld")
+    expected = _new_doc()
+    expected.entity("ex:c")
+    expected.hadMember("ex:c", "ex:e1")
+    expected.hadMember("ex:c", "ex:e2")
+    assert doc == expected
+
+
+def test_deserialize_membership_single_element_array():
+    # ProvToolbox writes the array form even for one member.
+    doc = ProvDocument.deserialize(content=_membership_payload(["ex:e1"]), format="jsonld")
+    expected = _new_doc()
+    expected.entity("ex:c")
+    expected.hadMember("ex:c", "ex:e1")
+    assert doc == expected
+
+
+def test_deserialize_membership_empty_entity_array_raises():
+    with pytest.raises(ProvJSONLDException, match="empty"):
+        ProvDocument.deserialize(content=_membership_payload([]), format="jsonld")
+```
+
+- [ ] **Step 3: Run them to see them fail**
+
+```bash
+uv run pytest src/prov/tests/test_jsonld.py -q -k "membership"
+```
+
+Expected: the first two fail with "takes a single value, not an array"; the third fails with the same message rather than "empty".
+
+- [ ] **Step 4: Change the decoder**
+
+In `src/prov/serializers/provjsonld.py`, add `PROV_ATTR_ENTITY,` and `PROV_MEMBERSHIP,` to the `from prov.constants import (` list (alphabetical position: after `PROV_ATTRIBUTE_LITERALS` insert `PROV_ATTR_ENTITY`; after `PROV_LOCATION` insert `PROV_MEMBERSHIP`).
+
+In `decode_jsonld_statement`, replace the body from `attributes: dict[QualifiedNameCandidate, Any] = {}` to the end of the function with:
+
+```python
+    attributes: dict[QualifiedNameCandidate, Any] = {}
+    other_attributes: list[AttributePair] = []
+    members: list[Any] | None = None
+    for key, value in item.items():
+        if key in ("@type", "@id"):
+            continue
+        attr = formal_by_term.get(_strip_prov_prefix(key))
+        if attr is not None and not isinstance(value, list):
+            if attr in PROV_ATTRIBUTE_LITERALS:
+                attributes[attr] = parse_xsd_datetime(value)
+            else:
+                attributes[attr] = _decode_formal_qname(bundle, value, type_term, key)
+            continue
+        if attr is not None:
+            if rec_type == PROV_MEMBERSHIP and attr == PROV_ATTR_ENTITY:
+                # Submission 4.18: a Membership's entity is "a single entity
+                # or an array of them" (schema QualifiedName+). PROV-DM's
+                # hadMember is binary, so the array becomes one record per
+                # member, below.
+                members = value
+                continue
+            raise ProvJSONLDException(
+                f"The formal attribute {key!r} of {type_term} takes a single "
+                f"value, not an array; found {value!r}"
+            )
+        stripped = _strip_prov_prefix(key)
+        term = stripped if stripped in SPECIAL_TERM_ATTRS else key
+        qname = SPECIAL_TERM_ATTRS.get(term) or bundle.mandatory_valid_qname(key)
+        if not isinstance(value, list):
+            raise ProvJSONLDException(
+                f"The attribute {key!r} must be an array of values; found {value!r}"
+            )
+        other_attributes.extend(
+            (qname, decode_jsonld_value(v, bundle, term)) for v in value
+        )
+    if members is None:
+        bundle.new_record(rec_type, rec_id, attributes, other_attributes)
+        return
+    if not members:
+        raise ProvJSONLDException(
+            f'The "entity" array of {type_term} is empty; found {item!r}'
+        )
+    for member in members:
+        entity = _decode_formal_qname(bundle, member, type_term, "entity")
+        bundle.new_record(
+            rec_type,
+            rec_id,
+            {**attributes, PROV_ATTR_ENTITY: entity},
+            list(other_attributes),
+        )
+```
+
+In the function's docstring `Raises:` clause, change "if a formal attribute's value is an array (formal attributes take a single value)" to "if a formal attribute's value is an array (formal attributes take a single value, except a Membership's ``entity``, which may be a non-empty array and yields one record per member)".
+
+- [ ] **Step 5: Run the JSON-LD tests and gates**
+
+```bash
+uv run pytest src/prov/tests/test_jsonld.py src/prov/tests/test_jsonld_schema.py src/prov/tests/test_jsonld_semantics.py src/prov/tests/test_statements.py -q
+uv run ruff check src/ && uv run mypy src
+```
+
+Expected: all pass, ruff and mypy clean.
+
+- [ ] **Step 6: Changelog**
+
+`HISTORY.md`, under 3.2.1 › Fixes:
+
+```markdown
+- The PROV-JSONLD deserializer accepts an array-valued `entity` on a `Membership`
+  statement, which the submission (section 4.18) allows and ProvToolbox always writes,
+  decoding one `hadMember` per member; an empty array raises `ProvJSONLDException`
+```
+
+- [ ] **Step 7: Full gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run ruff format --check src/ benchmarks/
+codacy-analysis analyze --files src/prov/serializers/provjsonld.py src/prov/tests/test_jsonld.py HISTORY.md
+git add -A src HISTORY.md
+git commit -m "fix(jsonld): decode an array-valued Membership entity as one record per member"
+git push -u origin fix/jsonld-membership-array
+gh pr create --title "fix(jsonld): accept an array-valued Membership entity" --body "The PROV-JSONLD submission (section 4.18) says a Membership contains \"a single entity or an array of them\", and its schema types the property as QualifiedName+. ProvToolbox writes the array form even for one member, so every ProvToolbox JSON-LD document with a hadMember failed to load with \"The formal attribute 'entity' of prov:Membership takes a single value, not an array\".
+
+A Membership whose entity is an array now decodes to one ProvMembership per element, sharing the statement's @id and other attributes; an empty array raises. Every other formal attribute keeps the single-value rule. The encoder is unchanged.
+
+Suite: 2465 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 5: PROV-N output spells booleans `true` and `false`
+
+**Goal:** `encoding_provn_value(True)` returns `"true" %% xsd:boolean` and `False` gives `"false" %% xsd:boolean`; the output still parses back to an equal document.
+
+**Files:**
+- Modify: `src/prov/model/records.py:375-377`
+- Modify: `src/prov/tests/test_provn.py` (one new test after `test_literal_forms`)
+- Modify: `HISTORY.md` (one bullet)
+
+**Acceptance Criteria:**
+- [ ] `get_provn()` of an entity with `True` and `False` attribute values contains `="true" %% xsd:boolean` and `="false" %% xsd:boolean`
+- [ ] The output parses under `strict` to a document equal to the original
+- [ ] `test_literal_forms` still parses `"1" %% xsd:boolean` to `True`
+- [ ] Suite: Task 4 count plus 1
+
+**Verify:** `uv run pytest src/prov/tests/test_provn.py src/prov/tests/test_statements.py src/prov/tests/test_attributes.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c fix/provn-boolean-words
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append after `test_literal_forms` in `src/prov/tests/test_provn.py`:
+
+```python
+def test_writer_spells_booleans_as_words():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1", {"ex:yes": True, "ex:no": False})
+    provn = doc.get_provn()
+    assert 'ex:yes="true" %% xsd:boolean' in provn
+    assert 'ex:no="false" %% xsd:boolean' in provn
+    assert ProvDocument.deserialize(content=provn, format="provn", profile="strict") == doc
+```
+
+(`ProvDocument` is already imported in `test_provn.py`; if not, add `from prov.model import ProvDocument`.)
+
+- [ ] **Step 3: Run it to see it fail**
+
+```bash
+uv run pytest src/prov/tests/test_provn.py -q -k "booleans_as_words"
+```
+
+Expected: fails on the first assertion (`"1"` is written).
+
+- [ ] **Step 4: Change the writer**
+
+In `src/prov/model/records.py`, `encoding_provn_value`, replace
+
+```python
+    elif isinstance(value, bool):
+        # bool is an int subtype, so :d renders "1"/"0" (not "True"/"False")
+        return f'"{value:d}" %% xsd:boolean'
+```
+
+with
+
+```python
+    elif isinstance(value, bool):
+        # Before the int branch: bool is an int subtype. "true"/"false" is
+        # the lexical form every other PROV-N producer writes.
+        return f'"{"true" if value else "false"}" %% xsd:boolean'
+```
+
+and in the function's docstring change "dates and booleans are rendered with their XSD datatype suffix" to "dates are rendered with their XSD datatype suffix and booleans as ``\"true\"``/``\"false\"`` with theirs".
+
+- [ ] **Step 5: Run tests and gates**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+uv run ruff check src/ && uv run ruff format --check src/ benchmarks/ && uv run mypy src
+```
+
+Expected: 2466 passed, 26 skipped, 191 xfailed.
+
+- [ ] **Step 6: Changelog**
+
+`HISTORY.md`, under 3.2.1 › Fixes:
+
+```markdown
+- PROV-N output spells `xsd:boolean` values `"true"` and `"false"` instead of `"1"` and
+  `"0"`. Both are legal lexical forms and the parser reads all four, but every other
+  producer writes the words
+```
+
+- [ ] **Step 7: Commit, PR**
+
+```bash
+codacy-analysis analyze --files src/prov/model/records.py src/prov/tests/test_provn.py HISTORY.md
+git add -A src HISTORY.md
+git commit -m "fix(provn): write xsd:boolean values as true and false"
+git push -u origin fix/provn-boolean-words
+gh pr create --title "fix(provn): write xsd:boolean values as true and false" --body "get_provn() rendered a bool as \"1\" %% xsd:boolean or \"0\" %% xsd:boolean. Both are legal XSD lexical forms and ProvToolbox preserves them, but every producer in the verification corpus and every example in the Recommendations write \"true\" and \"false\", so a reader comparing prov's output with anyone else's saw a spurious difference. The writer now spells the words; the parser is unchanged and no fixture pinned the old spelling.
+
+Suite: 2466 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 6: Stamp 3.2.1
+
+**Goal:** The five stamp files carry 3.2.1 and the release date, the how-to has its "Large documents" section, and `HISTORY.md`'s heading is dated.
+
+**Files:**
+- Modify: `src/prov/__init__.py:14`
+- Modify: `HISTORY.md` (heading)
+- Modify: `ROADMAP.md` (new row after 3.2.0's)
+- Modify: `docs/reference/conformance.md:4-6`
+- Modify: `CITATION.cff:16`
+- Modify: `docs/howto/provn.md` (new section before "Convert on the command line")
+
+**Acceptance Criteria:**
+- [ ] `uv run python -c "import prov; print(prov.__version__)"` → `3.2.1`
+- [ ] `uv run pytest src/prov/tests/test_citation.py -q` passes
+- [ ] `HISTORY.md` reads `## 3.2.1 (YYYY-MM-DD)` with the actual date; `ROADMAP.md` has the 3.2.1 row; `conformance.md`'s revision sentence names 3.2.1
+- [ ] Pre-flight gates from `docs/releasing.md` §1 all green on this branch
+
+**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q | tail -1` → `2466 passed, 26 skipped, 191 xfailed`; `grep -n "3.2.1" src/prov/__init__.py CITATION.cff HISTORY.md ROADMAP.md docs/reference/conformance.md` → five hits.
+
+**Steps:**
+
+- [ ] **Step 1: Branch and pre-flight**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only && git switch -c release/3.2.1
+for py in 3.10 3.11 3.12 3.13 3.14 pypy3.11; do
+    uv run --python $py --extra rdf --extra xml --extra dot --extra graph pytest -q || break
+done
+uv run --python 3.13 --extra rdf --extra xml --extra dot --extra graph mypy src
+uv run ruff check src/ benchmarks/ && uv run ruff format --check src/ benchmarks/
+uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json -q && uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json
+uv build && unzip -l dist/prov-*.whl | grep -E "py.typed|prov-jsonld-context"
+```
+
+Expected: every interpreter green with the same counts; mypy, ruff, own-warnings clean; benchmark comparison without an unexplained regression (the lenient resync change touches only the error path, so the parse benchmarks should be flat); wheel lists both files.
+
+- [ ] **Step 2: Stamp**
+
+`src/prov/__init__.py`: `__version__ = "3.2.1"`.
+`CITATION.cff`: `version: "3.2.1"`.
+`HISTORY.md`: `## 3.2.1 (unreleased)` → `## 3.2.1 (<today, YYYY-MM-DD>)`.
+`ROADMAP.md`: insert after the 3.2.0 row:
+
+```markdown
+| **3.2.1** *(released <YYYY-MM-DD>)* | Point release | Corrections from a by-eye verification of the 3.2.0 PROV-N parser against ProvToolbox and PLEAD documents: the `default` profile is the Recommendation grammar plus the bare `mentionOf` keyword only; the `lenient` profile warns once per skipped statement; the PROV-XML reader resolves ProvToolbox's nested `hadMember` reference; the PROV-JSONLD reader accepts an array-valued Membership `entity`; PROV-N booleans are written `true`/`false`. |
+```
+
+`docs/reference/conformance.md`, lines 4-6, replace "The last revision was for 3.2.0 (2026-09-12), which added the PROV-N round-trip column and closed the last generation-time exclusion in the round-trip property test ([#341](...))." with:
+
+```markdown
+The last revision was for
+3.2.1 (<YYYY-MM-DD>), which narrowed the `default` PROV-N profile to the bare `mentionOf`
+extension; the PROV-N column and corpus results are unchanged from 3.2.0, which added them
+([#341](https://github.com/trungdong/prov/issues/341)).
+```
+
+- [ ] **Step 3: Large-documents note**
+
+In `docs/howto/provn.md`, before `## Convert on the command line`, insert:
+
+```markdown
+## Large documents
+
+The parser tokenises the whole document before it builds any record, so peak memory
+during a parse is about 4 KiB per statement on CPython 3.12: a 100,000-statement,
+7.5 MiB document peaks near 400 MiB. Throughput on a 2023 laptop is on the order of
+20,000 statements per second, and `get_provn()` writes an order of magnitude faster than
+that. Neither figure is a limit, but a document of several million statements needs
+memory to match.
+
+```
+
+- [ ] **Step 4: Gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q | tail -1
+codacy-analysis analyze --files src/prov/__init__.py CITATION.cff HISTORY.md ROADMAP.md docs/reference/conformance.md docs/howto/provn.md
+git add -A
+git commit -m "release: 3.2.1"
+git push -u origin release/3.2.1
+gh pr create --title "Release 3.2.1" --body "Stamps 3.2.1: version, CITATION.cff, HISTORY.md heading, ROADMAP.md row, the conformance page's revision sentence, and a Large documents note in the PROV-N how-to.
+
+3.2.1 corrects what the by-eye verification of the 3.2.0 PROV-N parser found. The default profile is the Recommendation grammar plus the bare mentionOf keyword only (the shorthand keywords 3.2.0 accepted are written by no producer); the lenient profile warns once per skipped statement; the PROV-XML reader resolves ProvToolbox's nested hadMember reference instead of minting an identifier from whitespace; the PROV-JSONLD reader accepts an array-valued Membership entity as the submission allows; PROV-N booleans are written true and false.
+
+Pre-flight per docs/releasing.md section 1 is green on all six interpreters. Suite: 2466 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch && gh pr merge --merge --delete-branch
+```
+
+---
+
+### Task 7: Publish and verify 3.2.1
+
+**Goal:** 3.2.1 is on PyPI, tagged on GitHub with release notes taken from `HISTORY.md`, has a Zenodo DOI, is bumped on conda-forge, and its milestone is closed.
+
+**Files:**
+- None in the repository beyond what Task 6 merged; operations run against `main`.
+
+**Acceptance Criteria:**
+- [ ] `curl -s https://pypi.org/pypi/prov/3.2.1/json` reports version `3.2.1` with `bdist_wheel` and `sdist`, and every entry of `requires_dist` is gated behind an extra
+- [ ] A clean `uv venv` install of `prov==3.2.1` imports and parses `person(ex:x)` under `default` with `ProvNSyntaxError`, and reads ProvToolbox's nested `hadMember` XML from the verification directory's `out/GH.provx` with a `ProvWarning` and no `%0A` identifier
+- [ ] The GitHub release `3.2.1` exists with notes equal to the `HISTORY.md` 3.2.1 section
+- [ ] Zenodo shows a DOI for the `3.2.1` tag
+- [ ] The conda-forge feedstock PR for 3.2.1 is merged (merge in the web UI; the `workflow`-scope 403 from `gh pr merge` is a known trap)
+- [ ] Milestone `3.2.1` exists and is closed
+
+**Verify:** `.v/bin/python -c "import prov; print(prov.__version__)"` → `3.2.1` from the clean venv, and the notebook's cross-check on `GH.provx` no longer prints a `%0A` member.
+
+**Steps:**
+
+- [ ] **Step 1: Dry run to TestPyPI**
+
+```bash
+cd ~/projects/ProvPy/prov && git switch main && git pull --ff-only
+gh workflow run release.yml --repo trungdong/prov --ref main
+sleep 30 && gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch <run-id> --repo trungdong/prov --exit-status
+curl -s https://test.pypi.org/pypi/prov/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+```
+
+Expected: `publish-pypi` skipped, TestPyPI shows `3.2.1`.
+
+- [ ] **Step 2: Cut the release**
+
+Extract the notes from `HISTORY.md` (the `## 3.2.1` section body, without the heading) into `/tmp/notes-3.2.1.md`, then:
+
+```bash
+gh release create 3.2.1 --repo trungdong/prov --target main --title 3.2.1 --notes-file /tmp/notes-3.2.1.md
+sleep 30 && gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch <run-id> --repo trungdong/prov --exit-status
+curl -s "https://zenodo.org/api/records?q=metadata.related_identifiers.identifier:%22https://github.com/trungdong/prov/tree/3.2.1%22" | python3 -c "import json,sys; h=json.load(sys.stdin)['hits']['hits'][0]; print(h['doi'], h['conceptdoi'])"
+```
+
+- [ ] **Step 3: Verify what shipped**
+
+```bash
+curl -s https://pypi.org/pypi/prov/3.2.1/json | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print(d['info']['version'], [u['packagetype'] for u in d['urls']])
+print(d['info']['requires_dist'])"
+cd /tmp && rm -rf .v && uv venv .v && uv pip install --refresh --python .v/bin/python 'prov[xml]==3.2.1'
+.v/bin/python - <<'EOF'
+import warnings
+import prov
+from prov.model import ProvDocument
+from prov.serializers.provn import ProvNSyntaxError
+print(prov.__version__)
+try:
+    ProvDocument.deserialize(content="document\n prefix ex <http://example.org/>\n person(ex:x)\nendDocument", format="provn")
+except ProvNSyntaxError as e:
+    print("default rejects person:", e)
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    d = ProvDocument.deserialize(source="/Users/tdh/projects/ProvPy/prov-verification/out/GH.provx", format="xml")
+print(len(w), "warnings;", [r.get_provn() for r in d.get_records() if "hadMember" in r.get_provn()][:2])
+EOF
+```
+
+Expected: `3.2.1`; the `person` line prints `unknown statement keyword 'person'`; four `ProvWarning`s and `hadMember(appl:2020/GH, appl:2020/GH/3)`-style records with no `%0A`.
+
+- [ ] **Step 4: conda-forge**
+
+Wait for `regro-cf-autotick-bot` to open the bump PR on `conda-forge/prov-feedstock` (usually within a few hours), verify its `sha256` against `curl -s https://pypi.org/pypi/prov/3.2.1/json | python3 -c "import json,sys; print([u['digests']['sha256'] for u in json.load(sys.stdin)['urls'] if u['packagetype']=='sdist'][0])"`, confirm `requirements.run` is untouched, and merge it in the GitHub web UI.
+
+- [ ] **Step 5: Close out**
+
+```bash
+gh api repos/trungdong/prov/milestones -f title=3.2.1 -f state=closed --jq .number 2>/dev/null || gh api repos/trungdong/prov/milestones --jq '.[] | select(.title=="3.2.1") | .number'
+gh api -X PATCH repos/trungdong/prov/milestones/<number> -f state=closed
+```
+
+Confirm <https://pypi.org/project/prov/> shows 3.2.1 and, once merged, the conda-forge feed too. Update the memory file `provn-3-2-0-verification-notebook.md` to say the four defect-class findings shipped in 3.2.1.

--- a/planning/specs/2026-09-12-release-3.2.1-design.md
+++ b/planning/specs/2026-09-12-release-3.2.1-design.md
@@ -1,0 +1,215 @@
+# Release 3.2.1: point release design
+
+**Date:** 2026-09-12
+**Status:** Approved by the maintainer in conversation on 2026-09-12
+**Scope:** Corrections found by a by-eye verification of the 3.2.0 PROV-N parser
+against documents from other producers. No new features, no API changes, no
+dependency changes, Python floor unchanged at 3.10.
+
+## 1. Purpose
+
+3.2.0 shipped on 2026-09-12. The same day, a verification notebook
+(`~/projects/ProvPy/prov-verification/`, outside this repository; its
+`findings.md` is the source for every item below) ran the released wheel over
+402 PROV-N files from ProvToolbox templates, the PLEAD project and the
+Recommendations, cross-checked them against ProvToolbox 2.0.4, and pushed
+`prov`'s own PROV-N output back through ProvToolbox's reader. The parser
+accepted 259 documents and produced no unexplained result on any of them.
+
+The verification did find one false claim in the 3.2.0 release notes that the
+implementation embodies, one gap in the lenient profile's reporting, two
+interoperability defects in the PROV-XML and PROV-JSONLD readers, and one
+writer spelling that no other producer uses. All five are small and contained.
+Fixing them now, before anyone depends on 3.2.0's `default` profile, keeps the
+`default` correction a bug fix rather than a compatibility argument.
+
+## 2. Code changes
+
+Each item names the current behaviour, the change, and the tests that pin it.
+Every code item gets a changelog line under `## 3.2.1`.
+
+### 2.1 The `default` PROV-N profile accepts only what producers write
+
+**Current behaviour.** `default` accepts nine "shorthand" keywords
+(`person`, `organization`, `softwareAgent`, `collection`, `emptyCollection`,
+`plan`, `wasRevisionOf`, `wasQuotedFrom`, `hadPrimarySource`), each read as the
+base record plus the matching `prov:type`. The 3.2.0 release notes, the how-to,
+the architecture page and two docstrings say these are keywords "that `prov` and
+ProvToolbox write".
+
+**What is true.** `prov`'s writer never emits them; `get_provn()` writes
+`agent(ex:a, [prov:type='prov:Person'])` and
+`wasDerivedFrom(ex:e2, ex:e1, -, -, -, [prov:type='prov:Revision'])`.
+ProvToolbox's writer does not emit them either. ProvToolbox's ANTLR grammar
+defines the three derivation keywords and `mentionOf`, but its 2.0.4 reader
+discards `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource` ("Parsing not
+processed") and fails with a `NullPointerException` on `person`,
+`softwareAgent`, `collection` and `plan`. The six element keywords appear in no
+PROV-N grammar. The list came from `ADDITIONAL_N_MAP` in `prov/constants.py`,
+which the PROV-XML deserializer uses for PROV-XML's typed elements such as
+`<prov:person>`; that is a PROV-XML convention, not a PROV-N one.
+
+**Change.** Remove the `_SHORTHAND` table and its two uses from
+`provn_parser.py`. `default` becomes the Recommendation grammar plus the bare
+`mentionOf` keyword, which both tools do write, plus the `-` marker in a
+required identifier position, which `_STRICT_REQUIRED_LEADING` already governs.
+A shorthand keyword is an unknown keyword in every profile: `ProvNSyntaxError`
+under `strict` and `default`, a `ProvWarning` skip under `lenient`.
+`ADDITIONAL_N_MAP` stays; the XML reader still needs it.
+
+Under `strict`, the message for a bare `mentionOf` gains a hint, since the
+plain "unknown statement keyword 'mentionOf'" sends the reader to the
+documentation:
+
+```text
+line 7, column 3: unknown statement keyword 'mentionOf' under the strict profile: write 'prov:mentionOf', or parse with profile='default' to accept the bare keyword
+```
+
+**Tests.** The three shorthand tests in `test_provn_profiles.py` go. A
+parametrised test over the nine keywords and the `strict` and `default`
+profiles asserts `unknown statement keyword '<keyword>'`; a second asserts the
+`lenient` skip. `test_provn.py`'s strict-mention test asserts the hint text.
+
+**Docs.** `docs/howto/provn.md` (profile table), `docs/explanation/architecture.md`
+(the profile paragraph), the module docstring of `provn_parser.py` and the
+`deserialize()` docstring in `provn.py`. `docs/reference/conformance.md` already
+says "Mention is the one keyword that differs between profiles" and needs no
+change. The 3.2.0 GitHub release body is left as published; the 3.2.1 notes
+carry the correction.
+
+### 2.2 The `lenient` profile warns once per skipped statement
+
+**Current behaviour.** `_resync()` stops at a statement keyword followed by
+`(`, where "statement keyword" means a name in the parser's keyword tables. A
+following statement whose name is *not* in the tables (an unknown keyword, or a
+prefixed extensibility expression such as `provext:hadMember(`) is skipped as
+part of the same run, so consecutive unparsable statements produce one
+`ProvWarning` naming only the first. On the PLEAD corpus, 39 of 101 files that
+use `provext:` statements raise fewer warnings than they skip statements; the
+records that survive are correct. The 3.2.0 notes say `lenient` "skips any
+statement that fails to parse with a `ProvWarning` naming its line and column",
+which this contradicts.
+
+**Change.** `_looks_like_statement_start()` returns true for *any* `NAME` token
+immediately followed by `(`. No production of the grammar places `(` after a
+name inside a statement body (arguments and attribute values are followed by
+`,`, `]` or `)`), so the pair is a reliable boundary whatever the name is. The
+structural-keyword branch and the depth reset are unchanged.
+
+**Tests.** Two adjacent unknown keywords produce two warnings with their own
+lines; two adjacent `provext:` expressions produce two warnings; the good
+statements around them survive. The existing resync tests
+(`test_lenient_resync_*`) must still pass unchanged.
+
+**Docs.** `_resync()`'s docstring and the architecture page's description of
+the synchronisation point.
+
+### 2.3 The PROV-XML reader does not mint an identifier from whitespace
+
+**Current behaviour.** ProvToolbox 2.0.4 writes a `hadMember` as
+
+```xml
+<hadMember>
+  <collection prov:ref="ex:c"/>
+  <entity>
+    <entity prov:ref="ex:e1"/>
+  </entity>
+</hadMember>
+```
+
+where the PROV-XML schema has a single `<prov:entity prov:ref="ex:e1"/>`.
+`_extract_attributes()` sees an `<entity>` child with no XML attributes, takes
+the plain-text branch, and returns its whitespace text. The record becomes
+`hadMember(ex:c, %0A%20%20%20%20%20%20%20%20%20%20)` with no warning.
+
+**Change.** In `_extract_attributes()`, a child element whose name is one of the
+reference-valued formal attributes (`PROV_ATTRIBUTE_QNAMES`) and that carries no
+`prov:ref` is resolved by a new helper `_nested_reference()`:
+
+- if it has exactly one child element and that child carries `prov:ref`, the
+  child's reference is used and a `ProvWarning` names the element and says the
+  shape is off-schema (ProvToolbox writes it for `hadMember`);
+- otherwise, if the element has non-blank text, the text is returned as before;
+- otherwise `ProvXMLException` is raised: a reference element with no
+  `prov:ref` and no text has no value to give.
+
+`ProvWarning` rather than the file's `UserWarning`, because it is the category
+the 3.2.0 PROV-N reader established for recoverable problems in third-party
+input and the one callers can filter without silencing every `UserWarning`.
+
+**Tests.** ProvToolbox's shape decodes to `hadMember(ex:c, ex:e1)` with a
+`ProvWarning`; a blank `<entity>` raises `ProvXMLException`; a reference given
+as element text still decodes. The existing XML round-trip fixtures are
+unaffected: `prov`'s own writer always sets `prov:ref`.
+
+### 2.4 The PROV-JSONLD reader accepts an array-valued Membership `entity`
+
+**Current behaviour.** `decode_jsonld_statement()` raises
+`ProvJSONLDException("The formal attribute 'entity' of prov:Membership takes a
+single value, not an array")` for `"entity": ["ex:e1"]`. The PROV-JSONLD
+submission, section 4.18, says a Membership "SHOULD contain a collection ... and
+a single entity or an array of them", and its schema types the property as
+`QualifiedName+`. ProvToolbox always writes the array form, even for one member,
+so every ProvToolbox document with a `hadMember` fails to load.
+
+**Change.** For a `Membership` statement whose `entity` is an array, decode one
+`ProvMembership` per array element, all sharing the statement's `@id` (if any)
+and its other attributes. PROV-DM's `hadMember` is binary, so the fan-out is the
+only faithful reading. An empty array raises `ProvJSONLDException`. Every other
+formal attribute keeps the single-value rule and its existing message. The
+encoder is unchanged; `prov` writes one Membership per record with a single
+`entity`, which the submission also allows.
+
+**Tests.** `["ex:e1", "ex:e2"]` decodes to two memberships equal to
+`hadMember("ex:c", "ex:e1")` and `hadMember("ex:c", "ex:e2")`; `["ex:e1"]`
+decodes to one; `[]` raises; the existing `Generation` array case still raises
+with "single".
+
+### 2.5 PROV-N output spells booleans `true` and `false`
+
+**Current behaviour.** `encoding_provn_value()` renders a `bool` as
+`"1" %% xsd:boolean` or `"0" %% xsd:boolean`. Both are legal XSD lexical forms,
+the parser reads all four, and ProvToolbox preserves them. But every producer
+in the verification corpus and every example in the Recommendations write
+`"true"`/`"false"`, so a human comparing `prov`'s output with anyone else's
+sees a spurious difference.
+
+**Change.** Render `"true" %% xsd:boolean` and `"false" %% xsd:boolean`. The
+parser is unchanged. No fixture in the repository pins the old spelling
+(`test_literal_forms` parses `"1"`, which still yields `True`).
+
+**Tests.** A writer test asserts the new spelling and that the output parses
+back to an equal document.
+
+## 3. Documentation changes
+
+- `docs/howto/provn.md` gains a short "Large documents" section: the parser
+  tokenises the whole document before building records, peak memory during a
+  parse is about 4 KiB per statement (a 100,000-statement, 7.5 MiB document
+  peaks near 400 MiB on CPython 3.12), and throughput is on the order of
+  20,000 statements per second on a 2023 laptop. A figure to know before
+  feeding the parser very large files, not a limit.
+- `docs/reference/conformance.md`: the per-release revision sentence.
+- `ROADMAP.md`: a 3.2.1 row in the style of 3.1.1's.
+- `HISTORY.md`: the 3.2.1 section, one bullet per item in section 2.
+
+## 4. Out of scope
+
+- Filing the findings as GitHub issues. The changelog is the record; the
+  verification notebook and its `findings.md` are kept outside the repository.
+- Reducing the parser's peak memory (materialising tokens lazily). Documented,
+  not changed.
+- Any change to what ProvToolbox reads or writes.
+- The 3.2.0 GitHub release body. It stays as published; the 3.2.1 notes state
+  the correction.
+
+## 5. Decisions taken in conversation, not to be re-opened
+
+- All nine shorthand keywords are removed from `default`, including the three
+  derivation keywords that ProvToolbox's grammar lists, so that `default` is
+  describable in one true sentence.
+- The XML reader descends into a nested reference and warns; it raises only
+  when no reference can be found at all.
+- Booleans are written as words.
+- The memory figure goes in the how-to.
+- The 3.2.0 release-body correction ships as part of the 3.2.1 release notes.


### PR DESCRIPTION
Design spec and implementation plan for 3.2.1, the point release that corrects what the by-eye verification of the 3.2.0 PROV-N parser found: the default profile's shorthand keywords, the lenient profile's warning count, the PROV-XML reader's handling of a nested reference, the PROV-JSONLD reader's rejection of an array-valued Membership entity, and the PROV-N boolean spelling.

Planning documents only; no code changes.