### PR TITLE
fix(cli): prov-compare accepts '-' for standard input again

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 3.2.1 is a point release that corrects what a by-eye verification of the 3.2.0 PROV-N
 parser against ProvToolbox and PLEAD documents found: the `default` profile, the
-lenient profile's warnings, the PROV-XML and PROV-JSONLD readers on ProvToolbox output,
+`lenient` profile's warnings, the PROV-XML and PROV-JSONLD readers on ProvToolbox output,
 and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 
 ### Fixes
@@ -37,7 +37,7 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   producer writes the words
 - `prov-convert` and `prov-compare` open their files after parsing arguments instead of
   through `argparse.FileType`, which Python 3.14 deprecates; standard input and output are
-  used only when no file is given and are no longer closed by the tool, `--version` and
+  used when no file or `-` is given and are no longer closed by the tool, `--version` and
   `--help` no longer need a binary stdout, and `prov-compare` reports a missing file
   argument as a usage error. The own-warnings CI guard runs on Python 3.14 and treats
   `PendingDeprecationWarning` as an error

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,10 +44,9 @@ code changes.
 `prov` supports all non-EOL CPython versions and drops a version in the first release
 after it reaches end of life, the policy set when the 3.9 floor was dropped ahead of
 schedule in 2.3.0 (see "What changes in 3.0" below for the history). Python 3.10
-reaches EOL on 2026-10-31. 3.2.0 is targeted before that date and keeps the 3.10 floor,
-so it is the last release to support Python 3.10; the floor rises to 3.11 in 3.3.0, the
-first release after Python 3.10's EOL. If 3.2.0 slips past 2026-10-31, the floor rises in
-3.2.0 instead, under the same policy.
+reaches EOL on 2026-10-31. 3.2.0 shipped before that date and keeps the 3.10 floor,
+so the 3.2.x line is the last to support Python 3.10; the floor rises to 3.11 in 3.3.0, the
+first release after Python 3.10's EOL.
 
 ## What changes in 3.0
 

--- a/docs/howto/cli.md
+++ b/docs/howto/cli.md
@@ -76,7 +76,7 @@ in any registered format.
 ### Synopsis
 
 ```bash
-prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] [file1] [file2]
+prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] file1 file2
 ```
 
 ### Options
@@ -87,7 +87,7 @@ prov-compare [-h] [-f FORMAT1] [-F FORMAT2] [-V] [file1] [file2]
 | `-F`, `--format2` | `FORMAT2` | `json` | Format of `file2`: `json`, `xml`, `rdf`, `jsonld` or `provn` |
 | `-V`, `--version` | | | Print the version and exit |
 | `-h`, `--help` | | | Print usage and exit |
-| `file1`, `file2` | | | The two files to compare |
+| `file1`, `file2` | | | The two files to compare; `-` reads one of them from standard input |
 
 ### Examples
 

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -50,7 +50,9 @@ def main(argv: list[str] | None = None) -> int:  # IGNORE:C0111
     Parses two positional file arguments plus ``-f/--format1`` and
     ``-F/--format2`` (each defaulting to ``"json"``), deserializes both
     files, and compares the resulting documents for equality. Files are
-    opened after parsing; an unopenable path is a usage error (exit 2).
+    opened after parsing; ``-`` stands for standard input for at most one
+    of them and is not closed; an unopenable path is a usage error
+    (exit 2).
 
     Args:
         argv: Extra command-line arguments. If not ``None``, they are
@@ -95,8 +97,8 @@ USAGE
         parser = ArgumentParser(
             description=program_license, formatter_class=RawDescriptionHelpFormatter
         )
-        parser.add_argument("file1", help="first document")
-        parser.add_argument("file2", help="second document")
+        parser.add_argument("file1", help="first document ('-' reads standard input)")
+        parser.add_argument("file2", help="second document ('-' reads standard input)")
         parser.add_argument(
             "-f",
             "--format1",
@@ -118,15 +120,23 @@ USAGE
         )
 
         args = parser.parse_args()
+        if args.file1 == "-" and args.file2 == "-":
+            parser.error("only one of file1 and file2 may be '-' (standard input)")
         opened: list[BinaryIO] = []
         try:
+            streams: list[BinaryIO] = []
             for path in (args.file1, args.file2):
+                if path == "-":
+                    streams.append(sys.stdin.buffer)
+                    continue
                 try:
-                    opened.append(open(path, "rb"))  # noqa: SIM115 -- closed by main()
+                    stream: BinaryIO = open(path, "rb")  # noqa: SIM115 -- closed by main()
                 except OSError as exc:
                     parser.error(f"can't open '{path}': {exc}")
-            doc1 = ProvDocument.deserialize(opened[0], format=args.format1.lower())
-            doc2 = ProvDocument.deserialize(opened[1], format=args.format2.lower())
+                opened.append(stream)
+                streams.append(stream)
+            doc1 = ProvDocument.deserialize(streams[0], format=args.format1.lower())
+            doc2 = ProvDocument.deserialize(streams[1], format=args.format2.lower())
             return doc1 != doc2
         finally:
             for stream in opened:

--- a/src/prov/tests/test_jsonld.py
+++ b/src/prov/tests/test_jsonld.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 
 import prov
-from prov.model import Literal, ProvDocument
+from prov.constants import PROV
+from prov.model import Literal, ProvDocument, ProvMembership
 from prov.serializers.provjsonld import (
     JSONLD_CONTEXT_URL,
     ProvJSONLDException,
@@ -354,6 +355,29 @@ def test_deserialize_membership_single_element_array():
 def test_deserialize_membership_empty_entity_array_raises():
     with pytest.raises(ProvJSONLDException, match="empty"):
         ProvDocument.deserialize(content=_membership_payload([]), format="jsonld")
+
+
+def test_deserialize_membership_array_shares_id_and_attributes():
+    payload = json.dumps(
+        {
+            "@context": [{"ex": EX_URI}, JSONLD_CONTEXT_URL],
+            "@graph": [
+                {"@type": "Entity", "@id": "ex:c"},
+                {
+                    "@type": "Membership",
+                    "@id": "ex:m",
+                    "collection": "ex:c",
+                    "entity": ["ex:e1", "ex:e2"],
+                    "label": [{"@value": "members"}],
+                },
+            ],
+        }
+    )
+    doc = ProvDocument.deserialize(content=payload, format="jsonld")
+    memberships = sorted(doc.get_records(ProvMembership), key=lambda r: str(r.args[1]))
+    assert [str(r.identifier) for r in memberships] == ["ex:m", "ex:m"]
+    assert [str(r.args[1]) for r in memberships] == ["ex:e1", "ex:e2"]
+    assert all(list(r.get_attribute(PROV["label"])) == ["members"] for r in memberships)
 
 
 def _expected_primer_document() -> ProvDocument:

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -441,3 +441,22 @@ def test_compare_raises_no_pending_deprecation_warning(compare_files, monkeypatc
         warnings.simplefilter("error", PendingDeprecationWarning)
         warnings.simplefilter("error", DeprecationWarning)
         assert compare_main() == 0
+
+
+def test_compare_reads_one_file_from_stdin_for_dash(compare_files, monkeypatch):
+    json_file, xml_file = compare_files
+    stdin = io.TextIOWrapper(io.BytesIO(json_file.read_bytes()))
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(
+        sys, "argv", ["prov-compare", "-f", "json", "-F", "xml", "-", str(xml_file)]
+    )
+    assert compare_main() == 0
+    assert not stdin.buffer.closed
+
+
+def test_compare_two_dashes_exits_2(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prov-compare", "-", "-"])
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit) as ctx:
+        compare_main()
+    assert ctx.value.code == 2


### PR DESCRIPTION
The whole-release review of 3.2.1 found that replacing argparse.FileType in prov-compare dropped its handling of '-', which FileType mapped to standard input, so 'cat a.json | prov-compare - b.json' exited 2 with "can't open '-'". '-' now stands for standard input for at most one of the two files and is not closed, matching prov-convert; two dashes are a usage error.

Also from the review: the CLI how-to's prov-compare synopsis shows the two files as required, the 3.2.1 changelog mentions '-' alongside the defaults and puts the lenient profile in code font, the roadmap's Python-support sentence no longer says 3.2.0 is the last 3.10 release now that 3.2.1 follows it, and a test pins that a Membership with an @id and a label fans out to records sharing both.

Suite: 2473 passed, 26 skipped, 191 xfailed.