### PR TITLE
fix(provn): the default profile accepts only the bare mentionOf extension

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,26 @@
 # History
 
+## 3.2.1 (unreleased)
+
+3.2.1 is a point release that corrects what a by-eye verification of the 3.2.0 PROV-N
+parser against ProvToolbox and PLEAD documents found: the `default` profile, the
+lenient profile's warnings, the PROV-XML and PROV-JSONLD readers on ProvToolbox output,
+and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
+
+### Fixes
+
+- The `default` PROV-N profile no longer accepts the typed-element and derivation
+  shorthand keywords `person`, `organization`, `softwareAgent`, `collection`,
+  `emptyCollection`, `plan`, `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource`.
+  3.2.0 described them as keywords `prov` and ProvToolbox write; neither does, and
+  ProvToolbox's reader rejects them. `default` is now the Recommendation grammar plus the
+  bare `mentionOf` keyword, which both tools write. A shorthand keyword raises
+  `ProvNSyntaxError` under `strict` and `default` and is skipped with a `ProvWarning`
+  under `lenient`
+- Under the `strict` PROV-N profile, the error for a bare `mentionOf` says that
+  `prov:mentionOf` is the strict spelling and that the `default` profile accepts the bare
+  keyword
+
 ## 3.2.0 (2026-09-12)
 
 ### PROV-N

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -92,10 +92,10 @@ rather than reimplemented. The optional identifier before a relation's arguments
 place the grammar needs a second token of lookahead, is handled by reading the first
 argument and then checking for `;`.
 
-The three profiles share one parser. The profile selects which keyword table is consulted
-(the Recommendation's keywords alone, or also the shorthand keywords and the bare
-`mentionOf` that `prov` and ProvToolbox write) and whether a required-position check rejects
-`-` where the grammar demands an identifier. The `lenient` profile adds panic-mode error
+The three profiles share one parser. The profile selects whether the bare `mentionOf`
+keyword that `prov` and ProvToolbox write is accepted alongside the Recommendation's
+keywords, and whether a required-position check rejects `-` where the grammar demands an
+identifier. The `lenient` profile adds panic-mode error
 recovery. When a statement fails, the parser records the error, skips tokens until it
 reaches a synchronisation point (a statement keyword followed by `(`, or a structural
 keyword such as `endBundle` at the statement's own bracket depth) and resumes; the skipped
@@ -116,9 +116,8 @@ The PROV-N reader and writer set the pattern for any serializer added after 3.2.
 - Grammar clauses are cited on the code that implements them. Each regex or table names the
   production it encodes and says where it departs from a library default such as `\s` or `\d`
   and why.
-- Tables where the grammar is tabular. Keywords, arities and shorthand mappings are data,
-  derived from the model where they can be, and a test cross-checks them against the record
-  classes.
+- Tables where the grammar is tabular. Keywords and arities are data, derived from the
+  model where they can be, and a test cross-checks them against the record classes.
 - Records are built through {py:meth}`~prov.model.ProvBundle.new_record` with the same
   arguments the PROV-JSON deserializer passes, so a serializer adds no typing or namespace
   logic of its own.

--- a/docs/howto/provn.md
+++ b/docs/howto/provn.md
@@ -61,7 +61,7 @@ The parser accepts three dialects, selected with `profile`:
 | Profile | Accepts |
 | --- | --- |
 | `strict` | The W3C grammar only. Mention is written `prov:mentionOf`, as in the PROV-Links note. |
-| `default` | The grammar plus what `prov` and ProvToolbox write: the bare `mentionOf` keyword, and the shorthand keywords `person`, `organization`, `softwareAgent`, `collection`, `emptyCollection`, `plan`, `wasRevisionOf`, `wasQuotedFrom` and `hadPrimarySource`, each read as the base record with the matching `prov:type`. |
+| `default` | The grammar plus the bare `mentionOf` keyword that `prov` and ProvToolbox write. The Recommendation has no Mention production; PROV-Links spells it `prov:mentionOf`. |
 | `lenient` | As `default`. A statement that fails to parse is skipped with a {py:class}`~prov.model.ProvWarning` naming its line and column, and parsing resumes at the next statement. |
 
 ```python

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -50,10 +50,10 @@ class ProvNSerializer(Serializer):
             stream: Text or binary stream holding PROV-N; binary content is
                 decoded as UTF-8.
             profile: ``"strict"`` (the Recommendation grammar only),
-                ``"default"`` (plus the bare ``mentionOf`` keyword and the
-                shorthand keywords ``prov`` and ProvToolbox write) or
-                ``"lenient"`` (as ``default``, skipping any statement that
-                fails to parse with a :class:`~prov.model.ProvWarning`).
+                ``"default"`` (plus the bare ``mentionOf`` keyword that
+                ``prov`` and ProvToolbox write) or ``"lenient"`` (as
+                ``default``, skipping any statement that fails to parse with
+                a :class:`~prov.model.ProvWarning`).
             **args: Unused; accepted for interface compatibility.
 
         Returns:

--- a/src/prov/serializers/provn_parser.py
+++ b/src/prov/serializers/provn_parser.py
@@ -9,9 +9,10 @@ registration match every other format.
 Profiles:
 
 - ``strict``: the Recommendation grammar only.
-- ``default``: also the de-facto extensions ``prov`` and ProvToolbox write,
-  the bare ``mentionOf`` keyword and the shorthand keywords for typed
-  agents, entities and derivations.
+- ``default``: also the bare ``mentionOf`` keyword that ``prov`` and
+  ProvToolbox write (the Recommendation grammar has no Mention production;
+  PROV-Links spells it ``prov:mentionOf``), and the ``-`` marker where the
+  grammar has a plain identifier (see ``_STRICT_REQUIRED_LEADING``).
 - ``lenient``: as ``default``; a statement that fails to parse, including
   one the model rejects, is skipped and parsing resumes at the next
   statement. Tokenisation errors are fatal in every profile.
@@ -28,7 +29,6 @@ from __future__ import annotations
 from typing import Any
 
 from prov.constants import (
-    PROV,
     PROV_ACTIVITY,
     PROV_AGENT,
     PROV_ALTERNATE,
@@ -90,18 +90,6 @@ _RELATIONS: dict[str, tuple[QualifiedName, tuple[int, ...]]] = {
     "hadMember": (PROV_MEMBERSHIP, (2,)),
 }
 _MENTION: tuple[QualifiedName, tuple[int, ...]] = (PROV_MENTION, (3,))
-# default-profile shorthand keyword -> (base keyword, asserted prov:type)
-_SHORTHAND: dict[str, tuple[str, QualifiedName]] = {
-    "person": ("agent", PROV["Person"]),
-    "organization": ("agent", PROV["Organization"]),
-    "softwareAgent": ("agent", PROV["SoftwareAgent"]),
-    "collection": ("entity", PROV["Collection"]),
-    "emptyCollection": ("entity", PROV["EmptyCollection"]),
-    "plan": ("entity", PROV["Plan"]),
-    "wasRevisionOf": ("wasDerivedFrom", PROV["Revision"]),
-    "wasQuotedFrom": ("wasDerivedFrom", PROV["Quotation"]),
-    "hadPrimarySource": ("wasDerivedFrom", PROV["PrimarySource"]),
-}
 _STRUCTURAL = frozenset({"document", "endDocument", "bundle", "endBundle"})
 _ARGUMENT_KINDS = (TokenKind.NAME, TokenKind.MARKER, TokenKind.DATETIME)
 
@@ -338,12 +326,7 @@ class ProvNParser:
         prefix, local = token.value
         is_candidate = (
             not prefix
-            and (
-                local in _ELEMENTS
-                or local in _RELATIONS
-                or local in _SHORTHAND
-                or local == "mentionOf"
-            )
+            and (local in _ELEMENTS or local in _RELATIONS or local == "mentionOf")
         ) or (prefix, local) == ("prov", "mentionOf")
         # A bare NAME that merely spells a keyword (e.g. an attribute name or
         # value) is not a new statement unless it is actually followed by
@@ -382,34 +365,35 @@ class ProvNParser:
 
     # -- expressions -------------------------------------------------------------
 
-    def _classify(
-        self, token: Token
-    ) -> tuple[QualifiedName, tuple[int, ...], bool, QualifiedName | None]:
-        """Return (record type, arities, is_element, asserted type) for a keyword token."""
+    def _classify(self, token: Token) -> tuple[QualifiedName, tuple[int, ...], bool]:
+        """Return (record type, arities, is_element) for a keyword token."""
         prefix, local = token.value
         extensions = self.profile != "strict"
         if (prefix, local) == ("prov", "mentionOf") or (
             extensions and (prefix, local) == ("", "mentionOf")
         ):
-            return (*_MENTION, False, None)
+            return (*_MENTION, False)
         if prefix:
             raise self._error(
                 f"extensibility expression '{token.text}(...)' is not supported", token
             )
         if local in _ELEMENTS:
-            return (*_ELEMENTS[local], True, None)
+            return (*_ELEMENTS[local], True)
         if local in _RELATIONS:
-            return (*_RELATIONS[local], False, None)
-        if extensions and local in _SHORTHAND:
-            base, asserted = _SHORTHAND[local]
-            if base in _ELEMENTS:
-                return (*_ELEMENTS[base], True, asserted)
-            return (*_RELATIONS[base], False, asserted)
+            return (*_RELATIONS[local], False)
+        if local == "mentionOf":
+            # Only reachable under strict; default and lenient matched above.
+            raise self._error(
+                "unknown statement keyword 'mentionOf' under the strict profile: "
+                "write 'prov:mentionOf', or parse with profile='default' to accept "
+                "the bare keyword",
+                token,
+            )
         raise self._error(f"unknown statement keyword '{local}'", token)
 
     def _expression(self, bundle: ProvBundle) -> None:
         keyword = self._expect(TokenKind.NAME, "a statement keyword")
-        rec_type, arities, is_element, asserted_type = self._classify(keyword)
+        rec_type, arities, is_element = self._classify(keyword)
         self._expect(TokenKind.LPAREN)
         identifier: QualifiedName | str | None = None
         args: list[Token] = []
@@ -453,9 +437,7 @@ class ProvNParser:
             value = self._argument_value(token, attr, bundle)
             if value is not None:
                 attributes.append((attr, value))
-        record = bundle.new_record(rec_type, identifier, attributes, other_attributes)
-        if asserted_type is not None:
-            record.add_asserted_type(asserted_type)
+        bundle.new_record(rec_type, identifier, attributes, other_attributes)
 
     def _check_strict_required_positions(
         self, keyword: Token, local: str, args: list[Token]

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -314,11 +314,12 @@ def test_errors_name_the_problem_and_position(body, message, line):
     assert ctx.value.line == line
 
 
-def test_strict_rejects_bare_mention_and_shorthand():
-    with pytest.raises(ProvNSyntaxError, match="unknown statement keyword 'mentionOf'"):
+def test_strict_rejects_bare_mention_with_a_hint():
+    with pytest.raises(ProvNSyntaxError) as ctx:
         parse("mentionOf(ex:e1, ex:e0, ex:b)")
-    with pytest.raises(ProvNSyntaxError, match="unknown statement keyword 'person'"):
-        parse("person(ex:p)")
+    assert "unknown statement keyword 'mentionOf'" in ctx.value.message
+    assert "prov:mentionOf" in ctx.value.message
+    assert "profile='default'" in ctx.value.message
 
 
 def test_model_errors_carry_the_statement_position():

--- a/src/prov/tests/test_provn_profiles.py
+++ b/src/prov/tests/test_provn_profiles.py
@@ -44,49 +44,42 @@ def test_unknown_profile_raises():
         parse("entity(ex:e1)", profile="loose")
 
 
-@pytest.mark.parametrize(
-    ("keyword", "base", "asserted"),
-    [
-        ("person", "agent", PROV["Person"]),
-        ("organization", "agent", PROV["Organization"]),
-        ("softwareAgent", "agent", PROV["SoftwareAgent"]),
-        ("collection", "entity", PROV["Collection"]),
-        ("emptyCollection", "entity", PROV["EmptyCollection"]),
-        ("plan", "entity", PROV["Plan"]),
-    ],
-)
-def test_default_shorthand_elements(keyword, base, asserted):
-    (record,) = records(parse(f"{keyword}(ex:x)"))
-    assert record.get_type() == PROV[base.capitalize()]
-    assert asserted in record.get_asserted_types()
+SHORTHAND_KEYWORDS = [
+    "person",
+    "organization",
+    "softwareAgent",
+    "collection",
+    "emptyCollection",
+    "plan",
+    "wasRevisionOf",
+    "wasQuotedFrom",
+    "hadPrimarySource",
+]
+
+
+def _shorthand_statement(keyword):
+    derivation = keyword in ("wasRevisionOf", "wasQuotedFrom", "hadPrimarySource")
+    return f"{keyword}(ex:e2, ex:e1)" if derivation else f"{keyword}(ex:x)"
+
+
+@pytest.mark.parametrize("keyword", SHORTHAND_KEYWORDS)
+@pytest.mark.parametrize("profile", ["strict", "default"])
+def test_typed_shorthand_keywords_are_unknown(keyword, profile):
+    # PROV-XML has typed elements such as <prov:person>; PROV-N has no such
+    # keywords, and neither prov nor ProvToolbox writes them.
     with pytest.raises(
         ProvNSyntaxError, match=f"unknown statement keyword '{keyword}'"
     ):
-        parse(f"{keyword}(ex:x)", profile="strict")
+        parse(_shorthand_statement(keyword), profile=profile)
 
 
-@pytest.mark.parametrize(
-    ("keyword", "asserted"),
-    [
-        ("wasRevisionOf", PROV["Revision"]),
-        ("wasQuotedFrom", PROV["Quotation"]),
-        ("hadPrimarySource", PROV["PrimarySource"]),
-    ],
-)
-def test_default_shorthand_derivations(keyword, asserted):
-    (record,) = records(parse(f"{keyword}(ex:e2, ex:e1)"))
-    assert record.get_type() == PROV["Derivation"]
-    assert asserted in record.get_asserted_types()
-    with pytest.raises(ProvNSyntaxError):
-        parse(f"{keyword}(ex:e2, ex:e1)", profile="strict")
-
-
-def test_shorthand_equals_xml_decoding():
-    doc = parse('person(ex:p, [prov:label="P"])')
-    reloaded = ProvDocument.deserialize(
-        content=doc.serialize(format="xml"), format="xml"
-    )
-    assert doc == reloaded
+@pytest.mark.parametrize("keyword", SHORTHAND_KEYWORDS)
+def test_lenient_skips_a_typed_shorthand_keyword(keyword):
+    with pytest.warns(ProvWarning, match=f"unknown statement keyword '{keyword}'"):
+        doc = parse(
+            f"{_shorthand_statement(keyword)}\nentity(ex:e9)", profile="lenient"
+        )
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e9"]
 
 
 def test_strict_rejects_bare_mention_but_accepts_prefixed():


### PR DESCRIPTION
3.2.0's default PROV-N profile accepted nine shorthand keywords (person, organization, softwareAgent, collection, emptyCollection, plan, wasRevisionOf, wasQuotedFrom, hadPrimarySource) described as keywords prov and ProvToolbox write. Neither writes them: prov's writer emits the base keyword with a prov:type attribute, ProvToolbox's writer does the same, and ProvToolbox 2.0.4's reader discards or fails on every one of them. The list came from ADDITIONAL_N_MAP, a PROV-XML convention for typed elements, not a PROV-N one.

This removes the shorthand table, so default is the Recommendation grammar plus the bare mentionOf keyword both tools do write. The strict-profile error for a bare mentionOf now names prov:mentionOf and the default profile. The how-to, the architecture page, two docstrings and HISTORY.md are corrected; HISTORY.md gains the 3.2.1 section.

Suite: 2456 passed, 26 skipped, 191 xfailed (11 shorthand cases removed, 28 added; baseline was 2439 passed).