### PR TITLE
fix(cli): open files after parsing instead of through argparse.FileType

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,10 +106,11 @@ jobs:
         run: uv run --no-sync pytest src/prov/tests/test_minimal_install.py -v
 
   own-warnings:
-    # Non-blocking guard (#340): prov must raise no DeprecationWarning or
-    # FutureWarning of its own. It runs apart from the matrix so a failure
-    # names exactly one cause, and rdflib's deprecation notices (attributed
-    # to rdflib's own modules) stay out of scope.
+    # Non-blocking guard (#340): prov must raise no DeprecationWarning,
+    # PendingDeprecationWarning or FutureWarning of its own. It runs apart
+    # from the matrix so a failure names exactly one cause, and rdflib's
+    # deprecation notices (attributed to rdflib's own modules) stay out of
+    # scope.
     #
     # The ini-style filterwarnings form is deliberate. pytest's command-line
     # `-W error::DeprecationWarning:prov` escapes and anchors the module
@@ -127,13 +128,13 @@ jobs:
         uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          python-version: "3.12"
-      - name: Run the suite with prov's own deprecation warnings as errors
+          python-version: "3.14"
+      - name: Run the suite with prov's own deprecation warnings as errors (Python 3.14)
         env:
           HYPOTHESIS_PROFILE: ci
         run: |
           uv sync --locked --extra rdf --extra xml --extra dot --extra graph --group dev
-          uv run --no-sync pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+          uv run --no-sync pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::PendingDeprecationWarning:prov\nerror::FutureWarning:prov'
 
   benchmark:
     # Non-blocking regression check. Compares this run against the committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ codacy-analysis analyze --files <changed files>   # expect "0 issues found"
 Codacy's Cloud gate blocks a PR on a single finding of any severity, including markdownlint
 on Markdown files, so run the local analyser on every changed file before pushing. Coveralls
 is advisory as long as `uv run coverage report` stays above the 97% floor. CI also runs a
-non-blocking `own-warnings` job that fails if `prov` raises a `DeprecationWarning` or
-`FutureWarning` of its own (#340).
+non-blocking `own-warnings` job that fails if `prov` raises a `DeprecationWarning`,
+`PendingDeprecationWarning` or `FutureWarning` of its own on the newest interpreter
+(#340, #441).
 
 Performance changes also run `uv run pytest benchmarks/ --benchmark-json=/tmp/bench.json`
 and `uv run python benchmarks/compare.py benchmarks/baseline.json /tmp/bench.json`; the

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,6 +35,13 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - PROV-N output spells `xsd:boolean` values `"true"` and `"false"` instead of `"1"` and
   `"0"`. Both are legal lexical forms and the parser reads all four, but every other
   producer writes the words
+- `prov-convert` and `prov-compare` open their files after parsing arguments instead of
+  through `argparse.FileType`, which Python 3.14 deprecates; standard input and output are
+  used only when no file is given and are no longer closed by the tool, `--version` and
+  `--help` no longer need a binary stdout, and `prov-compare` reports a missing file
+  argument as a usage error. The own-warnings CI guard runs on Python 3.14 and treats
+  `PendingDeprecationWarning` as an error
+  ([#441](https://github.com/trungdong/prov/issues/441))
 
 ## 3.2.0 (2026-09-12)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,9 +35,10 @@ uv run mypy src
 uv run ruff check src/
 uv run ruff format --check src/
 
-# prov must raise no DeprecationWarning or FutureWarning of its own (#340); the
-# ini-style filter is deliberate, the -W form silently ignores submodules
-uv run pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::FutureWarning:prov'
+# prov must raise no DeprecationWarning, PendingDeprecationWarning or FutureWarning
+# of its own (#340, #441); the ini-style filter is deliberate, the -W form silently
+# ignores submodules
+uv run --python 3.14 --extra rdf --extra xml --extra dot --extra graph pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::PendingDeprecationWarning:prov\nerror::FutureWarning:prov'
 ```
 
 Run the benchmark suite and compare it with the committed baseline; a regression

--- a/planning/plans/2026-09-12-release-3.2.1.md
+++ b/planning/plans/2026-09-12-release-3.2.1.md
@@ -27,6 +27,7 @@
 - The memory figure (about 4 KiB per statement) goes into `docs/howto/provn.md`.
 - The 3.2.0 GitHub release body is not edited; the 3.2.1 notes carry the correction.
 - The findings are not filed as GitHub issues.
+- Fold in #441; leave #449, #450, #444 for 3.3.0.
 
 ---
 
@@ -40,6 +41,7 @@
 | D | 3 | `fix/xml-nested-reference` |
 | E | 4 | `fix/jsonld-membership-array` |
 | F | 5 | `fix/provn-boolean-words` |
+| H | 8 | `fix/cli-open-after-parse` |
 | G | 6 | `release/3.2.1` |
 | – | 7 | release operations on `main` |
 
@@ -935,6 +937,312 @@ gh pr checks --watch && gh pr merge --merge --delete-branch
 
 ---
 
+### Task 8: `prov-convert` and `prov-compare` open files after parsing (#441)
+
+**Goal:** Neither CLI script uses `argparse.FileType` (deprecated in Python 3.14); files are opened after argument parsing, standard streams are used only when no file is given and are never closed by the tool, and the own-warnings CI guard runs on 3.14 with `PendingDeprecationWarning` included so the regression cannot return. The spec and plan gain the matching section and task.
+
+**Files:**
+- Modify: `src/prov/scripts/convert.py` (imports; `convert_file` annotations; new `_open_binary` helper; `main()` argument definitions and the parse/convert/close block; `__updated__` and `@deffield updated`)
+- Modify: `src/prov/scripts/compare.py` (imports; `main()` argument definitions and the parse/compare/close block; `__updated__` and `@deffield updated`)
+- Modify: `src/prov/tests/test_scripts.py` (replace `test_convert_version_exits_0` and `test_convert_missing_input_file_exits_2`'s comment; add five tests)
+- Modify: `.github/workflows/CI.yml:108-136` (own-warnings job: Python 3.14, `PendingDeprecationWarning` filter)
+- Modify: `docs/releasing.md:38-41` (pre-flight own-warnings command)
+- Modify: `CLAUDE.md` (the own-warnings sentence under "Gates every PR must pass")
+- Modify: `HISTORY.md` (one bullet under 3.2.1 › Fixes)
+- Modify: `planning/specs/2026-09-12-release-3.2.1-design.md` (new section 2.6, and a line in section 4)
+- Modify: `planning/plans/2026-09-12-release-3.2.1.md` (PR map row, this task's text after Task 5, Task 6 count)
+
+**Acceptance Criteria:**
+- [ ] `grep -n FileType src/prov/scripts/*.py` → no output
+- [ ] `prov-convert -f json in.provn out.json` and `prov-compare a.json b.json` behave as before: exit 0 on success, 1 for differing documents, 2 on a bad format or an unopenable file (`SystemExit(2)` from `parser.error` for the latter)
+- [ ] `prov-convert --version` and `--help` succeed with `sys.stdout` replaced by an `io.StringIO` (no `.buffer` attribute)
+- [ ] Reading from stdin and writing to stdout works and leaves `sys.stdin.buffer` and `sys.stdout.buffer` open afterwards
+- [ ] `prov-compare` with one positional argument exits 2 with argparse's usage error
+- [ ] Running both `main()` functions under `warnings.simplefilter("error", PendingDeprecationWarning)` raises nothing, on Python 3.14 included (`uv run --python 3.14 --extra rdf --extra xml pytest src/prov/tests/test_scripts.py -q`)
+- [ ] Suite: 2470 passed, 26 skipped, 191 xfailed (five new tests on the 2465 after Task 5)
+
+**Verify:** `uv run --python 3.14 --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_scripts.py src/prov/tests/test_cli_smoke.py -q -W error::PendingDeprecationWarning` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/prov/tests/test_scripts.py`, add `import warnings` to the imports. Replace `test_convert_version_exits_0` with:
+
+```python
+def test_convert_version_exits_0_without_stdout_buffer(monkeypatch):
+    # Files are opened after parsing, so --version never needs
+    # sys.stdout.buffer; a plain StringIO stdout must do.
+    monkeypatch.setattr(sys, "argv", ["prov-convert", "--version"])
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        convert_main()
+    assert ctx.value.code == 0
+```
+
+In `test_convert_missing_input_file_exits_2`, replace the comment with:
+
+```python
+    # A path that cannot be opened is reported through parser.error(),
+    # which exits 2; that SystemExit propagates out of main() rather than
+    # being caught by the `except Exception` handler.
+```
+
+Append after `test_convert_works_with_stdin_set_to_none`:
+
+```python
+def test_convert_leaves_standard_streams_open(provn_infile, monkeypatch):
+    # "-" (the default) means the standard streams, which belong to the
+    # caller: the tool must not close them after use.
+    stdin = io.TextIOWrapper(io.BytesIO(provn_infile.read_bytes()))
+    stdout = io.TextIOWrapper(io.BytesIO())
+    monkeypatch.setattr(sys, "argv", ["prov-convert", "-i", "provn", "-f", "json"])
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    assert convert_main() == 0
+    assert not stdin.buffer.closed
+    assert not stdout.buffer.closed
+    stdout.flush()
+    written = stdout.buffer.getvalue().decode("utf-8")
+    assert ProvDocument.deserialize(content=written, format="json") == primer_example()
+
+
+def test_convert_unwritable_output_path_exits_2(infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "no-such-dir" / "doc.xml"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-f", "xml", str(infile), str(outfile)]
+    )
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        convert_main()
+    assert ctx.value.code == 2
+
+
+def test_convert_raises_no_pending_deprecation_warning(infile, tmp_path, monkeypatch):
+    # argparse.FileType is deprecated from Python 3.14 (#441); the scripts
+    # must not use it on any interpreter.
+    outfile = tmp_path / "doc.xml"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-f", "xml", str(infile), str(outfile)]
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        assert convert_main() == 0
+```
+
+Append after `test_closes_both_files_on_error`:
+
+```python
+def test_compare_one_positional_exits_2(compare_files, monkeypatch):
+    json_file, _xml_file = compare_files
+    monkeypatch.setattr(sys, "argv", ["prov-compare", str(json_file)])
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        compare_main()
+    assert ctx.value.code == 2
+
+
+def test_compare_raises_no_pending_deprecation_warning(compare_files, monkeypatch):
+    json_file, xml_file = compare_files
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prov-compare", "-f", "json", "-F", "xml", str(json_file), str(xml_file)],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        assert compare_main() == 0
+```
+
+- [ ] **Step 2: Run them to see them fail**
+
+```bash
+uv run --python 3.14 --extra rdf --extra xml pytest src/prov/tests/test_scripts.py -q -k "pending_deprecation or standard_streams or one_positional or without_stdout_buffer or unwritable"
+```
+
+Expected: the two `pending_deprecation` tests fail on 3.14 with `PendingDeprecationWarning: FileType is deprecated`; `leaves_standard_streams_open` fails because stdout's buffer is closed; `one_positional` fails (currently `deserialize(None)` raises inside `main`, returning 2 rather than exiting); the other two may already pass. (Switching interpreters re-syncs the venv; run `uv sync --extra rdf --extra xml --extra dot --extra graph --group bench` afterwards to return to 3.12, or keep using `--python 3.14` consistently for this task.)
+
+- [ ] **Step 3: Change `convert.py`**
+
+Imports: replace `from argparse import ArgumentParser, FileType, RawDescriptionHelpFormatter` with `from argparse import ArgumentParser, RawDescriptionHelpFormatter` and add `from typing import BinaryIO, cast` (replacing `from typing import cast`). Change `convert_file`'s two parameters from `io.FileIO` to `BinaryIO` (the docstring already says "file-like object"). `io` stays imported if anything else uses it; otherwise remove it (ruff F401 tells you).
+
+Add after `CLIError`:
+
+```python
+def _open_binary(
+    parser: ArgumentParser, path: str, mode: str, standard: BinaryIO
+) -> tuple[BinaryIO, bool]:
+    """Open ``path`` in binary ``mode``, or return ``standard`` for ``"-"``.
+
+    The second element says whether the caller owns the stream and must
+    close it; the standard streams belong to the process. An unopenable
+    path is reported through :meth:`argparse.ArgumentParser.error`, which
+    exits with status 2 like argparse's own file handling did.
+    """
+    if path == "-":
+        return standard, False
+    try:
+        return cast(BinaryIO, open(path, mode)), True  # noqa: SIM115 -- closed by main()
+    except OSError as exc:
+        parser.error(f"can't open '{path}': {exc}")
+```
+
+(If ruff does not flag SIM115 in this project, drop the `# noqa` comment; run `uv run ruff check src/` and keep the file clean either way.)
+
+In `main()`, replace the two positional `add_argument` calls with:
+
+```python
+        parser.add_argument("infile", nargs="?", default="-", help="input file (default: stdin)")
+        parser.add_argument("outfile", nargs="?", default="-", help="output file (default: stdout)")
+```
+
+and replace the block from `args = None` to the end of its `finally` with:
+
+```python
+        args = parser.parse_args()
+        owned: list[BinaryIO] = []
+        try:
+            infile, owns_infile = _open_binary(parser, args.infile, "rb", sys.stdin.buffer if args.infile == "-" else cast(BinaryIO, None))
+            if owns_infile:
+                owned.append(infile)
+            outfile, owns_outfile = _open_binary(parser, args.outfile, "wb", sys.stdout.buffer if args.outfile == "-" else cast(BinaryIO, None))
+            if owns_outfile:
+                owned.append(outfile)
+            convert_file(infile, outfile, args.format.lower(), args.input_format.lower())
+            outfile.flush()
+        finally:
+            for stream in owned:
+                stream.close()
+```
+
+The conditional `sys.stdin.buffer if args.infile == "-" else ...` keeps `sys.stdin` untouched when a file is given (`test_convert_works_with_stdin_set_to_none` sets `sys.stdin = None`). If you prefer, restructure `_open_binary` to take the standard-stream *name* (`"stdin"`/`"stdout"`) and resolve `getattr(sys, name).buffer` only in the `"-"` branch; either shape is acceptable as long as the standard stream attribute is not touched when a path is given.
+
+Update the docstring of `main()`: "an optional input file (default stdin), and an optional output file (default stdout)" stays true; add one sentence: "Files are opened after parsing; the standard streams are used for `-` and are not closed."
+
+Set `__updated__ = "2026-09-12"` and `@deffield    updated: 2026-09-12`.
+
+- [ ] **Step 4: Change `compare.py`**
+
+Imports: drop `FileType`; add `from typing import BinaryIO` if you reuse the helper shape (do not import from `convert.py`; keep the two scripts independent). Replace the two positional `add_argument` calls with:
+
+```python
+        parser.add_argument("file1", help="first document")
+        parser.add_argument("file2", help="second document")
+```
+
+(required positionals: argparse reports a missing one as a usage error, exit 2; `--version` still exits before the check). Replace the block from `args = None` to the end of its `finally` with:
+
+```python
+        args = parser.parse_args()
+        opened: list[BinaryIO] = []
+        try:
+            for path in (args.file1, args.file2):
+                try:
+                    opened.append(open(path, "rb"))
+                except OSError as exc:
+                    parser.error(f"can't open '{path}': {exc}")
+            doc1 = ProvDocument.deserialize(opened[0], format=args.format1.lower())
+            doc2 = ProvDocument.deserialize(opened[1], format=args.format2.lower())
+            return doc1 != doc2
+        finally:
+            for stream in opened:
+                stream.close()
+```
+
+Both files are opened in binary mode, as `prov-convert` already reads its input; every deserializer accepts a binary stream. Update `main()`'s docstring: "Parses two positional file arguments" stays; add "Files are opened after parsing; an unopenable path is a usage error (exit 2)." Set `__updated__` and `@deffield updated` to `2026-09-12`.
+
+- [ ] **Step 5: Run the script tests on 3.12 and 3.14, then the gates**
+
+```bash
+uv run --python 3.14 --extra rdf --extra xml --extra dot --extra graph pytest src/prov/tests/test_scripts.py src/prov/tests/test_cli_smoke.py -q -W error::PendingDeprecationWarning
+uv sync --extra rdf --extra xml --extra dot --extra graph --group bench
+uv run pytest src/prov/tests/test_scripts.py src/prov/tests/test_cli_smoke.py -q
+uv run mypy src && uv run ruff check src/ benchmarks/ && uv run ruff format --check src/ benchmarks/
+```
+
+Expected: all pass on both interpreters; mypy and ruff clean.
+
+- [ ] **Step 6: Make CI enforce it**
+
+`.github/workflows/CI.yml`, own-warnings job: change the two comment lines "prov must raise no DeprecationWarning or / FutureWarning of its own" to "prov must raise no DeprecationWarning, / PendingDeprecationWarning or FutureWarning of its own", change `python-version: "3.12"` to `python-version: "3.14"` (the newest interpreter is where deprecations first appear), change the step name to "Run the suite with prov's own deprecation warnings as errors (Python 3.14)", and change the filter to:
+
+```yaml
+          uv run --no-sync pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::PendingDeprecationWarning:prov\nerror::FutureWarning:prov'
+```
+
+`docs/releasing.md`, the pre-flight block: change the comment to "prov must raise no DeprecationWarning, PendingDeprecationWarning or FutureWarning of its own (#340, #441)" and the command to `uv run --python 3.14 --extra rdf --extra xml --extra dot --extra graph pytest -q -o $'filterwarnings=\nerror::DeprecationWarning:prov\nerror::PendingDeprecationWarning:prov\nerror::FutureWarning:prov'`.
+
+`CLAUDE.md`: change "fails if `prov` raises a `DeprecationWarning` or `FutureWarning` of its own (#340)" to "fails if `prov` raises a `DeprecationWarning`, `PendingDeprecationWarning` or `FutureWarning` of its own on the newest interpreter (#340, #441)".
+
+- [ ] **Step 7: Changelog, spec and plan**
+
+`HISTORY.md`, under 3.2.1 › Fixes, after the existing bullets:
+
+```markdown
+- `prov-convert` and `prov-compare` open their files after parsing arguments instead of
+  through `argparse.FileType`, which Python 3.14 deprecates; standard input and output are
+  used only when no file is given and are no longer closed by the tool, `--version` and
+  `--help` no longer need a binary stdout, and `prov-compare` reports a missing file
+  argument as a usage error. The own-warnings CI guard runs on Python 3.14 and treats
+  `PendingDeprecationWarning` as an error
+  ([#441](https://github.com/trungdong/prov/issues/441))
+```
+
+`planning/specs/2026-09-12-release-3.2.1-design.md`: insert before `## 3. Documentation changes`:
+
+```markdown
+### 2.6 CLI scripts stop using `argparse.FileType` (#441)
+
+**Current behaviour.** `prov-convert` and `prov-compare` declare their file
+arguments with `argparse.FileType`, which Python 3.14 marks deprecated
+(`PendingDeprecationWarning` attributed to `prov.scripts.convert` and
+`prov.scripts.compare`). The own-warnings CI guard runs on 3.12 and filters
+`DeprecationWarning` and `FutureWarning` only, so it does not see it.
+`prov-convert` also closes `sys.stdout.buffer` after writing to it when no
+output file is given.
+
+**Change.** Both scripts take plain path strings and open them after
+parsing, reporting an unopenable path through `parser.error()` (exit 2, as
+before). `-` and the defaults mean the standard streams, which are not
+closed. `prov-compare`'s two files become required positionals, so a missing
+one is a usage error. The own-warnings guard moves to Python 3.14 and adds
+`PendingDeprecationWarning`, in CI and in the release runbook's pre-flight.
+
+**Tests.** Both `main()` functions run clean under
+`warnings.simplefilter("error", PendingDeprecationWarning)` on 3.14;
+`--version` works with a `StringIO` stdout; stdin-to-stdout conversion leaves
+both standard streams open; an unwritable output path and a single
+`prov-compare` positional exit 2.
+```
+
+and in `## 4. Out of scope`, replace the first bullet's text "Filing the findings as GitHub issues." with "Filing the findings as GitHub issues. Of the open issues, only #441 is folded in (section 2.6); #449 and #450 stay at 3.3.0 because they change emitted output or restructure files this release fixes."
+
+`planning/plans/2026-09-12-release-3.2.1.md`: add a PR map row `| H | 8 | `fix/cli-open-after-parse` |` between F and G; insert this task's full text (this brief, from `### Task 8` to the end of its steps) after Task 5 and before Task 6; in Task 6, change the expected suite count from 2466 to 2470 in the Verify line, Step 4's pytest expectation and the PR body; and add the decision "Fold in #441; leave #449, #450, #444 for 3.3.0." under **User decisions (already made)**.
+
+- [ ] **Step 8: Full gates, commit, PR**
+
+```bash
+uv run --extra rdf --extra xml --extra dot --extra graph pytest -q -rsx | tail -3
+codacy-analysis analyze --files src/prov/scripts/convert.py src/prov/scripts/compare.py src/prov/tests/test_scripts.py .github/workflows/CI.yml docs/releasing.md CLAUDE.md HISTORY.md planning/specs/2026-09-12-release-3.2.1-design.md planning/plans/2026-09-12-release-3.2.1.md
+git add -A src .github docs CLAUDE.md HISTORY.md planning/specs planning/plans/2026-09-12-release-3.2.1.md
+git commit -m "fix(cli): open files after parsing instead of through argparse.FileType"
+git push -u origin fix/cli-open-after-parse
+gh pr create --title "fix(cli): open files after parsing instead of through argparse.FileType" --body "prov-convert and prov-compare declared their file arguments with argparse.FileType, which Python 3.14 marks deprecated (PendingDeprecationWarning attributed to prov.scripts.convert and prov.scripts.compare). The own-warnings guard runs on 3.12 and filters DeprecationWarning and FutureWarning only, so CI did not see it. prov-convert also closed sys.stdout.buffer after writing to it when no output file was given.
+
+Both scripts now take plain paths and open them after parsing, reporting an unopenable path through parser.error() (exit 2, as before). The standard streams are used for '-' and the defaults and are no longer closed; --version and --help no longer need a binary stdout; prov-compare's two files are required positionals, so a missing one is a usage error. The own-warnings CI job moves to Python 3.14 and adds PendingDeprecationWarning, as does the release runbook's pre-flight. The 3.2.1 spec and plan gain the matching section and task.
+
+Closes #441.
+
+Suite: 2470 passed, 26 skipped, 191 xfailed."
+gh pr checks --watch
+```
+
+Do not merge; report the PR number and check results.
+
+---
+
 ### Task 6: Stamp 3.2.1
 
 **Goal:** The five stamp files carry 3.2.1 and the release date, the how-to has its "Large documents" section, and `HISTORY.md`'s heading is dated.
@@ -953,7 +1261,7 @@ gh pr checks --watch && gh pr merge --merge --delete-branch
 - [ ] `HISTORY.md` reads `## 3.2.1 (YYYY-MM-DD)` with the actual date; `ROADMAP.md` has the 3.2.1 row; `conformance.md`'s revision sentence names 3.2.1
 - [ ] Pre-flight gates from `docs/releasing.md` §1 all green on this branch
 
-**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q | tail -1` → `2466 passed, 26 skipped, 191 xfailed`; `grep -n "3.2.1" src/prov/__init__.py CITATION.cff HISTORY.md ROADMAP.md docs/reference/conformance.md` → five hits.
+**Verify:** `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q | tail -1` → `2470 passed, 26 skipped, 191 xfailed`; `grep -n "3.2.1" src/prov/__init__.py CITATION.cff HISTORY.md ROADMAP.md docs/reference/conformance.md` → five hits.
 
 **Steps:**
 
@@ -1021,7 +1329,7 @@ gh pr create --title "Release 3.2.1" --body "Stamps 3.2.1: version, CITATION.cff
 
 3.2.1 corrects what the by-eye verification of the 3.2.0 PROV-N parser found. The default profile is the Recommendation grammar plus the bare mentionOf keyword only (the shorthand keywords 3.2.0 accepted are written by no producer); the lenient profile warns once per skipped statement; the PROV-XML reader resolves ProvToolbox's nested hadMember reference instead of minting an identifier from whitespace; the PROV-JSONLD reader accepts an array-valued Membership entity as the submission allows; PROV-N booleans are written true and false.
 
-Pre-flight per docs/releasing.md section 1 is green on all six interpreters. Suite: 2466 passed, 26 skipped, 191 xfailed."
+Pre-flight per docs/releasing.md section 1 is green on all six interpreters. Suite: 2470 passed, 26 skipped, 191 xfailed."
 gh pr checks --watch && gh pr merge --merge --delete-branch
 ```
 

--- a/planning/specs/2026-09-12-release-3.2.1-design.md
+++ b/planning/specs/2026-09-12-release-3.2.1-design.md
@@ -181,6 +181,29 @@ parser is unchanged. No fixture in the repository pins the old spelling
 **Tests.** A writer test asserts the new spelling and that the output parses
 back to an equal document.
 
+### 2.6 CLI scripts stop using `argparse.FileType` (#441)
+
+**Current behaviour.** `prov-convert` and `prov-compare` declare their file
+arguments with `argparse.FileType`, which Python 3.14 marks deprecated
+(`PendingDeprecationWarning` attributed to `prov.scripts.convert` and
+`prov.scripts.compare`). The own-warnings CI guard runs on 3.12 and filters
+`DeprecationWarning` and `FutureWarning` only, so it does not see it.
+`prov-convert` also closes `sys.stdout.buffer` after writing to it when no
+output file is given.
+
+**Change.** Both scripts take plain path strings and open them after
+parsing, reporting an unopenable path through `parser.error()` (exit 2, as
+before). `-` and the defaults mean the standard streams, which are not
+closed. `prov-compare`'s two files become required positionals, so a missing
+one is a usage error. The own-warnings guard moves to Python 3.14 and adds
+`PendingDeprecationWarning`, in CI and in the release runbook's pre-flight.
+
+**Tests.** Both `main()` functions run clean under
+`warnings.simplefilter("error", PendingDeprecationWarning)` on 3.14;
+`--version` works with a `StringIO` stdout; stdin-to-stdout conversion leaves
+both standard streams open; an unwritable output path and a single
+`prov-compare` positional exit 2.
+
 ## 3. Documentation changes
 
 - `docs/howto/provn.md` gains a short "Large documents" section: the parser
@@ -195,7 +218,9 @@ back to an equal document.
 
 ## 4. Out of scope
 
-- Filing the findings as GitHub issues. The changelog is the record; the
+- Filing the findings as GitHub issues. Of the open issues, only #441 is folded in
+  (section 2.6); #449 and #450 stay at 3.3.0 because they change emitted output or
+  restructure files this release fixes. The changelog is the record; the
   verification notebook and its `findings.md` are kept outside the repository.
 - Reducing the parser's peak memory (materialising tokens lazily). Documented,
   not changed.

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -9,14 +9,15 @@ prov-compare -- Compare two PROV documents (PROV-JSON, PROV-XML, PROV-O or PROV-
 @license:    MIT Licence
 
 @contact:    trungdong@donggiang.com
-@deffield    updated: 2026-09-10
+@deffield    updated: 2026-09-12
 """
 
 import logging
 import os
 import sys
 import traceback
-from argparse import ArgumentParser, FileType, RawDescriptionHelpFormatter
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from typing import BinaryIO
 
 from prov.model import ProvDocument
 
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 __all__: list[str] = []
 __version__ = 0.1
 __date__ = "2015-06-16"
-__updated__ = "2026-09-10"
+__updated__ = "2026-09-12"
 
 DEBUG = 0
 TESTRUN = 0
@@ -48,7 +49,8 @@ def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
 
     Parses two positional file arguments plus ``-f/--format1`` and
     ``-F/--format2`` (each defaulting to ``"json"``), deserializes both
-    files, and compares the resulting documents for equality.
+    files, and compares the resulting documents for equality. Files are
+    opened after parsing; an unopenable path is a usage error (exit 2).
 
     Args:
         argv: Extra command-line arguments. If not ``None``, they are
@@ -93,8 +95,8 @@ USAGE
         parser = ArgumentParser(
             description=program_license, formatter_class=RawDescriptionHelpFormatter
         )
-        parser.add_argument("file1", nargs="?", type=FileType("r"))
-        parser.add_argument("file2", nargs="?", type=FileType("r"))
+        parser.add_argument("file1", help="first document")
+        parser.add_argument("file2", help="second document")
         parser.add_argument(
             "-f",
             "--format1",
@@ -115,20 +117,20 @@ USAGE
             "-V", "--version", action="version", version=program_version_message
         )
 
-        args = None
+        args = parser.parse_args()
+        opened: list[BinaryIO] = []
         try:
-            # Process arguments
-            args = parser.parse_args()
-            doc1 = ProvDocument.deserialize(args.file1, format=args.format1.lower())
-            doc2 = ProvDocument.deserialize(args.file2, format=args.format2.lower())
+            for path in (args.file1, args.file2):
+                try:
+                    opened.append(open(path, "rb"))  # noqa: SIM115 -- closed by main()
+                except OSError as exc:
+                    parser.error(f"can't open '{path}': {exc}")
+            doc1 = ProvDocument.deserialize(opened[0], format=args.format1.lower())
+            doc2 = ProvDocument.deserialize(opened[1], format=args.format2.lower())
             return doc1 != doc2
-
         finally:
-            if args:
-                if args.file1:
-                    args.file1.close()
-                if args.file2:
-                    args.file2.close()
+            for stream in opened:
+                stream.close()
 
     except Exception as e:
         if DEBUG or TESTRUN:

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -9,16 +9,15 @@ convert -- Convert a PROV document between PROV-JSON, PROV-N, PROV-XML, PROV-O, 
 @license:    MIT License
 
 @contact:    trungdong@donggiang.com
-@deffield    updated: 2026-09-10
+@deffield    updated: 2026-09-12
 """
 
-import io
 import logging
 import os
 import sys
 import traceback
-from argparse import ArgumentParser, FileType, RawDescriptionHelpFormatter
-from typing import cast
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from typing import BinaryIO, cast
 
 from prov import serializers
 from prov.model import ProvDocument
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 __all__: list[str] = []
 __version__ = 0.1
 __date__ = "2014-03-14"
-__updated__ = "2026-09-10"
+__updated__ = "2026-09-12"
 
 DEBUG = 0
 TESTRUN = 0
@@ -84,9 +83,30 @@ class CLIError(Exception):
         return self.msg
 
 
+def _open_binary(
+    parser: ArgumentParser, path: str, mode: str, standard_name: str
+) -> tuple[BinaryIO, bool]:
+    """Open ``path`` in binary ``mode``, or return the standard stream for ``"-"``.
+
+    ``standard_name`` is ``"stdin"`` or ``"stdout"``; its ``.buffer`` is
+    resolved only when ``path`` is ``"-"``, so the other standard stream is
+    never touched. The second element says whether the caller owns the
+    returned stream and must close it; the standard streams belong to the
+    process. An unopenable path is reported through
+    :meth:`argparse.ArgumentParser.error`, which exits with status 2 like
+    argparse's own file handling did.
+    """
+    if path == "-":
+        return cast(BinaryIO, getattr(sys, standard_name).buffer), False
+    try:
+        return cast(BinaryIO, open(path, mode)), True
+    except OSError as exc:
+        parser.error(f"can't open '{path}': {exc}")
+
+
 def convert_file(
-    infile: io.FileIO,
-    outfile: io.FileIO,
+    infile: BinaryIO,
+    outfile: BinaryIO,
     output_format: str,
     input_format: str = "json",
 ) -> None:
@@ -145,7 +165,8 @@ def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
 
     Parses ``-f/--format``, ``-i/--input-format``, an optional input file
     (default stdin), and an optional output file (default stdout), then
-    converts between them via :func:`convert_file`.
+    converts between them via :func:`convert_file`. Files are opened after
+    parsing; the standard streams are used for ``-`` and are not closed.
 
     Args:
         argv: Extra command-line arguments. If not ``None``, they are
@@ -204,28 +225,32 @@ USAGE
             default="json",
             help="output format: json, xml, rdf, jsonld, provn, or a Graphviz output format (e.g. svg, pdf, png)",
         )
-        parser.add_argument("infile", nargs="?", type=FileType("rb"), default="-")
-        parser.add_argument("outfile", nargs="?", type=FileType("wb"), default="-")
+        parser.add_argument(
+            "infile", nargs="?", default="-", help="input file (default: stdin)"
+        )
+        parser.add_argument(
+            "outfile", nargs="?", default="-", help="output file (default: stdout)"
+        )
         parser.add_argument(
             "-V", "--version", action="version", version=program_version_message
         )
 
-        args = None
+        args = parser.parse_args()
+        owned: list[BinaryIO] = []
         try:
-            # Process arguments
-            args = parser.parse_args()
+            infile, owns_infile = _open_binary(parser, args.infile, "rb", "stdin")
+            if owns_infile:
+                owned.append(infile)
+            outfile, owns_outfile = _open_binary(parser, args.outfile, "wb", "stdout")
+            if owns_outfile:
+                owned.append(outfile)
             convert_file(
-                args.infile,
-                args.outfile,
-                args.format.lower(),
-                args.input_format.lower(),
+                infile, outfile, args.format.lower(), args.input_format.lower()
             )
+            outfile.flush()
         finally:
-            if args:
-                if args.infile:
-                    args.infile.close()
-                if args.outfile:
-                    args.outfile.close()
+            for stream in owned:
+                stream.close()
 
         return 0
     except KeyboardInterrupt:

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -18,6 +18,7 @@ import contextlib
 import io
 import shutil
 import sys
+import warnings
 
 import pytest
 
@@ -142,10 +143,9 @@ def test_convert_file_raises_cli_error_for_unsupported_format(infile, tmp_path):
 
 
 def test_convert_missing_input_file_exits_2(infile, tmp_path, monkeypatch):
-    # FileType('rb') fails to open a nonexistent path *inside argparse*,
-    # which calls parser.error() -> sys.exit(2); that SystemExit
-    # propagates straight out of main() without being caught by the
-    # `except Exception` handler.
+    # A path that cannot be opened is reported through parser.error(),
+    # which exits 2; that SystemExit propagates out of main() rather than
+    # being caught by the `except Exception` handler.
     missing = tmp_path / "does-not-exist.json"
     outfile = tmp_path / "doc.xml"
     monkeypatch.setattr(
@@ -157,13 +157,11 @@ def test_convert_missing_input_file_exits_2(infile, tmp_path, monkeypatch):
     assert ctx.value.code == 2
 
 
-def test_convert_version_exits_0(monkeypatch):
+def test_convert_version_exits_0_without_stdout_buffer(monkeypatch):
+    # Files are opened after parsing, so --version never needs
+    # sys.stdout.buffer; a plain StringIO stdout must do.
     monkeypatch.setattr(sys, "argv", ["prov-convert", "--version"])
-    # argparse's --version action exits before argument parsing reaches
-    # infile/outfile, but their defaults (sys.stdin.buffer/sys.stdout.buffer)
-    # are still evaluated when the arguments are added, so stdout needs a
-    # .buffer attribute here too.
-    monkeypatch.setattr(sys, "stdout", io.TextIOWrapper(io.BytesIO()))
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
     with pytest.raises(SystemExit) as ctx:
         convert_main()
     assert ctx.value.code == 0
@@ -281,6 +279,46 @@ def test_convert_works_with_stdin_set_to_none(infile, tmp_path, monkeypatch):
     assert outfile.stat().st_size > 0
 
 
+def test_convert_leaves_standard_streams_open(provn_infile, monkeypatch):
+    # "-" (the default) means the standard streams, which belong to the
+    # caller: the tool must not close them after use.
+    stdin = io.TextIOWrapper(io.BytesIO(provn_infile.read_bytes()))
+    stdout = io.TextIOWrapper(io.BytesIO())
+    monkeypatch.setattr(sys, "argv", ["prov-convert", "-i", "provn", "-f", "json"])
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    assert convert_main() == 0
+    assert not stdin.buffer.closed
+    assert not stdout.buffer.closed
+    stdout.flush()
+    written = stdout.buffer.getvalue().decode("utf-8")
+    assert ProvDocument.deserialize(content=written, format="json") == primer_example()
+
+
+def test_convert_unwritable_output_path_exits_2(infile, tmp_path, monkeypatch):
+    outfile = tmp_path / "no-such-dir" / "doc.xml"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-f", "xml", str(infile), str(outfile)]
+    )
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        convert_main()
+    assert ctx.value.code == 2
+
+
+def test_convert_raises_no_pending_deprecation_warning(infile, tmp_path, monkeypatch):
+    # argparse.FileType is deprecated from Python 3.14 (#441); the scripts
+    # must not use it on any interpreter.
+    outfile = tmp_path / "doc.xml"
+    monkeypatch.setattr(
+        sys, "argv", ["prov-convert", "-f", "xml", str(infile), str(outfile)]
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        assert convert_main() == 0
+
+
 @pytest.fixture
 def compare_files(tmp_path):
     json_file = tmp_path / "doc.json"
@@ -381,3 +419,25 @@ def test_closes_both_files_on_error(compare_files, monkeypatch):
     assert len(captured_sources) == 2
     for source in captured_sources:
         assert source.closed
+
+
+def test_compare_one_positional_exits_2(compare_files, monkeypatch):
+    json_file, _xml_file = compare_files
+    monkeypatch.setattr(sys, "argv", ["prov-compare", str(json_file)])
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        compare_main()
+    assert ctx.value.code == 2
+
+
+def test_compare_raises_no_pending_deprecation_warning(compare_files, monkeypatch):
+    json_file, xml_file = compare_files
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prov-compare", "-f", "json", "-F", "xml", str(json_file), str(xml_file)],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        assert compare_main() == 0


### PR DESCRIPTION
prov-convert and prov-compare declared their file arguments with argparse.FileType, which Python 3.14 marks deprecated (PendingDeprecationWarning attributed to prov.scripts.convert and prov.scripts.compare). The own-warnings guard runs on 3.12 and filters DeprecationWarning and FutureWarning only, so CI did not see it. prov-convert also closed sys.stdout.buffer after writing to it when no output file was given.

Both scripts now take plain paths and open them after parsing, reporting an unopenable path through parser.error() (exit 2, as before). The standard streams are used for '-' and the defaults and are no longer closed; --version and --help no longer need a binary stdout; prov-compare's two files are required positionals, so a missing one is a usage error. The own-warnings CI job moves to Python 3.14 and adds PendingDeprecationWarning, as does the release runbook's pre-flight. The 3.2.1 spec and plan gain the matching section and task.

Closes #441.

Suite: 2470 passed, 26 skipped, 191 xfailed.