### PR TITLE
fix(xml): resolve a nested prov:ref instead of minting an identifier from whitespace

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,11 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   unparsable statements, such as a run of `provext:` extensibility expressions, were
   skipped as one with a single `ProvWarning` naming only the first; resynchronisation
   now stops at any name followed by `(`, not only at a keyword the parser knows
+- The PROV-XML deserializer no longer turns a reference element that has no `prov:ref`
+  into an identifier made of its whitespace. ProvToolbox writes a `hadMember` member as
+  `<entity><entity prov:ref="..."/></entity>`; the nested reference is now used, with a
+  `ProvWarning`, and a reference element with neither a `prov:ref` nor text raises
+  `ProvXMLException`
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -583,11 +583,14 @@ def _extract_attributes(
     Warns:
         UserWarning: For any child attribute that is none of ``prov:ref``,
             ``xsi:type``, or ``xml:lang``; such attributes are ignored.
+        ProvWarning: When a reference-valued attribute's prov:ref sits on a
+            nested child element (see ``_nested_reference``).
 
     Raises:
         ProvXMLException: If a child element carries XML attributes but
             none of them is ``prov:ref``, ``xsi:type``, or ``xml:lang``, so
-            no attribute value can be determined.
+            no attribute value can be determined, or if a reference-valued
+            attribute element carries neither a prov:ref nor text.
     """
     attributes: list[NameValuePair] = []
     _unassigned = object()
@@ -629,14 +632,17 @@ def _extract_attributes(
                 )
 
         if not subel.attrib:
-            # A plain-text attribute value (no xsi:type/xml:lang/prov:ref):
-            # lxml reports an empty element's .text as None rather than ""
-            # (e.g. <ex:k0></ex:k0>), which would otherwise make the
-            # attribute vanish entirely once None reaches record
-            # construction. Coalesce back to the empty string (#224). This
-            # does not affect optional formal attributes that are absent
-            # from the XML altogether: those never enter this loop.
-            _v = subel.text if subel.text is not None else ""
+            if _t in PROV_ATTRIBUTE_QNAMES:
+                _v = _nested_reference(subel, _t)
+            else:
+                # A plain-text attribute value (no xsi:type/xml:lang/prov:ref):
+                # lxml reports an empty element's .text as None rather than ""
+                # (e.g. <ex:k0></ex:k0>), which would otherwise make the
+                # attribute vanish entirely once None reaches record
+                # construction. Coalesce back to the empty string (#224). This
+                # does not affect optional formal attributes that are absent
+                # from the XML altogether: those never enter this loop.
+                _v = subel.text if subel.text is not None else ""
 
         if _v is _unassigned:
             raise ProvXMLException(
@@ -647,6 +653,45 @@ def _extract_attributes(
         attributes.append((_t, _v))
 
     return attributes
+
+
+def _nested_reference(
+    subel: etree._Element, attr: prov.identifier.QualifiedName
+) -> prov.identifier.QualifiedName | str:
+    """Value of a reference-valued formal attribute element with no ``prov:ref``.
+
+    PROV-XML puts the reference on the element itself
+    (``<prov:entity prov:ref="ex:e1"/>``). ProvToolbox 2.0.4 writes a
+    ``hadMember`` member inside a wrapper,
+    ``<entity><entity prov:ref="ex:e1"/></entity>``; the single child's
+    reference is taken, with a warning. Non-blank text is returned as the
+    reference. A blank element with no reference anywhere has no value.
+
+    Raises:
+        ProvXMLException: If ``subel`` has neither a ``prov:ref`` child nor
+            text.
+
+    Warns:
+        ProvWarning: When the reference is taken from a nested child.
+    """
+    ref = _ns_prov("ref")
+    children = list(subel)
+    if len(children) == 1 and ref in children[0].attrib:
+        warnings.warn(
+            f"The element '{attr}' carries its prov:ref on a nested "
+            f"<{etree.QName(children[0]).localname}> child rather than on "
+            "itself; the nested reference is used. The shape is not "
+            "PROV-XML schema-valid (ProvToolbox writes it for hadMember).",
+            prov.model.ProvWarning,
+            stacklevel=3,
+        )
+        return xml_qname_to_QualifiedName(children[0], str(children[0].attrib[ref]))
+    if subel.text is not None and subel.text.strip():
+        return subel.text
+    raise ProvXMLException(
+        f"The reference element '{attr}' has no prov:ref attribute and no "
+        "reference text."
+    )
 
 
 def xml_qname_to_QualifiedName(

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -883,3 +883,45 @@ def test_force_types_controls_xsi_type_on_non_prov_attributes(force_types):
     assert xsi_type(".//ex:count") == "xsd:int"
     assert xsi_type(".//ex:when") == "xsd:dateTime"
     assert xsi_type(".//prov:type") == "xsd:string"
+
+
+def _membership_xml(entity_element: str) -> str:
+    return f"""<document xmlns="http://www.w3.org/ns/prov#"
+        xmlns:prov="http://www.w3.org/ns/prov#"
+        xmlns:ex="http://example.org/">
+      <entity prov:id="ex:c"/>
+      <entity prov:id="ex:e1"/>
+      <hadMember>
+        <collection prov:ref="ex:c"/>
+        {entity_element}
+      </hadMember>
+    </document>"""
+
+
+def test_nested_reference_child_is_used_with_a_warning():
+    # ProvToolbox 2.0.4 wraps a hadMember's member in an extra <entity>
+    # element; the schema puts prov:ref on the element itself.
+    xml_string = _membership_xml(
+        '<entity>\n          <entity prov:ref="ex:e1"/>\n        </entity>'
+    )
+    with pytest.warns(prov.ProvWarning, match="nested"):
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+    (membership,) = document.get_records(prov.ProvMembership)
+    (member,) = membership.get_attribute(PROV["entity"])
+    assert str(member) == "ex:e1"
+
+
+def test_blank_reference_element_without_ref_raises():
+    xml_string = _membership_xml("<entity>   </entity>")
+    with pytest.raises(ProvXMLException, match="no prov:ref"):
+        prov.ProvDocument.deserialize(content=xml_string, format="xml")
+
+
+def test_reference_given_as_element_text_still_decodes():
+    xml_string = _membership_xml("<entity>ex:e1</entity>")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        document = prov.ProvDocument.deserialize(content=xml_string, format="xml")
+    (membership,) = document.get_records(prov.ProvMembership)
+    (member,) = membership.get_attribute(PROV["entity"])
+    assert str(member) == "ex:e1"


### PR DESCRIPTION
ProvToolbox 2.0.4 writes a hadMember's member as <entity><entity prov:ref="..."/></entity>, where the PROV-XML schema has a single <prov:entity prov:ref="..."/>. prov's XML reader took the outer element's whitespace text and URL-encoded it into an identifier, producing hadMember(c, %0A%20%20...) with no warning.

A reference-valued formal attribute element without prov:ref now takes the reference from its single prov:ref child with a ProvWarning, keeps non-blank text as before, and raises ProvXMLException when it has neither. prov's own XML output always sets prov:ref, so the round-trip fixtures are unchanged.

Suite: 2461 passed, 26 skipped, 191 xfailed.