### PR TITLE
fix(provn): write xsd:boolean values as true and false

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,9 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - The PROV-JSONLD deserializer accepts an array-valued `entity` on a `Membership`
   statement, which the submission (section 4.18) allows and ProvToolbox always writes,
   decoding one `hadMember` per member; an empty array raises `ProvJSONLDException`
+- PROV-N output spells `xsd:boolean` values `"true"` and `"false"` instead of `"1"` and
+  `"0"`. Both are legal lexical forms and the parser reads all four, but every other
+  producer writes the words
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -359,8 +359,8 @@ def encoding_provn_value(
     """Return the PROV-N literal representation of a Python value.
 
     Strings are quoted (triple-quoted when they span multiple lines); dates
-    and booleans are rendered with their XSD datatype suffix. Floats are
-    rendered as full-precision ``xsd:double`` (#251). Plain ints are typed by
+    are rendered with their XSD datatype suffix and booleans as ``"true"``/``"false"``
+    with theirs. Floats are rendered as full-precision ``xsd:double`` (#251). Plain ints are typed by
     magnitude: within +/-(2**31-1) they render as a bare ``INT_LITERAL`` (PROV-N
     [60] sugar for ``xsd:int``); beyond that they carry an explicit
     ``xsd:long``/``xsd:integer`` suffix (#249). Any other value is rendered
@@ -373,8 +373,9 @@ def encoding_provn_value(
     elif isinstance(value, float):
         return f'"{value!r}" %% xsd:double'
     elif isinstance(value, bool):
-        # bool is an int subtype, so :d renders "1"/"0" (not "True"/"False")
-        return f'"{value:d}" %% xsd:boolean'
+        # Before the int branch: bool is an int subtype. "true"/"false" is
+        # the lexical form every other PROV-N producer writes.
+        return f'"{"true" if value else "false"}" %% xsd:boolean'
     elif isinstance(value, int):
         datatype = canonical_xsd_datatype(value)
         if datatype == XSD_INT:

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -130,6 +130,18 @@ def test_literal_forms(literal, expected):
         assert value == expected
 
 
+def test_writer_spells_booleans_as_words():
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.entity("ex:e1", {"ex:yes": True, "ex:no": False})
+    provn = doc.get_provn()
+    assert 'ex:yes="true" %% xsd:boolean' in provn
+    assert 'ex:no="false" %% xsd:boolean' in provn
+    assert (
+        ProvDocument.deserialize(content=provn, format="provn", profile="strict") == doc
+    )
+
+
 def test_literal_equivalence_with_json():
     body = (
         'entity(ex:e1, [ex:s="x", ex:i=1, ex:f="1.5" %% xsd:double, ex:q=\'ex:q1\','


### PR DESCRIPTION
get_provn() rendered a bool as "1" %% xsd:boolean or "0" %% xsd:boolean. Both are legal XSD lexical forms and ProvToolbox preserves them, but every producer in the verification corpus and every example in the Recommendations write "true" and "false", so a reader comparing prov's output with anyone else's saw a spurious difference. The writer now spells the words; the parser is unchanged and no fixture pinned the old spelling.

Suite: 2465 passed, 26 skipped, 191 xfailed.