### PR TITLE
fix(provn): lenient profile warns once per skipped statement

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,10 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - Under the `strict` PROV-N profile, the error for a bare `mentionOf` says that
   `prov:mentionOf` is the strict spelling and that the `default` profile accepts the bare
   keyword
+- The `lenient` PROV-N profile warns once for every skipped statement. Consecutive
+  unparsable statements, such as a run of `provext:` extensibility expressions, were
+  skipped as one with a single `ProvWarning` naming only the first; resynchronisation
+  now stops at any name followed by `(`, not only at a keyword the parser knows
 
 ## 3.2.0 (2026-09-12)
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -97,7 +97,7 @@ keyword that `prov` and ProvToolbox write is accepted alongside the Recommendati
 keywords, and whether a required-position check rejects `-` where the grammar demands an
 identifier. The `lenient` profile adds panic-mode error
 recovery. When a statement fails, the parser records the error, skips tokens until it
-reaches a synchronisation point (a statement keyword followed by `(`, or a structural
+reaches a synchronisation point (any name followed by `(`, or a structural
 keyword such as `endBundle` at the statement's own bracket depth) and resumes; the skipped
 statements are reported as {py:class}`~prov.model.ProvWarning` by the serializer, attributed
 to the caller's frame.

--- a/src/prov/serializers/provn_parser.py
+++ b/src/prov/serializers/provn_parser.py
@@ -323,15 +323,17 @@ class ProvNParser:
         self._resync(start_depth)
 
     def _looks_like_statement_start(self, token: Token) -> bool:
-        prefix, local = token.value
-        is_candidate = (
-            not prefix
-            and (local in _ELEMENTS or local in _RELATIONS or local == "mentionOf")
-        ) or (prefix, local) == ("prov", "mentionOf")
-        # A bare NAME that merely spells a keyword (e.g. an attribute name or
-        # value) is not a new statement unless it is actually followed by
-        # '(', as every real keyword use is.
-        return is_candidate and self._peek().kind is TokenKind.LPAREN
+        """A NAME immediately followed by '(' opens a statement.
+
+        No production puts '(' after a name inside a statement body
+        (arguments and attribute values are followed by ',', ']' or ')'),
+        so the pair marks a boundary whatever the name is: a keyword, an
+        unknown keyword or a prefixed extensibility expression. Testing the
+        name against the keyword tables instead would run a skip through
+        every following statement the tables do not know, reporting a run
+        of bad statements as one.
+        """
+        return self._peek().kind is TokenKind.LPAREN
 
     def _resync(self, start_depth: int) -> None:
         """Skip to the next statement boundary.
@@ -339,11 +341,10 @@ class ProvNParser:
         A statement missing a closing ``)``/``]`` leaves ``self._depth``
         above ``start_depth`` forever, since ``_advance()`` only lowers it
         on a matching close. Gating every boundary on depth would then
-        reject every statement keyword that follows, so a statement
-        keyword immediately followed by ``(`` is trusted at any depth (it
-        is never legal inside a statement body) and forces the depth back
-        down to where the failed statement started, clearing whatever
-        imbalance it left.
+        reject every statement keyword that follows, so a name immediately
+        followed by ``(`` is trusted at any depth (it is never legal inside
+        a statement body) and forces the depth back down to where the
+        failed statement started, clearing whatever imbalance it left.
 
         A bare structural keyword (``document``, ``bundle``, ...) is not
         followed by ``(``, so it cannot be told apart this way from the

--- a/src/prov/tests/test_provn_profiles.py
+++ b/src/prov/tests/test_provn_profiles.py
@@ -131,6 +131,38 @@ def test_lenient_warns_once_per_bad_statement():
     assert [str(r.identifier) for r in records(doc)] == ["ex:e2"]
 
 
+def test_lenient_warns_for_each_of_two_adjacent_unknown_statements():
+    body = "entity(ex:e1)\nfoo(ex:e2)\nbar(ex:e3)\nentity(ex:e4)"
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert [str(w.message) for w in caught] == [
+        "PROV-N statement skipped: line 4, column 1: unknown statement keyword 'foo'",
+        "PROV-N statement skipped: line 5, column 1: unknown statement keyword 'bar'",
+    ]
+    assert sorted(str(r.identifier) for r in records(doc)) == ["ex:e1", "ex:e4"]
+
+
+def test_lenient_warns_for_each_of_two_adjacent_extensibility_expressions():
+    # ProvToolbox's summary documents write runs of provext: statements; each
+    # must be reported, not only the first of a run.
+    body = (
+        "prefix provext <http://openprovenance.org/prov/extension#>\n"
+        "entity(ex:e1)\n"
+        "provext:hadMember(ex:c, ex:e1)\n"
+        "provext:hadMember(ex:c, ex:e2)\n"
+        "entity(ex:e2)"
+    )
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert [str(w.message) for w in caught] == [
+        "PROV-N statement skipped: line 5, column 1: extensibility expression "
+        "'provext:hadMember(...)' is not supported",
+        "PROV-N statement skipped: line 6, column 1: extensibility expression "
+        "'provext:hadMember(...)' is not supported",
+    ]
+    assert sorted(str(r.identifier) for r in records(doc)) == ["ex:e1", "ex:e2"]
+
+
 def test_lenient_skips_extensibility_expression():
     with pytest.warns(ProvWarning, match="extensibility"):
         doc = parse("ex:custom(ex:e1)\nentity(ex:e2)", profile="lenient")


### PR DESCRIPTION
Under the lenient profile, resynchronisation after a failed statement stopped only at a keyword the parser's tables know. A following statement with an unknown keyword, or a prefixed extensibility expression such as provext:hadMember(...), was swallowed into the same skip, so a run of bad statements produced one ProvWarning naming only the first. On the PLEAD corpus, 39 of 101 files using provext: statements under-reported their skips; the surviving records were correct.

Resynchronisation now stops at any name immediately followed by '(', which no grammar production places inside a statement body. Two tests pin the per-statement warnings for adjacent unknown keywords and adjacent extensibility expressions; the existing resync tests are unchanged.

Suite: 2458 passed, 26 skipped, 191 xfailed.