### PR TITLE
refactor: cleanups from the 3.2.x quality review

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -42,6 +42,9 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   argument as a usage error. The own-warnings CI guard runs on Python 3.14 and treats
   `PendingDeprecationWarning` as an error
   ([#441](https://github.com/trungdong/prov/issues/441))
+- PROV-XML reader warnings (`<prov:other>` skipped, unrepresentable attribute, nested
+  reference) are attributed to the caller of `deserialize()` or `prov.read()` rather than to
+  a frame inside `prov`, as the PROV-N reader's already are
 
 ## 3.2.0 (2026-09-12)
 

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -51,7 +51,3 @@ def build_document(n: int = N) -> ProvDocument:
 @pytest.fixture(scope="session")
 def document() -> ProvDocument:
     return build_document()
-
-
-def serialized(doc: ProvDocument, fmt: str) -> str:
-    return doc.serialize(format=fmt)

--- a/benchmarks/test_bench.py
+++ b/benchmarks/test_bench.py
@@ -10,7 +10,7 @@ import pytest
 
 from prov.model import ProvDocument
 
-from .conftest import N, build_document, serialized
+from .conftest import N, build_document
 
 FORMATS = ("json", "xml", "rdf", "provn", "jsonld")
 
@@ -21,12 +21,12 @@ def test_construct(benchmark):
 
 @pytest.mark.parametrize("fmt", FORMATS)
 def test_serialize(benchmark, document, fmt):
-    benchmark(serialized, document, fmt)
+    benchmark(document.serialize, format=fmt)
 
 
 @pytest.mark.parametrize("fmt", FORMATS)
 def test_deserialize(benchmark, document, fmt):
-    content = serialized(document, fmt)
+    content = document.serialize(format=fmt)
     benchmark(ProvDocument.deserialize, content=content, format=fmt)
 
 

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -212,9 +212,6 @@ class QualifiedName(Identifier):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self._str}>"
 
-    def __hash__(self) -> int:
-        return self._hash
-
     def provn_bare_representation(self) -> str:
         """Return the ``prefix:local`` PROV-N form used at IDENTIFIER positions.
 

--- a/src/prov/scripts/__init__.py
+++ b/src/prov/scripts/__init__.py
@@ -1,0 +1,24 @@
+import sys
+from argparse import ArgumentParser
+from typing import BinaryIO, cast
+
+
+def _open_binary(
+    parser: ArgumentParser, path: str, mode: str, standard_name: str
+) -> tuple[BinaryIO, bool]:
+    """Open ``path`` in binary ``mode``, or return the standard stream for ``"-"``.
+
+    ``standard_name`` is ``"stdin"`` or ``"stdout"``; its ``.buffer`` is
+    resolved only when ``path`` is ``"-"``, so the other standard stream is
+    never touched. The second element says whether the caller owns the
+    returned stream and must close it; the standard streams belong to the
+    process. An unopenable path is reported through
+    :meth:`argparse.ArgumentParser.error`, which exits with status 2 like
+    argparse's own file handling did.
+    """
+    if path == "-":
+        return cast(BinaryIO, getattr(sys, standard_name).buffer), False
+    try:
+        return cast(BinaryIO, open(path, mode)), True
+    except OSError as exc:
+        parser.error(f"can't open '{path}': {exc}")

--- a/src/prov/scripts/compare.py
+++ b/src/prov/scripts/compare.py
@@ -20,6 +20,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from typing import BinaryIO
 
 from prov.model import ProvDocument
+from prov.scripts import _open_binary
 
 logger = logging.getLogger(__name__)
 
@@ -122,24 +123,19 @@ USAGE
         args = parser.parse_args()
         if args.file1 == "-" and args.file2 == "-":
             parser.error("only one of file1 and file2 may be '-' (standard input)")
-        opened: list[BinaryIO] = []
+        owned: list[BinaryIO] = []
         try:
             streams: list[BinaryIO] = []
             for path in (args.file1, args.file2):
-                if path == "-":
-                    streams.append(sys.stdin.buffer)
-                    continue
-                try:
-                    stream: BinaryIO = open(path, "rb")  # noqa: SIM115 -- closed by main()
-                except OSError as exc:
-                    parser.error(f"can't open '{path}': {exc}")
-                opened.append(stream)
+                stream, owns = _open_binary(parser, path, "rb", "stdin")
+                if owns:
+                    owned.append(stream)
                 streams.append(stream)
             doc1 = ProvDocument.deserialize(streams[0], format=args.format1.lower())
             doc2 = ProvDocument.deserialize(streams[1], format=args.format2.lower())
             return doc1 != doc2
         finally:
-            for stream in opened:
+            for stream in owned:
                 stream.close()
 
     except Exception as e:

--- a/src/prov/scripts/convert.py
+++ b/src/prov/scripts/convert.py
@@ -21,6 +21,7 @@ from typing import BinaryIO, cast
 
 from prov import serializers
 from prov.model import ProvDocument
+from prov.scripts import _open_binary
 
 logger = logging.getLogger(__name__)
 
@@ -81,27 +82,6 @@ class CLIError(Exception):
 
     def __str__(self) -> str:
         return self.msg
-
-
-def _open_binary(
-    parser: ArgumentParser, path: str, mode: str, standard_name: str
-) -> tuple[BinaryIO, bool]:
-    """Open ``path`` in binary ``mode``, or return the standard stream for ``"-"``.
-
-    ``standard_name`` is ``"stdin"`` or ``"stdout"``; its ``.buffer`` is
-    resolved only when ``path`` is ``"-"``, so the other standard stream is
-    never touched. The second element says whether the caller owns the
-    returned stream and must close it; the standard streams belong to the
-    process. An unopenable path is reported through
-    :meth:`argparse.ArgumentParser.error`, which exits with status 2 like
-    argparse's own file handling did.
-    """
-    if path == "-":
-        return cast(BinaryIO, getattr(sys, standard_name).buffer), False
-    try:
-        return cast(BinaryIO, open(path, mode)), True
-    except OSError as exc:
-        parser.error(f"can't open '{path}': {exc}")
 
 
 def convert_file(

--- a/src/prov/serializers/provn_parser.py
+++ b/src/prov/serializers/provn_parser.py
@@ -66,6 +66,15 @@ __all__ = ["PROFILES", "ProvNParser"]
 
 PROFILES = ("strict", "default", "lenient")
 
+
+def _default_namespace(bundle: ProvBundle) -> Namespace | None:
+    """The bundle's default namespace, falling back to its document's."""
+    default = bundle.get_default_namespace()
+    if default is None and bundle.document is not None:
+        default = bundle.document.get_default_namespace()
+    return default
+
+
 # keyword -> (record type, allowed argument counts after the identifier)
 _ELEMENTS: dict[str, tuple[QualifiedName, tuple[int, ...]]] = {
     "entity": (PROV_ENTITY, (0,)),
@@ -322,7 +331,7 @@ class ProvNParser:
         self.skipped.append(f"PROV-N statement skipped: {error}")
         self._resync(start_depth)
 
-    def _looks_like_statement_start(self, token: Token) -> bool:
+    def _looks_like_statement_start(self) -> bool:
         """A NAME immediately followed by '(' opens a statement.
 
         No production puts '(' after a name inside a statement body
@@ -359,7 +368,7 @@ class ProvNParser:
                 if not prefix and local in _STRUCTURAL:
                     if self._depth <= start_depth:
                         return
-                elif self._looks_like_statement_start(token):
+                elif self._looks_like_statement_start():
                     self._depth = start_depth
                     return
             self._advance()
@@ -430,8 +439,7 @@ class ProvNParser:
             raise self._error(
                 f"'{keyword.text}' takes {allowed} arguments, got {len(args)}", keyword
             )
-        _, local = keyword.value
-        self._check_strict_required_positions(keyword, local, args)
+        self._check_strict_required_positions(keyword, args)
         formal_names = PROV_REC_CLS[rec_type].FORMAL_ATTRIBUTES
         attributes = []
         for attr, token in zip(formal_names, args, strict=False):
@@ -441,13 +449,14 @@ class ProvNParser:
         bundle.new_record(rec_type, identifier, attributes, other_attributes)
 
     def _check_strict_required_positions(
-        self, keyword: Token, local: str, args: list[Token]
+        self, keyword: Token, args: list[Token]
     ) -> None:
         """Under ``strict``, reject '-' where the grammar has a plain
         identifier (no ``OrMarker``); ``default``/``lenient`` keep accepting
         it there, matching the model's scruffy-statement policy."""
         if self.profile != "strict":
             return
+        _, local = keyword.value
         required = _STRICT_REQUIRED_LEADING.get(local, 0)
         for index, arg in enumerate(args[:required]):
             if arg.kind is TokenKind.MARKER:
@@ -535,9 +544,7 @@ class ProvNParser:
             # mis-split by valid_qualified_name()'s string-based prefix
             # lookup, so this one shape still resolves against the default
             # namespace directly.
-            default = bundle.get_default_namespace()
-            if default is None and bundle.document is not None:
-                default = bundle.document.get_default_namespace()
+            default = _default_namespace(bundle)
             if default is None:
                 raise self._error(
                     f"cannot resolve {token.text!r}: no default namespace declared",
@@ -593,9 +600,7 @@ class ProvNParser:
                 # inside an unprefixed local part would otherwise be
                 # mis-split by valid_qualified_name()'s string-based prefix
                 # lookup below.
-                default = bundle.get_default_namespace()
-                if default is None and bundle.document is not None:
-                    default = bundle.document.get_default_namespace()
+                default = _default_namespace(bundle)
                 if default is not None:
                     return default[local]
             text = f"{prefix}:{local}" if prefix else local

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -11,6 +11,7 @@ from lxml import etree
 
 import prov.identifier
 import prov.model
+from prov._warnings import external_stacklevel
 from prov.constants import *
 from prov.identifier import _NCNAME_CHARS, _NCNAME_START_CHARS
 from prov.model import (
@@ -300,7 +301,7 @@ class ProvXMLSerializer(Serializer):
                     "Document contains non-PROV information in "
                     "<prov:other>. It will be ignored in this package.",
                     UserWarning,
-                    stacklevel=2,
+                    stacklevel=external_stacklevel(),
                 )
                 continue
 
@@ -628,7 +629,7 @@ def _extract_attributes(
                     "which is not representable in the prov module's "
                     "internal data model and will thus be ignored.",
                     UserWarning,
-                    stacklevel=2,
+                    stacklevel=external_stacklevel(),
                 )
 
         if not subel.attrib:
@@ -667,6 +668,9 @@ def _nested_reference(
     reference is taken, with a warning. Non-blank text is returned as the
     reference. A blank element with no reference anywhere has no value.
 
+    Returns:
+        The referenced qualified name, or the element's non-blank text.
+
     Raises:
         ProvXMLException: If ``subel`` has neither a ``prov:ref`` child nor
             text.
@@ -683,7 +687,7 @@ def _nested_reference(
             "itself; the nested reference is used. The shape is not "
             "PROV-XML schema-valid (ProvToolbox writes it for hadMember).",
             prov.model.ProvWarning,
-            stacklevel=3,
+            stacklevel=external_stacklevel(),
         )
         return xml_qname_to_QualifiedName(children[0], str(children[0].attrib[ref]))
     if subel.text is not None and subel.text.strip():

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -75,40 +75,21 @@ def test_attribute_name_plain_unchanged():
     assert '[ex:plain_key="value"]' in document.get_provn()
 
 
-def test_leading_dash_local_part_is_escaped():
+@pytest.mark.parametrize(
+    ("local", "written"),
+    [
+        ("-abc", "\\-abc"),  # leading dash is escaped
+        (".abc", "\\.abc"),  # leading dot is escaped
+        ("abc.", "abc\\."),  # trailing dot is escaped
+        ("-", "\\-"),  # the Recommendation's own PN_LOCAL example
+        ("ab-cd.ef", "ab-cd.ef"),  # inner dash and dot stay bare
+    ],
+)
+def test_dash_and_dot_local_parts(local, written):
     document = _doc()
-    document.entity("ex:-abc")
+    document.entity(f"ex:{local}")
     provn = _roundtrips(document)
-    assert "entity(ex:\\-abc)" in provn
-
-
-def test_leading_dot_local_part_is_escaped():
-    document = _doc()
-    document.entity("ex:.abc")
-    provn = _roundtrips(document)
-    assert "entity(ex:\\.abc)" in provn
-
-
-def test_trailing_dot_local_part_is_escaped():
-    document = _doc()
-    document.entity("ex:abc.")
-    provn = _roundtrips(document)
-    assert "entity(ex:abc\\.)" in provn
-
-
-def test_bare_dash_local_part_matches_recommendation_example():
-    """The Recommendation's own PN_LOCAL example is ``entity(ex:\\-)``."""
-    document = _doc()
-    document.entity("ex:-")
-    provn = _roundtrips(document)
-    assert "entity(ex:\\-)" in provn
-
-
-def test_inner_dash_and_dot_stay_bare():
-    document = _doc()
-    document.entity("ex:ab-cd.ef")
-    provn = _roundtrips(document)
-    assert "entity(ex:ab-cd.ef)" in provn
+    assert f"entity(ex:{written})" in provn
 
 
 @pytest.mark.parametrize(
@@ -130,23 +111,6 @@ def test_unrepresentable_chars_are_percent_encoded(local, escaped):
     reloaded = ProvDocument.deserialize(content=provn, format="provn")
     (reloaded_entity,) = reloaded.get_records()
     assert reloaded_entity.identifier.localpart == escaped
-
-
-def test_unrepresentable_char_is_percent_encoded():
-    """A space cannot appear in PN_LOCAL even escaped, so it is percent-encoded.
-
-    The local part changes from "a b" to "a%20b", so the reloaded
-    QualifiedName is not equal to the original one, a documented exclusion.
-    The entity's own identity still survives the round trip; only this bare
-    local part changes.
-    """
-    document = _doc()
-    document.entity("ex:a b")
-    provn = document.get_provn()
-    assert "entity(ex:a%20b)" in provn
-    reloaded = ProvDocument.deserialize(content=provn, format="provn")
-    (reloaded_entity,) = reloaded.get_records()
-    assert reloaded_entity.identifier.localpart == "a%20b"
 
 
 def test_empty_langtag_literal_written_as_plain_string():

--- a/src/prov/tests/test_provn_lexer.py
+++ b/src/prov/tests/test_provn_lexer.py
@@ -304,10 +304,7 @@ def test_prefix_with_inner_dot_is_still_accepted():
 
 
 def test_qname_literal_trailing_dot_raises():
-    # Unlike the bare form, this used to succeed silently before _PN_LOCAL
-    # excluded a bare trailing '.'; now _QNAME_FULL simply doesn't match
-    # "ex:abc." and _split_qname reports the dot itself, consistent with
-    # test_qname_literal_error_position_is_the_first_invalid_character.
+    # _QNAME_FULL rejects a bare trailing '.'; the reported position is the dot.
     with pytest.raises(ProvNSyntaxError) as ctx:
         list(tokenize("'ex:abc.'"))
     assert (ctx.value.line, ctx.value.column) == (1, 8)

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -18,7 +18,6 @@ import contextlib
 import io
 import shutil
 import sys
-import warnings
 
 import pytest
 
@@ -207,6 +206,10 @@ def provn_infile(tmp_path):
     return path
 
 
+# argparse.FileType is deprecated from Python 3.14 (#441); the scripts must
+# not use it on any interpreter.
+@pytest.mark.filterwarnings("error::PendingDeprecationWarning")
+@pytest.mark.filterwarnings("error::DeprecationWarning")
 def test_convert_from_provn(provn_infile, tmp_path, monkeypatch):
     outfile = tmp_path / "doc.json"
     monkeypatch.setattr(
@@ -306,19 +309,6 @@ def test_convert_unwritable_output_path_exits_2(infile, tmp_path, monkeypatch):
     assert ctx.value.code == 2
 
 
-def test_convert_raises_no_pending_deprecation_warning(infile, tmp_path, monkeypatch):
-    # argparse.FileType is deprecated from Python 3.14 (#441); the scripts
-    # must not use it on any interpreter.
-    outfile = tmp_path / "doc.xml"
-    monkeypatch.setattr(
-        sys, "argv", ["prov-convert", "-f", "xml", str(infile), str(outfile)]
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", PendingDeprecationWarning)
-        warnings.simplefilter("error", DeprecationWarning)
-        assert convert_main() == 0
-
-
 @pytest.fixture
 def compare_files(tmp_path):
     json_file = tmp_path / "doc.json"
@@ -329,6 +319,10 @@ def compare_files(tmp_path):
     return json_file, xml_file
 
 
+# argparse.FileType is deprecated from Python 3.14 (#441); the scripts must
+# not use it on any interpreter.
+@pytest.mark.filterwarnings("error::PendingDeprecationWarning")
+@pytest.mark.filterwarnings("error::DeprecationWarning")
 def test_equivalent_documents_return_0(compare_files, monkeypatch):
     json_file, xml_file = compare_files
     monkeypatch.setattr(
@@ -428,19 +422,6 @@ def test_compare_one_positional_exits_2(compare_files, monkeypatch):
     with pytest.raises(SystemExit) as ctx:
         compare_main()
     assert ctx.value.code == 2
-
-
-def test_compare_raises_no_pending_deprecation_warning(compare_files, monkeypatch):
-    json_file, xml_file = compare_files
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["prov-compare", "-f", "json", "-F", "xml", str(json_file), str(xml_file)],
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", PendingDeprecationWarning)
-        warnings.simplefilter("error", DeprecationWarning)
-        assert compare_main() == 0
 
 
 def test_compare_reads_one_file_from_stdin_for_dash(compare_files, monkeypatch):

--- a/src/prov/tests/test_xml.py
+++ b/src/prov/tests/test_xml.py
@@ -925,3 +925,14 @@ def test_reference_given_as_element_text_still_decodes():
     (membership,) = document.get_records(prov.ProvMembership)
     (member,) = membership.get_attribute(PROV["entity"])
     assert str(member) == "ex:e1"
+
+
+def test_nested_reference_warning_is_attributed_to_the_caller():
+    xml_string = _membership_xml(
+        '<entity>\n          <entity prov:ref="ex:e1"/>\n        </entity>'
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        prov.ProvDocument.deserialize(content=xml_string, format="xml")
+    (warning,) = [w for w in caught if issubclass(w.category, prov.ProvWarning)]
+    assert warning.filename == __file__


### PR DESCRIPTION
Behaviour-preserving cleanups from a reuse, simplification, efficiency and altitude review of everything since 3.1.1.

One _open_binary helper in prov.scripts serves both prov-convert and prov-compare instead of two copies. The PROV-XML reader's three warnings use external_stacklevel(), as the PROV-N reader's do, so they name the caller of deserialize() or prov.read() rather than a frame inside prov; a test pins the attribution. The parser's _looks_like_statement_start no longer takes a token it never read, _check_strict_required_positions derives the keyword's local part itself, and the bundle-then-document default-namespace fallback is one helper instead of two copies. QualifiedName's __hash__ override, identical to the inherited one, is gone. Five near-identical escaping tests are one parametrised test, the two CLI deprecation-warning tests become filterwarnings marks on existing happy-path tests, one stale comment is rewritten, and a one-line benchmark wrapper is removed.

Suite: 2471 passed, 26 skipped, 191 xfailed.