### PR TITLE
fix(jsonld): accept an array-valued Membership entity

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,9 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   `<entity><entity prov:ref="..."/></entity>`; the nested reference is now used, with a
   `ProvWarning`, and a reference element with neither a `prov:ref` nor text raises
   `ProvXMLException`
+- The PROV-JSONLD deserializer accepts an array-valued `entity` on a `Membership`
+  statement, which the submission (section 4.18) allows and ProvToolbox always writes,
+  decoding one `hadMember` per member; an empty array raises `ProvJSONLDException`
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/serializers/provjsonld.py
+++ b/src/prov/serializers/provjsonld.py
@@ -14,11 +14,13 @@ from typing import Any
 
 from prov import Error
 from prov.constants import (
+    PROV_ATTR_ENTITY,
     PROV_ATTRIBUTE_LITERALS,
     PROV_BUNDLE,
     PROV_ENTITY,
     PROV_LABEL,
     PROV_LOCATION,
+    PROV_MEMBERSHIP,
     PROV_MENTION,
     PROV_N_MAP,
     PROV_QUALIFIEDNAME,
@@ -541,33 +543,39 @@ def _decode_statement_type(item: dict[str, Any]) -> tuple[QualifiedName, str]:
     return rec_type, type_term
 
 
-def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
-    """Decode one submission §4 statement object and add it to ``bundle``.
+def _decode_statement_attributes(
+    item: dict[str, Any],
+    bundle: ProvBundle,
+    rec_type: QualifiedName,
+    type_term: str,
+    formal_by_term: dict[str, QualifiedName],
+) -> tuple[dict[QualifiedNameCandidate, Any], list[AttributePair], list[Any] | None]:
+    """Split one statement object's keys into formal, non-formal and Membership members.
 
     Args:
-        item: The statement object (one ``@graph`` entry), as produced by
-            :func:`encode_jsonld_statement`.
-        bundle: Bundle to add the decoded record to.
+        item: The statement object, as passed to :func:`decode_jsonld_statement`.
+        bundle: Bundle the decoded values resolve qualified names against.
+        rec_type: The statement's record type.
+        type_term: ``item``'s ``"@type"`` term, for error messages.
+        formal_by_term: ``rec_type``'s formal attributes, keyed by local part.
+
+    Returns:
+        A ``(attributes, other_attributes, members)`` triple: ``attributes``
+        holds every single-valued formal attribute, ``other_attributes``
+        every non-formal attribute value, and ``members`` is ``None`` unless
+        ``rec_type`` is ``Membership`` and its ``entity`` is a JSON array, in
+        which case it holds that array's raw (still-encoded) values.
 
     Raises:
-        ProvJSONLDException: If ``item``'s ``"@type"`` is missing, is not a
-            recognised PROV-JSONLD statement type (including ``"Mention"``,
-            which the submission defines no term for), or names an element
-            type without an ``"@id"``; if a formal attribute's value is an
-            array (formal attributes take a single value) or cannot be
+        ProvJSONLDException: If a formal attribute's value is an array
+            (formal attributes take a single value, except a Membership's
+            ``entity``, which may be a non-empty array) or cannot be
             resolved to a qualified name; or if a non-formal attribute's
             value is not a JSON array.
     """
-    rec_type, type_term = _decode_statement_type(item)
-    cls = PROV_REC_CLS[rec_type]
-    formal_by_term = FORMAL_ATTRS_BY_TERM[cls]
-    rec_id = item.get("@id")
-    if rec_id is None and issubclass(cls, ProvElement):
-        raise ProvJSONLDException(
-            f'A {type_term} statement requires an "@id"; found {item!r}'
-        )
     attributes: dict[QualifiedNameCandidate, Any] = {}
     other_attributes: list[AttributePair] = []
+    members: list[Any] | None = None
     for key, value in item.items():
         if key in ("@type", "@id"):
             continue
@@ -579,6 +587,13 @@ def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
                 attributes[attr] = _decode_formal_qname(bundle, value, type_term, key)
             continue
         if attr is not None:
+            if rec_type == PROV_MEMBERSHIP and attr == PROV_ATTR_ENTITY:
+                # Submission 4.18: a Membership's entity is "a single entity
+                # or an array of them" (schema QualifiedName+). PROV-DM's
+                # hadMember is binary, so the array becomes one record per
+                # member, in decode_jsonld_statement.
+                members = value
+                continue
             raise ProvJSONLDException(
                 f"The formal attribute {key!r} of {type_term} takes a single "
                 f"value, not an array; found {value!r}"
@@ -593,7 +608,54 @@ def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
         other_attributes.extend(
             (qname, decode_jsonld_value(v, bundle, term)) for v in value
         )
-    bundle.new_record(rec_type, rec_id, attributes, other_attributes)
+    return attributes, other_attributes, members
+
+
+def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
+    """Decode one submission §4 statement object and add it to ``bundle``.
+
+    Args:
+        item: The statement object (one ``@graph`` entry), as produced by
+            :func:`encode_jsonld_statement`.
+        bundle: Bundle to add the decoded record to.
+
+    Raises:
+        ProvJSONLDException: If ``item``'s ``"@type"`` is missing, is not a
+            recognised PROV-JSONLD statement type (including ``"Mention"``,
+            which the submission defines no term for), or names an element
+            type without an ``"@id"``; if a formal attribute's value is an
+            array (formal attributes take a single value, except a
+            Membership's ``entity``, which may be a non-empty array and
+            yields one record per member) or cannot be
+            resolved to a qualified name; or if a non-formal attribute's
+            value is not a JSON array.
+    """
+    rec_type, type_term = _decode_statement_type(item)
+    cls = PROV_REC_CLS[rec_type]
+    formal_by_term = FORMAL_ATTRS_BY_TERM[cls]
+    rec_id = item.get("@id")
+    if rec_id is None and issubclass(cls, ProvElement):
+        raise ProvJSONLDException(
+            f'A {type_term} statement requires an "@id"; found {item!r}'
+        )
+    attributes, other_attributes, members = _decode_statement_attributes(
+        item, bundle, rec_type, type_term, formal_by_term
+    )
+    if members is None:
+        bundle.new_record(rec_type, rec_id, attributes, other_attributes)
+        return
+    if not members:
+        raise ProvJSONLDException(
+            f'The "entity" array of {type_term} is empty; found {item!r}'
+        )
+    for member in members:
+        entity = _decode_formal_qname(bundle, member, type_term, "entity")
+        bundle.new_record(
+            rec_type,
+            rec_id,
+            {**attributes, PROV_ATTR_ENTITY: entity},
+            list(other_attributes),
+        )
 
 
 def decode_jsonld_document(container: Any, document: ProvDocument) -> None:

--- a/src/prov/tests/test_jsonld.py
+++ b/src/prov/tests/test_jsonld.py
@@ -315,6 +315,47 @@ def test_deserialize_malformed(payload, match):
         ProvDocument.deserialize(content=json.dumps(payload), format="jsonld")
 
 
+def _membership_payload(entities) -> str:
+    return json.dumps(
+        {
+            "@context": [{"ex": EX_URI}, JSONLD_CONTEXT_URL],
+            "@graph": [
+                {"@type": "Entity", "@id": "ex:c"},
+                {"@type": "Membership", "collection": "ex:c", "entity": entities},
+            ],
+        }
+    )
+
+
+def test_deserialize_membership_entity_array_gives_one_record_per_member():
+    # Submission 4.18: "a single entity or an array of them"; PROV-DM's
+    # hadMember is binary, so the array fans out.
+    doc = ProvDocument.deserialize(
+        content=_membership_payload(["ex:e1", "ex:e2"]), format="jsonld"
+    )
+    expected = _new_doc()
+    expected.entity("ex:c")
+    expected.hadMember("ex:c", "ex:e1")
+    expected.hadMember("ex:c", "ex:e2")
+    assert doc == expected
+
+
+def test_deserialize_membership_single_element_array():
+    # ProvToolbox writes the array form even for one member.
+    doc = ProvDocument.deserialize(
+        content=_membership_payload(["ex:e1"]), format="jsonld"
+    )
+    expected = _new_doc()
+    expected.entity("ex:c")
+    expected.hadMember("ex:c", "ex:e1")
+    assert doc == expected
+
+
+def test_deserialize_membership_empty_entity_array_raises():
+    with pytest.raises(ProvJSONLDException, match="empty"):
+        ProvDocument.deserialize(content=_membership_payload([]), format="jsonld")
+
+
 def _expected_primer_document() -> ProvDocument:
     """Build the document ``submission-example-3.jsonld`` is expected to decode to."""
     doc = ProvDocument()


### PR DESCRIPTION
The PROV-JSONLD submission (section 4.18) says a Membership contains "a single entity or an array of them", and its schema types the property as QualifiedName+. ProvToolbox writes the array form even for one member, so every ProvToolbox JSON-LD document with a hadMember failed to load with "The formal attribute 'entity' of prov:Membership takes a single value, not an array".

A Membership whose entity is an array now decodes to one ProvMembership per element, sharing the statement's @id and other attributes; an empty array raises. Every other formal attribute keeps the single-value rule. The encoder is unchanged.

Suite: 2464 passed, 26 skipped, 191 xfailed.