### PR TITLE
planning: 3.2.1 review-fix wave spec and plan

### DIFF
--- a/planning/plans/2026-09-12-release-3.2.1-review-fixes.md
+++ b/planning/plans/2026-09-12-release-3.2.1-review-fixes.md
@@ -1,0 +1,983 @@
+# Release 3.2.1 Review-Fix Wave Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix every confirmed defect from the whole-diff review of 3.1.1..main before 3.2.1 is tagged: identifier pickling and hashing, the namespace resolve cache and empty local parts, eight PROV-N parser gaps, five PROV-N writer gaps, `prov.read()` option handling, PROV-O predicate resolution, the identified Membership fan-out, CLI text stdin, and the documentation the review found wrong.
+
+**Architecture:** Eight code tasks, one PR each, grouped by module so each PR has one reviewer's worth of context; a ninth task refreshes the release date if it moved, re-runs the eye-check notebook against a wheel built from the final `main`, and hands over to the existing publish task. Every code task adds tests that fail before the change and its `HISTORY.md` bullet.
+
+**Tech Stack:** Python 3.10+, `uv`, pytest, mypy `--strict`, ruff, lxml, rdflib, Codacy CLI, `gh`.
+
+**Spec:** `planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md`. Findings source: the `/code-review xhigh changes since 3.1.1` report of 2026-09-12 (fifteen reported plus the sub-cap items it listed).
+
+## Global Constraints
+
+- **Point release, one behaviour reversion allowed per spec §2.1 and §2.6.** No new public names except `Serializer.deserialize_options`; no dependency or floor changes.
+- **Branching and PRs.** Each task branches from up-to-date `origin/main` in the worktree `~/projects/ProvPy/prov-3.2.1`, opens one PR, does not merge; the controller merges after review. Never squash.
+- **Suite invariant.** Baseline `main` @ 6309cbb: **2471 passed, 26 skipped, 191 xfailed**. Each task states its expected delta; skips and xfails unchanged.
+- **Every code task adds its `HISTORY.md` bullets** under `## 3.2.1 (2026-09-12)` › `### Fixes`, after the existing bullets, British English, one bullet per behaviour change, no plan or task references.
+- **Quality gates per PR:** full suite, `uv run mypy src`, `uv run ruff check src/ benchmarks/`, `uv run ruff format --check src/ benchmarks/`, `codacy-analysis analyze --files <changed files>` → `0 issues found` for the changed files (pre-existing findings on `provxml.py:251`, `__init__.py` and `test_scripts.py:407` are not new).
+- **Text.** No em dashes; comments and docstrings present-state; commit and PR paragraphs unwrapped; no AI attribution lines. Warnings raised for third-party input use `prov.model.ProvWarning` with `external_stacklevel()`.
+
+**User decisions (already made):**
+- No cap: every confirmed defect is fixed before tagging.
+- `Identifier` hashes by URI alone (equal objects hash equal); pickles recompute the hash.
+- Empty language tag handling stays as commit 4c213f8 left it.
+- Percent-encoded identifiers warn rather than raise; aliasing documented.
+- Predicates under an undeclared namespace raise (3.1.1 behaviour); values keep minting.
+- An identified Membership with several members drops the `@id` with a warning.
+
+---
+
+## PR map
+
+| PR | Task | Branch |
+|---|---|---|
+| A | 1 | `fix/identifier-pickle-hash` |
+| B | 2 | `fix/namespace-cache-empty-local` |
+| C | 3 | `fix/provn-parser-review` |
+| D | 4 | `fix/provn-writer-review` |
+| E | 5 | `fix/read-options` |
+| F | 6 | `fix/rdf-predicate-namespaces` |
+| G | 7 | `fix/jsonld-membership-id-cli-stdin` |
+| H | 8 | `docs/review-corrections` |
+| – | 9 | refresh, re-verify, then the publish task of `2026-09-12-release-3.2.1.md` |
+
+---
+
+### Task 1: Identifier pickling, weak references and URI-only hashing
+
+**Goal:** `Identifier`, `QualifiedName`, `Namespace` and `Literal` pickle under every protocol, load 3.1.1 pickles, recompute their hash on load, support `weakref.ref`, and equal identifiers hash equal regardless of concrete class.
+
+**Files:**
+- Modify: `src/prov/identifier.py` (`Identifier.__slots__`, `_compute_hash`, new `__getstate__`/`__setstate__`; `QualifiedName._compute_hash` docstring; `Namespace.__slots__`, new `__getstate__`/`__setstate__`)
+- Modify: `src/prov/model/records.py` (`Literal.__slots__`, new `__getstate__`/`__setstate__`)
+- Modify: `src/prov/tests/test_identifier_slots.py`
+- Modify: `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] `pickle.dumps(obj, protocol=p)` round-trips for `p` in 0..`HIGHEST_PROTOCOL` for all four types and equals the original
+- [ ] A `QualifiedName` pickled in a subprocess with `PYTHONHASHSEED=1` and loaded in a process with seed 2 is found in a dict keyed by a fresh equal `QualifiedName`
+- [ ] `__setstate__` accepts the 3.1.1 dict state (fields without `_hash`) and the object hashes and compares correctly
+- [ ] `weakref.ref(obj)` works for all four types on CPython
+- [ ] `hash(Identifier("http://e/x")) == hash(Namespace("ex", "http://e/")["x"])`
+- [ ] Suite: 2471 minus the rewritten test cases plus the new ones; report the count
+
+**Verify:** `uv run pytest src/prov/tests/test_identifier_slots.py src/prov/tests/test_model.py src/prov/tests/test_qnames.py -q` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Tests.** In `src/prov/tests/test_identifier_slots.py`, add `import subprocess`, `import sys`, `import weakref` to the imports and replace `test_copy_and_pickle_preserve_equality`, `test_qualified_name_hash_is_stored_and_uri_based` and `test_identifier_hash_unchanged` with:
+
+```python
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_copy_preserves_equality(obj):
+    assert copy.copy(obj) == obj
+    assert copy.deepcopy(obj) == obj
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_pickle_round_trips_under_every_protocol(obj, protocol):
+    # Round-trips a value created immediately above, not external input.
+    loaded = pickle.loads(pickle.dumps(obj, protocol=protocol))  # nosec B301 - nosemgrep
+    assert loaded == obj
+    assert hash(loaded) == hash(obj)
+
+
+def test_unpickled_qualified_name_recomputes_its_hash_in_the_loading_process():
+    # The hash is process-specific (str hashing is seeded), so a pickle must
+    # not carry it. Produce the pickle under a different seed and look the
+    # object up in a dict keyed by a fresh, equal qualified name.
+    script = (
+        "import pickle, sys; from prov.identifier import Namespace; "
+        "sys.stdout.buffer.write(pickle.dumps(Namespace('ex', 'http://example.org/')['e1']))"
+    )
+    seed = "1" if hash("x") != hash("x") else "12345"
+    produced = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+        env={"PYTHONHASHSEED": seed, "PATH": "", "PYTHONPATH": ":".join(sys.path)},
+    ).stdout
+    loaded = pickle.loads(produced)  # nosec B301 - nosemgrep
+    fresh = Namespace("ex", "http://example.org/")["e1"]
+    assert loaded == fresh
+    assert hash(loaded) == hash(fresh)
+    assert {fresh: 1}.get(loaded) == 1
+
+
+def test_setstate_accepts_a_pre_3_2_dict_state():
+    # prov <= 3.1.1 pickled these classes through __dict__; that state has no
+    # _hash and Namespace's carries its cache.
+    ns = Namespace.__new__(Namespace)
+    ns.__setstate__({"_prefix": "ex", "_uri": "http://example.org/", "_cache": {}})
+    assert ns == Namespace("ex", "http://example.org/")
+    qn = QualifiedName.__new__(QualifiedName)
+    qn.__setstate__(
+        {"_uri": "http://example.org/e1", "_namespace": ns, "_localpart": "e1", "_str": "ex:e1"}
+    )
+    assert qn == ns["e1"]
+    assert hash(qn) == hash(ns["e1"])
+    lit = Literal.__new__(Literal)
+    lit.__setstate__({"_value": "1", "_datatype": XSD_INT, "_langtag": None})
+    assert lit == Literal("1", XSD_INT)
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_weak_references_are_supported(obj):
+    assert weakref.ref(obj)() is obj
+
+
+def test_equal_identifiers_hash_equal_across_classes():
+    ident = Identifier("http://example.org/e1")
+    qname = NS["e1"]
+    assert ident == qname
+    assert hash(ident) == hash(qname) == hash("http://example.org/e1")
+```
+
+Add `from prov.identifier import Identifier, Namespace, QualifiedName` (extend the existing import). If the subprocess test cannot import `prov` because the venv's site-packages is not on `PYTHONPATH`, pass `env={**os.environ, "PYTHONHASHSEED": seed}` instead (add `import os`); the point is only the different seed.
+
+- [ ] **Step 2: See them fail.** `uv run pytest src/prov/tests/test_identifier_slots.py -q` → protocol 0/1 raise `TypeError`, weakref raises `TypeError`, cross-class hash differs, the legacy-state test fails on `__setstate__` missing.
+
+- [ ] **Step 3: `identifier.py`.**
+
+`Identifier`:
+
+```python
+    __slots__ = ("__weakref__", "_hash", "_uri")
+    ...
+    def _compute_hash(self) -> int:
+        """Hash by URI alone, so equal identifiers hash equal whatever their
+        concrete class: ``__eq__`` compares URIs across Identifier subclasses."""
+        return hash(self._uri)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Pickle state: every slot except the process-specific ``_hash``,
+        which :meth:`__setstate__` recomputes in the loading process."""
+        return {"_uri": self._uri}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Also accepts the __dict__ state of pickles written before 3.2.0.
+        object.__setattr__(self, "_uri", state["_uri"])
+        object.__setattr__(self, "_hash", self._compute_hash())
+```
+
+`QualifiedName`: keep `_compute_hash` but reword its docstring to "Hash by URI alone, as the base class does; kept explicit because the string form is cached separately." Add:
+
+```python
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "_uri": self._uri,
+            "_namespace": self._namespace,
+            "_localpart": self._localpart,
+            "_str": self._str,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        object.__setattr__(self, "_namespace", state["_namespace"])
+        object.__setattr__(self, "_localpart", state["_localpart"])
+        object.__setattr__(self, "_str", state["_str"])
+        Identifier.__setstate__(self, state)
+```
+
+`Namespace`:
+
+```python
+    __slots__ = ("__weakref__", "_cache", "_prefix", "_uri")
+    ...
+    def __getstate__(self) -> dict[str, Any]:
+        """Pickle state without the interning cache, which is rebuilt lazily."""
+        return {"_prefix": self._prefix, "_uri": self._uri}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Also accepts the __dict__ state of pickles written before 3.2.0,
+        # which carries the cache; it is discarded.
+        object.__setattr__(self, "_prefix", state["_prefix"])
+        object.__setattr__(self, "_uri", state["_uri"])
+        object.__setattr__(self, "_cache", {})
+```
+
+(`Final`-annotated slots are assigned through `object.__setattr__` so mypy does not flag reassignment; if mypy still objects, annotate the methods' assignments with `# type: ignore[misc]` and say why in one comment.)
+
+- [ ] **Step 4: `records.py` `Literal`.**
+
+```python
+    __slots__ = ("__weakref__", "_datatype", "_langtag", "_value")
+    ...
+    def __getstate__(self) -> dict[str, Any]:
+        return {"_value": self._value, "_datatype": self._datatype, "_langtag": self._langtag}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        object.__setattr__(self, "_value", state["_value"])
+        object.__setattr__(self, "_datatype", state["_datatype"])
+        object.__setattr__(self, "_langtag", state["_langtag"])
+```
+
+- [ ] **Step 5: Gates.** Focused tests, then full suite, mypy, ruff. Check `test_model.py`/`test_qnames.py` for any test pinning `hash(Identifier(...)) != hash(qname)` and update it to the new contract.
+
+- [ ] **Step 6: Changelog.**
+
+```markdown
+- `Identifier`, `QualifiedName`, `Namespace` and `Literal` pickle under every protocol,
+  load pickles written by earlier releases, and recompute their hash when loaded, so an
+  object unpickled in another process (a `multiprocessing` worker, a disk cache) matches
+  equal objects in sets and dicts again; `weakref.ref` works on them. 3.2.0's `__slots__`
+  had pickled the stored hash and broken protocols 0 and 1
+- An `Identifier` hashes by its URI alone, as a `QualifiedName` already did, so two
+  identifiers that compare equal always hash equal
+```
+
+- [ ] **Step 7: Commit, PR.** Commit `fix(identifier): pickle without the stored hash, support weakref, hash by URI`. PR title the same; body: what the review found (two sentences), what changed (two sentences), suite count. `gh pr checks --watch`; do not merge.
+
+---
+
+### Task 2: Namespace resolve cache and empty local parts
+
+**Goal:** `add_namespace` never leaves a stale `_resolve_cache`; URI compaction against the default namespace does not mint an empty local part; the PROV-N writer refuses to write one.
+
+**Files:**
+- Modify: `src/prov/model/namespaces.py` (`add_namespace`, `_resolve_prefixed_string`)
+- Modify: `src/prov/identifier.py` (`QualifiedName.provn_bare_representation`)
+- Modify: `src/prov/tests/test_model.py` (or the namespace test module the checkout uses; `grep -ln "_resolve_cache\|add_namespace" src/prov/tests/*.py`)
+- Modify: `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] The finding's sequence (`x`→`a:`, `y`→`a:b`, `entity('a:bc')`, `a`→`a:b`, `entity('a:bc')`) yields the same two identifiers as adding all three namespaces first (`y:bc`, URI `a:bbc`)
+- [ ] `doc.set_default_namespace("http://d/"); doc.valid_qualified_name("http://d/")` returns `None` (no empty local part), while `ns = doc.add_namespace("ex", "http://e/"); doc.valid_qualified_name("ex:")` still returns `ex:` with an empty local part
+- [ ] `QualifiedName(Namespace("", "http://d/"), "").provn_bare_representation()` raises `ProvException` mentioning a prefix
+- [ ] Suite: Task 1 count plus 3
+
+**Steps:**
+
+- [ ] **Step 1: Tests** (in the namespace test module):
+
+```python
+def test_add_namespace_with_known_uri_clears_the_resolve_cache():
+    ordered = ProvDocument()
+    for prefix, uri in (("x", "a:"), ("y", "a:b"), ("a", "a:b")):
+        ordered.add_namespace(prefix, uri)
+    expected = ordered.valid_qualified_name("a:bc")
+
+    doc = ProvDocument()
+    doc.add_namespace("x", "a:")
+    doc.add_namespace("y", "a:b")
+    first = doc.valid_qualified_name("a:bc")
+    doc.add_namespace("a", "a:b")  # same URI as y: registers a rename, must drop the cache
+    second = doc.valid_qualified_name("a:bc")
+    assert first == expected
+    assert second == expected
+    assert second.uri == "a:bbc"
+
+
+def test_default_namespace_uri_alone_is_not_an_empty_local_name():
+    doc = ProvDocument()
+    doc.set_default_namespace("http://d/")
+    assert doc.valid_qualified_name("http://d/") is None
+    assert doc.valid_qualified_name("http://d/e1").localpart == "e1"
+    ex = doc.add_namespace("ex", "http://e/")
+    assert doc.valid_qualified_name("ex:") == ex[""]  # [52] allows a prefixed empty local
+
+
+def test_provn_cannot_write_an_empty_local_part_without_a_prefix():
+    qname = QualifiedName(Namespace("", "http://d/"), "")
+    with pytest.raises(ProvException, match="prefix"):
+        qname.provn_bare_representation()
+    assert Namespace("ex", "http://e/")[""].provn_bare_representation() == "ex:"
+```
+
+- [ ] **Step 2: See them fail.**
+
+- [ ] **Step 3: `namespaces.py`.** In `add_namespace`, the branch
+
+```python
+        if uri in self._uri_map:
+            existing_ns = self._uri_map[uri]
+            self._rename_map[namespace] = existing_ns
+            self._prefix_renamed_map[prefix] = existing_ns
+            return existing_ns
+```
+
+gains `self._resolve_cache.clear()` before `return existing_ns`, with the comment `# _prefix_renamed_map feeds _resolve_prefixed_string, so cached resolutions are stale from here.` In `_resolve_prefixed_string`'s compaction loop:
+
+```python
+            for namespace in self.values():
+                if str_value.startswith(namespace.uri):
+                    local = str_value[len(namespace.uri) :]
+                    if not local and not namespace.prefix:
+                        # The URI is the default namespace itself; a bare empty
+                        # local name has no PROV-N spelling, so it is not a
+                        # qualified name here.
+                        continue
+                    return namespace[local]
+```
+
+(replaces the `str_value.replace(namespace.uri, "")` form, which also replaced later occurrences).
+
+- [ ] **Step 4: `identifier.py`.** At the top of `provn_bare_representation`:
+
+```python
+        if not self._localpart and not self._namespace.prefix:
+            raise ProvException(
+                f"the qualified name for <{self._uri}> has an empty local part in a "
+                "namespace with no prefix, which PROV-N cannot write; give the "
+                "namespace a prefix"
+            )
+```
+
+`identifier.py` cannot import `prov.model` (circular); raise `prov.Error`'s subclass available there, or define the exception where `identifier.py` can see it. Check `grep -n "^from\|^import" src/prov/identifier.py`; if only `prov.Error` is importable, raise `Error` and have the test match on `Error` (import from `prov`). State which you did in the report.
+
+- [ ] **Step 5: Gates; changelog:**
+
+```markdown
+- `add_namespace()` clears the qualified-name resolution cache when the URI was already
+  registered under another prefix, so resolving the same text before and after the
+  call gives the same result; 3.2.0's cache had made it order-dependent
+- A URI equal to the default namespace itself is no longer compacted to a qualified name
+  with an empty local part, and the PROV-N writer raises instead of writing an empty
+  identifier for one; `prefix:` with an empty local part is still written and read
+```
+
+- [ ] **Step 6: Commit `fix(model): clear the resolve cache on every rename path; no bare empty local parts`; PR; do not merge.**
+
+---
+
+### Task 3: PROV-N parser gaps
+
+**Goal:** The eight parser findings from spec §2.3.
+
+**Files:**
+- Modify: `src/prov/serializers/provn_lexer.py` (`_SHORT_STRING`, `_QNAME_LITERAL`, `tokenize` BOM)
+- Modify: `src/prov/serializers/provn_parser.py` (`_advance`/previous-kind tracking, `_declarations`, `_bundle`, `_resync`, `_attributes`, `_literal`)
+- Modify: `src/prov/serializers/provn.py` (`bytearray`)
+- Modify: `src/prov/tests/test_provn.py`, `src/prov/tests/test_provn_profiles.py`, `src/prov/tests/test_provn_lexer.py`
+- Modify: `docs/howto/provn.md` (lenient paragraph: declarations and duplicate bundles), `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] Each test in Step 1 passes; every existing parser test passes unchanged
+- [ ] Suite: Task 2 count plus 11
+
+**Steps:**
+
+- [ ] **Step 1: Tests.** In `test_provn.py` (strict `parse()` helper; `PREFIXES` declares `ex` and `dc`, so the body's line numbers start at 4):
+
+```python
+def test_duplicate_prefix_in_one_scope_is_an_error():
+    with pytest.raises(ProvNSyntaxError, match="prefix 'ex' is declared twice") as ctx:
+        parse("entity(ex:e1)", prefixes="prefix ex <http://a.org/>\nprefix ex <http://b.org/>\n")
+    assert (ctx.value.line, ctx.value.column) == (3, 8)
+
+
+def test_escaped_colon_literal_needs_a_default_namespace():
+    with pytest.raises(ProvNSyntaxError, match="no default namespace declared"):
+        parse(r"entity(ex:e1, [ex:k='a\:b'])")
+
+
+def test_duplicate_bundle_identifier_is_a_positioned_syntax_error():
+    with pytest.raises(ProvNSyntaxError, match="already exists") as ctx:
+        parse("bundle ex:b\nendBundle\nbundle ex:b\nendBundle")
+    assert ctx.value.line == 6
+
+
+@pytest.mark.parametrize(
+    "body",
+    ['entity(ex:e1, [123="x"])', 'entity(ex:e1, [ex:a="x" %% 123])'],
+)
+def test_all_digit_local_names_in_attribute_positions(body):
+    doc = parse(body, prefixes=PREFIXES + "default <http://d/>\n")
+    (record,) = doc.get_records()
+    assert record.attributes
+
+
+def test_leading_byte_order_mark_is_skipped():
+    doc = ProvDocument.deserialize(
+        content="﻿document\n prefix ex <http://example.org/>\n entity(ex:e1)\nendDocument",
+        format="provn",
+    )
+    assert [str(r.identifier) for r in doc.get_records()] == ["ex:e1"]
+
+
+def test_bytearray_stream_is_decoded():
+    text = "document\n prefix ex <http://example.org/>\n entity(ex:e1)\nendDocument"
+    doc = ProvDocument.deserialize(io.BytesIO(bytearray(text, "utf-8")), format="provn")
+    assert [str(r.identifier) for r in doc.get_records()] == ["ex:e1"]
+```
+
+(add `import io` to the module). In `test_provn_lexer.py`:
+
+```python
+@pytest.mark.parametrize("text", ['"a\rb"', "'a\rb'"])
+def test_carriage_return_ends_a_short_literal(text):
+    with pytest.raises(ProvNSyntaxError, match="unterminated"):
+        list(tokenize(text))
+```
+
+In `test_provn_profiles.py` (default `parse()`, body starts at line 3):
+
+```python
+def test_lenient_resync_stops_at_a_bundle_header_after_an_unclosed_statement():
+    body = 'entity(ex:e, [ex:a="x"\nbundle ex:b\n  entity(ex:f)\nendBundle'
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 1
+    assert records(doc) == []
+    (bundle,) = doc.bundles
+    assert [str(r.identifier) for r in records(bundle)] == ["ex:f"]
+
+
+def test_lenient_resync_stops_at_end_document_after_an_unclosed_statement():
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse("entity(", profile="lenient")
+    assert len(caught) == 1
+    assert records(doc) == []
+
+
+def test_lenient_skips_a_duplicate_bundle_whole():
+    body = "bundle ex:b\n  entity(ex:e1)\nendBundle\nbundle ex:b\n  entity(ex:e2)\nendBundle\nentity(ex:e3)"
+    with pytest.warns(ProvWarning, match="already exists") as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 1
+    (bundle,) = doc.bundles
+    assert [str(r.identifier) for r in records(bundle)] == ["ex:e1"]
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e3"]
+```
+
+- [ ] **Step 2: See them fail.**
+
+- [ ] **Step 3: Lexer.** `_SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n\r])*)"')` and `_QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n\r])*)'")`. In `tokenize(text)` (or the lexer's `__init__`), before tokenising: `if text.startswith("﻿"): text = text[1:]` with the comment `# A UTF-8 byte order mark is not part of the document.`
+
+- [ ] **Step 4: Parser.**
+
+(a) Previous token kind. In `__init__` add `self._previous_kind: TokenKind | None = None`; in `_advance`, before `self._pos += 1`, set `self._previous_kind = token.kind`.
+
+(b) `_resync`: replace the structural branch with
+
+```python
+                if not prefix and local in _STRUCTURAL:
+                    # A structural keyword is a boundary unless it is an
+                    # attribute value ([ex:k=bundle]), which only follows '='.
+                    if self._previous_kind is not TokenKind.EQUALS:
+                        self._depth = start_depth
+                        return
+```
+
+and update the docstring's last paragraph to say the test is "not preceded by `=`" rather than depth. Keep the existing test `test_lenient_resync_does_not_stop_on_a_structural_keyword_shaped_value` passing.
+
+(c) `_declarations`: keep a `seen: set[str]` of prefixes; on `if local in seen: raise self._error(f"prefix '{local}' is declared twice in this scope", name)` before appending.
+
+(d) `_bundle`: wrap the two creation paths:
+
+```python
+        try:
+            if (prefix and prefix in {ns.prefix for ns in namespaces}) or (
+                not prefix and default is not None
+            ):
+                bundle = ProvBundle(document=document)
+                self._apply_declarations(bundle, namespaces, default)
+                identifier = self._resolve(id_token, bundle)
+                document.add_bundle(bundle, identifier)
+            else:
+                identifier = self._resolve(id_token, document)
+                bundle = document.bundle(identifier)
+                self._apply_declarations(bundle, namespaces, default)
+        except ProvException as exc:
+            error = ProvNSyntaxError(str(exc), id_token.line, id_token.column)
+            error.__cause__ = exc
+            if self.profile != "lenient":
+                raise error
+            self.skipped.append(f"PROV-N bundle skipped: {error}")
+            self._skip_bundle_body()
+            return
+```
+
+with
+
+```python
+    def _skip_bundle_body(self) -> None:
+        """Consume everything up to and including the next 'endBundle'."""
+        while not self._at_keyword("endBundle"):
+            if self._current.kind is TokenKind.EOF:
+                raise self._error("expected 'endBundle', found end of input")
+            self._advance()
+        self._advance()
+```
+
+The lenient test above expects the warning text to contain "already exists"; `ProvNSerializer` prefixes nothing, so the message is the skipped entry itself. Note `ProvNSyntaxError` from `_resolve` inside the `try` propagates unchanged (it is not a `ProvException`... check: `ProvNSyntaxError` subclasses `ProvException`, so catch order matters; catch `ProvNSyntaxError` first and re-raise it, then `ProvException`).
+
+(e) `_attributes`: `name = self._digit_run_as_name() or self._expect(TokenKind.NAME, "an attribute name")`. In `_literal`'s TYPED branch: `datatype_token = self._digit_run_as_name() or self._expect(TokenKind.NAME, "a datatype")`.
+
+(f) `_literal` QNAME_LITERAL branch: when `not prefix and ":" in local` and `_default_namespace(bundle)` is `None`, `raise self._error(f"cannot resolve {token.text!r}: no default namespace declared", token)`.
+
+- [ ] **Step 5: `provn.py`:** `if isinstance(content, (bytes, bytearray)): content = bytes(content).decode("utf-8")`.
+
+- [ ] **Step 6: Docs and changelog.** `docs/howto/provn.md`, the lenient paragraph after the profile table, add: "A duplicate prefix declaration and a tokenisation error still raise in every profile; a bundle whose identifier is already taken is skipped whole under `lenient`." `HISTORY.md`:
+
+```markdown
+- PROV-N parser: a prefix declared twice in one scope is a `ProvNSyntaxError` (the
+  Recommendation forbids it); a bare qualified-name literal with an escaped colon and no
+  default namespace is an error instead of resolving in the wrong namespace; a duplicate
+  bundle identifier is a positioned `ProvNSyntaxError`, and `lenient` skips that bundle
+  whole; an all-digit local name is accepted as an attribute name and as a datatype; a
+  leading byte order mark is skipped; a carriage return ends a short string like a line
+  feed; a `bytearray` stream is decoded
+- The `lenient` PROV-N profile no longer swallows a `bundle` header or `endDocument` that
+  follows a statement missing its closing bracket
+```
+
+- [ ] **Step 7: Gates, commit `fix(provn): parser fixes from the 3.2.x review`, PR; do not merge.**
+
+---
+
+### Task 4: PROV-N writer gaps
+
+**Goal:** The five writer findings from spec §2.4, with the tutorial output updated.
+
+**Files:**
+- Modify: `src/prov/identifier.py` (`_provn_escape_local`, `QualifiedName.provn_bare_representation`)
+- Modify: `src/prov/model/bundle.py` (`ProvBundle.get_provn` header and declarations)
+- Modify: `src/prov/model/records.py` (`encoding_provn_value` datetime; formal-attribute datetime; a shared `_xsd_datetime_text` helper)
+- Modify: `src/prov/tests/test_provn_escaping.py`, `src/prov/tests/test_provn.py`
+- Modify: `docs/tutorial/getting-started.md`, `docs/reference/conformance.md`, `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] The bundle-header scenario round-trips equal and the header reads `bundle dn:b1` with `prefix dn <http://doc.org/>` inside the bundle
+- [ ] Writing an identifier with an unrepresentable character emits one `ProvWarning`; a lone surrogate is encoded, not raised; a leading U+00B7 is percent-encoded and the output re-parses
+- [ ] A namespace URI with a space raises `ProvException` from `get_provn()` naming the prefix
+- [ ] A datetime with a 30-second offset is written in UTC and re-parses
+- [ ] Suite: Task 3 count plus 7
+
+**Steps:**
+
+- [ ] **Step 1: Tests.** `test_provn.py`:
+
+```python
+def test_bundle_in_document_default_with_its_own_default_round_trips():
+    d = ProvDocument()
+    d.set_default_namespace("http://doc.org/")
+    b = d.bundle("b1")
+    b.set_default_namespace("http://bundle.org/")
+    b.entity("e1")
+    text = d.get_provn()
+    assert "bundle dn:b1" in text and "prefix dn <http://doc.org/>" in text
+    again = ProvDocument.deserialize(content=text, format="provn")
+    assert again == d
+    (bundle,) = again.bundles
+    assert bundle.identifier.uri == "http://doc.org/b1"
+
+
+def test_namespace_uri_that_is_not_an_iri_cannot_be_written():
+    d = ProvDocument()
+    d.add_namespace("bad", "http://example.org/a b/")
+    with pytest.raises(ProvException, match="bad"):
+        d.get_provn()
+
+
+def test_sub_minute_utc_offset_is_written_in_utc():
+    tz = datetime.timezone(datetime.timedelta(seconds=30))
+    d = ProvDocument()
+    d.add_namespace("ex", "http://example.org/")
+    d.activity("ex:a1", datetime.datetime(2026, 9, 12, 10, 0, 30, tzinfo=tz))
+    text = d.get_provn()
+    assert "2026-09-12T10:00:00+00:00" in text
+    assert ProvDocument.deserialize(content=text, format="provn") == d
+```
+
+`test_provn_escaping.py`:
+
+```python
+def test_percent_encoding_warns_that_the_iri_changes():
+    with pytest.warns(ProvWarning, match="percent"):
+        assert NS["a b"].provn_bare_representation() == "ex:a%20b"
+
+
+def test_lone_surrogate_is_percent_encoded():
+    with pytest.warns(ProvWarning):
+        assert NS["e\udc80"].provn_bare_representation() == "ex:e%ED%B2%80"
+
+
+@pytest.mark.parametrize("first", ["·", "́", "‿"])
+def test_leading_name_char_that_cannot_start_a_local_part_is_encoded(first):
+    with pytest.warns(ProvWarning):
+        written = NS[first + "a"].provn_bare_representation()
+    assert written.startswith("ex:%")
+    doc = ProvDocument.deserialize(
+        content=f"document\n prefix ex <{NS.uri}>\n entity({written})\nendDocument", format="provn"
+    )
+    assert len(list(doc.get_records())) == 1
+```
+
+(check the module's fixture names; it may already define `NS` or a `ns` fixture.)
+
+- [ ] **Step 2: See them fail.**
+
+- [ ] **Step 3: `identifier.py`.** In `_provn_escape_local`: (i) add a module constant `_PN_LOCAL_BAD_START = re.compile("[\xb7̀-ͯ‿-⁀]")` and in the loop, before the metachar branch, `if i == 0 and _PN_LOCAL_BAD_START.match(char): parts.extend(f"%{byte:02X}" for byte in char.encode("utf-8")); encoded = True; continue`; (ii) `char.encode("utf-8", "surrogatepass")` in the percent branch, setting `encoded = True`; (iii) return `(text, encoded)`; `provn_bare_representation` warns when `encoded`:
+
+```python
+        escaped_localpart, encoded = _provn_escape_local(self._localpart)
+        if encoded:
+            warnings.warn(
+                f"the local part {self._localpart!r} of <{self._uri}> contains a "
+                "character PROV-N cannot write; it is percent-encoded, which changes "
+                "the IRI a PROV-N reader recovers",
+                ProvWarning,
+                stacklevel=external_stacklevel(),
+            )
+```
+
+`identifier.py` cannot import `prov.model.ProvWarning` (circular). Define `ProvWarning` where both can import it: move `class ProvWarning(Warning)` to `prov/_warnings.py` and re-export it from `prov.model` (keep the name in `prov.model.__all__` and `dir(prov.model)` unchanged; `test_public_api.py` freezes it). Update the one other definition site accordingly and grep for `records.ProvWarning` uses.
+
+- [ ] **Step 4: `bundle.py` `get_provn`.** Replace the header/declaration block:
+
+```python
+        default_namespace = self._namespaces.get_default_namespace()
+        registered_namespaces = list(self._namespaces.get_registered_namespaces())
+        bundle_id = ""
+        extra_prefix: Namespace | None = None
+        if self._identifier is not None:
+            id_namespace = self._identifier.namespace
+            if (
+                not id_namespace.prefix
+                and default_namespace is not None
+                and default_namespace.uri != id_namespace.uri
+            ):
+                # A bare name in the header would resolve against this
+                # bundle's own default on re-read (PROV-N 3.4.1); give the
+                # identifier's namespace a prefix for the header.
+                prefix = "dn"
+                taken = {ns.prefix for ns in registered_namespaces}
+                count = 1
+                while prefix in taken:
+                    prefix = f"dn_{count}"
+                    count += 1
+                extra_prefix = Namespace(prefix, id_namespace.uri)
+                bundle_id = f"{prefix}:{_provn_escape_local(self._identifier.localpart)}"
+            else:
+                bundle_id = self._identifier.provn_bare_representation()
+        lines = ["document"] if self.is_document() else [f"bundle {bundle_id}"]
+        for namespace in ([default_namespace] if default_namespace else []) + registered_namespaces + ([extra_prefix] if extra_prefix else []):
+            _check_provn_iri(namespace)
+        if default_namespace:
+            lines.append(f"default <{default_namespace.uri}>")
+        lines.extend(f"prefix {ns.prefix} <{ns.uri}>" for ns in registered_namespaces)
+        if extra_prefix is not None:
+            lines.append(f"prefix {extra_prefix.prefix} <{extra_prefix.uri}>")
+        if default_namespace or registered_namespaces or extra_prefix:
+            lines.append("")
+```
+
+with, at module level:
+
+```python
+_PROVN_IRI_FORBIDDEN = re.compile(r'[<>"{}|^`\\\x00-\x20]')
+
+
+def _check_provn_iri(namespace: Namespace) -> None:
+    """A namespace URI must be a PROV-N IRI_REF ([56]) to be declared."""
+    if _PROVN_IRI_FORBIDDEN.search(namespace.uri):
+        where = f"prefix '{namespace.prefix}'" if namespace.prefix else "the default namespace"
+        raise ProvException(
+            f"{where} has URI <{namespace.uri}>, which PROV-N cannot write as an IRI: "
+            "it contains a space, a control character or one of <>\"{}|^`\\"
+        )
+```
+
+Import `_provn_escape_local` from `prov.identifier` (it now returns a tuple; take `[0]`) and `re` if absent.
+
+- [ ] **Step 5: `records.py`.** Add
+
+```python
+def _xsd_datetime_text(value: datetime.datetime) -> str:
+    """ISO 8601 text with an xsd:dateTime-legal zone: an offset that is not a
+    whole number of minutes (historical LMT offsets) is normalised to UTC."""
+    offset = value.utcoffset()
+    if offset is not None and (offset.total_seconds() % 60 or offset.microseconds):
+        value = value.astimezone(datetime.timezone.utc)
+    return value.isoformat()
+```
+
+and use it at both `isoformat()` sites (`encoding_provn_value` and the formal-attribute loop).
+
+- [ ] **Step 6: Docs.** `docs/tutorial/getting-started.md`: the printed output block's `bundle e001` line becomes `bundle dn:e001` and, after its `default <http://example.org/2/>` line, `prefix dn <http://example.org/0/>`; add one sentence after the block: "The bundle's identifier lives in the document's default namespace while the bundle declares its own default, so the writer gives that namespace the prefix `dn` inside the bundle; a bare `bundle e001` would be read as `http://example.org/2/e001`." `docs/reference/conformance.md`, PROV-N caveat: add "A local part containing a character PN_LOCAL cannot express is percent-encoded with a `ProvWarning`; a PROV-N reader recovers the percent-encoded IRI, so `a b` and `a%20b` read back as the same identifier." `HISTORY.md`:
+
+```markdown
+- PROV-N output names a bundle with a prefixed identifier when the bundle declares a default
+  namespace different from the one its identifier lives in, adding the prefix declaration
+  inside the bundle, so the identifier's IRI survives re-reading; a bare name was resolved
+  against the bundle's own default
+- The PROV-N writer warns with `ProvWarning` when it percent-encodes a character a local
+  part cannot express, encodes a lone surrogate instead of raising `UnicodeEncodeError`,
+  percent-encodes a leading character PN_LOCAL forbids first, raises `ProvException` for a
+  namespace URI that is not an IRI, and writes a datetime whose UTC offset is not a whole
+  number of minutes in UTC
+```
+
+- [ ] **Step 7: Gates, commit `fix(provn): writer fixes from the 3.2.x review`, PR; do not merge.** Expect the `ProvWarning` move to touch `src/prov/model/records.py`, `src/prov/_warnings.py`, `src/prov/model/__init__.py`; run `uv run pytest src/prov/tests/test_public_api.py -q` explicitly.
+
+---
+
+### Task 5: `prov.read()` options per serializer
+
+**Goal:** Each serializer declares the deserialize options it accepts; auto-detection forwards only those; an explicit-format call rejects an unknown option with a clear `TypeError`.
+
+**Files:**
+- Modify: `src/prov/serializers/__init__.py` (`Serializer.deserialize_options`)
+- Modify: `src/prov/serializers/provn.py`, `src/prov/serializers/provrdf.py` (class attribute)
+- Modify: `src/prov/__init__.py` (`_detect_and_parse`, `read`)
+- Modify: `src/prov/tests/test_read.py` (or where `read()` tests live: `grep -ln "def test_read" src/prov/tests/*.py`)
+- Modify: `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] `prov.read(io.BytesIO(doc.serialize(format="rdf", rdf_format="xml").encode()), rdf_format="xml")` auto-detects and equals `doc`
+- [ ] `prov.read(json_text, format="json", profile="strict")` raises `TypeError` matching `accepts no option 'profile'` and emits no `UserWarning`
+- [ ] `prov.read(path, format="provn", profile="strict")` and `format="rdf", rdf_format="turtle"` still work
+- [ ] Suite: Task 4 count plus 3
+
+**Steps:**
+
+- [ ] **Step 1: Tests:**
+
+```python
+def test_auto_detection_forwards_rdf_options(tmp_path):
+    doc = primer_example()
+    text = doc.serialize(format="rdf", rdf_format="xml")
+    assert prov.read(io.BytesIO(text.encode("utf-8")), rdf_format="xml") == doc
+
+
+def test_unknown_option_for_an_explicit_format_is_a_clear_type_error():
+    text = primer_example().serialize(format="json")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(TypeError, match="'json' deserializer accepts no option 'profile'"):
+            prov.read(text, format="json", profile="strict")
+
+
+def test_declared_options_per_serializer():
+    from prov.serializers import Registry
+    Registry.load_serializers()
+    assert Registry.serializers["provn"].deserialize_options == frozenset({"profile"})
+    assert Registry.serializers["json"].deserialize_options == frozenset()
+    if "rdf" in Registry.serializers:
+        assert "rdf_format" in Registry.serializers["rdf"].deserialize_options
+```
+
+- [ ] **Step 2: Implementation.** `Serializer`: `deserialize_options: ClassVar[frozenset[str]] = frozenset()` with a docstring "Keyword arguments :meth:`deserialize` accepts beyond ``stream``; :func:`prov.read` forwards only these." `ProvNSerializer.deserialize_options = frozenset({"profile"})`; `ProvRDFSerializer.deserialize_options = frozenset({"rdf_format", "relation_mapper", "predicate_mapper"})`. In `_detect_and_parse`:
+
+```python
+            candidate_kwargs = {
+                key: value
+                for key, value in kwargs.items()
+                if key in Registry.serializers[format].deserialize_options
+            }
+```
+
+(import `Registry` where the loop can see it; the loop already receives `serializers` as the keys, so pass the dict or look it up). In `read()`:
+
+```python
+    if format:
+        cls = Registry.serializers.get(format.lower())
+        if cls is not None:
+            unknown = sorted(set(kwargs) - cls.deserialize_options)
+            if unknown:
+                accepted = ", ".join(sorted(cls.deserialize_options)) or "none"
+                raise TypeError(
+                    f"the {format.lower()!r} deserializer accepts no option "
+                    f"{unknown[0]!r}; it accepts: {accepted}"
+                )
+        try:
+            ...
+```
+
+Update `read()`'s docstring `**kwargs` paragraph: "Passed to the deserializer. Each serializer declares the options it accepts (`deserialize_options`); with `format` given, an undeclared option raises `TypeError`; with auto-detection, every candidate receives only the options it declares." Update the comment above `candidate_kwargs`.
+
+- [ ] **Step 3: Gates; changelog:**
+
+```markdown
+- `prov.read()` forwards each deserializer the options it declares (`profile` for PROV-N;
+  `rdf_format`, `relation_mapper` and `predicate_mapper` for PROV-O), so auto-detection can
+  read non-TriG RDF with `rdf_format`, and an option a format does not accept raises a
+  `TypeError` naming the format and its options instead of a JSON or rdflib error
+```
+
+- [ ] **Step 4: Commit `fix(read): forward declared deserializer options; reject unknown ones clearly`, PR; do not merge.**
+
+---
+
+### Task 6: PROV-O predicates under undeclared namespaces raise again
+
+**Goal:** `_resolve_predicate_key` falls back to graph-declared namespaces only and raises `ProvExceptionInvalidQualifiedName` otherwise; value-side minting unchanged.
+
+**Files:**
+- Modify: `src/prov/serializers/provrdf.py`
+- Modify: `src/prov/tests/test_rdf.py`
+- Modify: `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] Turtle with `<http://other.org/p> "v"` on an entity and no `@prefix` for `other.org` raises `ProvExceptionInvalidQualifiedName` mentioning the IRI
+- [ ] The same predicate with `@prefix o: <http://other.org/> .` declared decodes to attribute `o:p`
+- [ ] `test_unregistered_namespace_iri_decodes_via_compute_qname` (a subject IRI) still passes
+- [ ] Suite: Task 5 count plus 2
+
+**Steps:**
+
+- [ ] **Step 1: Tests:**
+
+```python
+def test_predicate_under_undeclared_namespace_raises():
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    ex:e1 a prov:Entity ; <http://other.org/p> "v" .
+    """
+    with pytest.raises(ProvExceptionInvalidQualifiedName, match="http://other.org/p"):
+        ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+
+
+def test_predicate_under_graph_declared_namespace_decodes():
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    @prefix o: <http://other.org/> .
+    ex:e1 a prov:Entity ; o:p "v" .
+    """
+    doc = ProvDocument.deserialize(content=turtle, format="rdf", rdf_format="turtle")
+    (entity,) = doc.get_records()
+    (value,) = entity.get_attribute(doc.valid_qualified_name("o:p"))
+    assert value == "v"
+```
+
+- [ ] **Step 2: Implementation.** Extract the graph-namespace step of `_resolve_iri` into `_resolve_iri_via_graph(self, iri, graph) -> QualifiedName | None` (returns `None` when no bound namespace is a proper prefix); `_resolve_iri` calls it first and keeps steps 2 and 3. `_resolve_predicate_key`:
+
+```python
+        pred_str = str(pred)
+        qname = self.document.valid_qualified_name(pred_str) or self._resolve_iri_via_graph(pred_str, graph)
+        if qname is None:
+            raise ProvExceptionInvalidQualifiedName(
+                f"Invalid Qualified Name: {pred_str} (predicate under a namespace declared "
+                "neither in the document nor in the graph)"
+            )
+        return qname
+```
+
+(`ProvExceptionInvalidQualifiedName` carries a `qname` attribute; set it if the existing raise sites do.) Update the docstring: fallback is graph-declared namespaces only (#341).
+
+- [ ] **Step 3: Gates; changelog:**
+
+```markdown
+- The PROV-O deserializer resolves an attribute predicate against the document's namespaces
+  and then the graph's own declarations only; a predicate under a namespace declared in
+  neither raises `ProvExceptionInvalidQualifiedName`, as before 3.2.0, instead of minting an
+  `ns1:` prefix silently
+```
+
+- [ ] **Step 4: Commit `fix(rdf): predicates under undeclared namespaces raise instead of minting a prefix`, PR; do not merge.**
+
+---
+
+### Task 7: Identified Membership fan-out; CLI text stdin
+
+**Goal:** A PROV-JSONLD Membership with an `@id` and several members produces unidentified records with a warning; `prov-compare -` and `prov-convert` accept a text-only standard stream.
+
+**Files:**
+- Modify: `src/prov/serializers/provjsonld.py`
+- Modify: `src/prov/scripts/__init__.py`
+- Modify: `src/prov/tests/test_jsonld.py`, `src/prov/tests/test_scripts.py`
+- Modify: `HISTORY.md`
+
+**Acceptance Criteria:**
+- [ ] `{"@type": "Membership", "@id": "ex:m", "collection": "ex:c", "entity": ["ex:e1", "ex:e2"]}` decodes to two memberships with `identifier is None` and one `ProvWarning` naming `ex:m`; `doc.unified()` succeeds
+- [ ] With one member the `@id` is kept (existing `test_deserialize_membership_array_shares_id_and_attributes` is rewritten to the new rule)
+- [ ] `prov-compare -f json -F xml - b.xml` with `sys.stdin = io.StringIO(json_text)` exits 0
+- [ ] Suite: Task 6 count plus 2
+
+**Steps:**
+
+- [ ] **Step 1: Tests.** Rewrite `test_deserialize_membership_array_shares_id_and_attributes` as:
+
+```python
+def test_deserialize_identified_membership_array_drops_the_id_with_a_warning():
+    payload = json.dumps({... as before, "entity": ["ex:e1", "ex:e2"], "label": [{"@value": "members"}] ...})
+    with pytest.warns(ProvWarning, match="ex:m"):
+        doc = ProvDocument.deserialize(content=payload, format="jsonld")
+    memberships = sorted(doc.get_records(ProvMembership), key=lambda r: str(list(r.get_attribute(PROV["entity"]))[0]))
+    assert [r.identifier for r in memberships] == [None, None]
+    assert all(list(r.get_attribute(PROV["label"])) == ["members"] for r in memberships)
+    doc.unified()
+
+
+def test_deserialize_identified_membership_with_one_member_keeps_the_id():
+    payload = json.dumps({... "entity": ["ex:e1"] ...})
+    doc = ProvDocument.deserialize(content=payload, format="jsonld")
+    (membership,) = doc.get_records(ProvMembership)
+    assert str(membership.identifier) == "ex:m"
+```
+
+`test_scripts.py`:
+
+```python
+def test_compare_reads_a_text_only_stdin_for_dash(compare_files, monkeypatch):
+    json_file, xml_file = compare_files
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json_file.read_text()))
+    monkeypatch.setattr(sys, "argv", ["prov-compare", "-f", "json", "-F", "xml", "-", str(xml_file)])
+    assert compare_main() == 0
+```
+
+- [ ] **Step 2: Implementation.** `provjsonld.py` fan-out:
+
+```python
+    member_id = rec_id
+    if rec_id is not None and len(members) > 1:
+        warnings.warn(
+            f"Membership {rec_id!r} lists {len(members)} members; PROV-DM membership is "
+            "binary, so the members are decoded as unidentified hadMember records",
+            ProvWarning,
+            stacklevel=external_stacklevel(),
+        )
+        member_id = None
+    for member in members:
+        ... bundle.new_record(rec_type, member_id, ...)
+```
+
+`scripts/__init__.py`: `standard = getattr(sys, standard_name); return cast(BinaryIO, getattr(standard, "buffer", standard)), False` with the docstring noting a text-only stream is returned as is.
+
+- [ ] **Step 3: Gates; changelog:**
+
+```markdown
+- A PROV-JSONLD `Membership` with an `@id` and several members decodes to unidentified
+  `hadMember` records with a `ProvWarning`, since records sharing one identifier cannot be
+  unified; with one member the `@id` is kept
+- `prov-convert` and `prov-compare` accept a text-only standard stream for `-`
+```
+
+- [ ] **Step 4: Commit `fix(jsonld,cli): unidentified fan-out for identified memberships; text stdin`, PR; do not merge.**
+
+---
+
+### Task 8: Documentation corrections
+
+**Goal:** The four documentation findings.
+
+**Files:**
+- Modify: `docs/explanation/architecture.md` (the "expected X, found Y" bullet)
+- Modify: `HISTORY.md` (3.2.0 binary-mode bullet loses its `#341` link)
+- Modify: `docs/reference/conformance.md` (PN_PREFIX parenthetical)
+- Modify: `src/prov/identifier.py` docstrings if Task 1 left any stale wording
+
+**Steps:**
+
+- [ ] `architecture.md`: "and every message reads \"expected X, found Y\"" → "and every message names what was expected and what was found".
+- [ ] `HISTORY.md` 3.2.0 › the bullet ending `([#341](...))` about binary-mode `deserialize()`: remove the link line (keep any other `#341` reference that is about PROV-O colon local parts).
+- [ ] `conformance.md`: "(start with a letter, not end with `.`)" → "(a `PN_PREFIX`: begin with a letter, continue with name characters or `.`, and not end with `.`)".
+- [ ] Gates (Codacy on the three Markdown files), commit `docs: corrections from the 3.2.x review`, PR; do not merge.
+
+---
+
+### Task 9: Refresh the stamp if the date moved, re-verify, hand over to publish
+
+**Goal:** `HISTORY.md`, `ROADMAP.md` and `conformance.md` carry the actual release date; the eye-check notebook passes against a wheel built from the final `main`; the publish task of `2026-09-12-release-3.2.1.md` runs on the maintainer's word.
+
+**Steps:**
+
+- [ ] If today is not 2026-09-12: one PR `release: 3.2.1 date` changing the three dates.
+- [ ] Pre-flight per `docs/releasing.md` §1 on the final `main` (all six interpreters, mypy, ruff, own-warnings on 3.14, benchmarks, wheel).
+- [ ] In `~/projects/ProvPy/prov-verification/`: copy the new wheel, `uv lock --upgrade-package prov && uv sync --reinstall-package prov`, update the commit hash in `verify-provn-3.2.1.py` and `findings-3.2.1.md`, adjust the notebook's expectations that Task 4 changed (bundle header text is not asserted; the percent-encoding warning does not arise in the corpus), re-execute, expect 70 of 70.
+- [ ] Ask the maintainer to publish; then Task 7 of `planning/plans/2026-09-12-release-3.2.1.md`.

--- a/planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md
+++ b/planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md
@@ -1,0 +1,199 @@
+# Release 3.2.1: review-fix wave design
+
+**Date:** 2026-09-12
+**Status:** Approved in conversation ("there should be no cap, we should fix all defects")
+**Scope:** Every confirmed defect from the `/code-review xhigh` sweep of the changes
+since 3.1.1, fixed on `main` before 3.2.1 is tagged. No new features, no dependency
+changes, Python floor unchanged. One public-behaviour change is accepted where a
+3.2.0 regression is reverted or a hash/equality contract is restored.
+
+## 1. Purpose
+
+After the six planned 3.2.1 fixes and the simplify wave were merged (`main` 6309cbb),
+a whole-diff correctness review of 3.1.1..main confirmed 21 defects, 15 of which were
+reported under the review's cap. The maintainer removed the cap. This document fixes
+the decision for each item so the implementation plan can be executed without further
+design calls. Items the review classed as pre-existing and deliberately decided are
+listed in section 4 and left alone.
+
+## 2. Decisions, by area
+
+### 2.1 Identifier pickling, hashing and slots (`identifier.py`, `records.py`)
+
+Findings: the stored `_hash` slot is pickled, so an object unpickled in another
+process (different `PYTHONHASHSEED`, `multiprocessing` spawn, disk caches) keeps a
+foreign hash and stops matching equal objects in sets and dicts; `__slots__` without
+`__getstate__`/`__setstate__` breaks pickles written by 3.1.1, pickle protocols 0 and
+1, and `weakref.ref` on CPython; `Identifier._compute_hash` folds in `hash(cls)`, so
+an `Identifier` and a `QualifiedName` with the same URI compare equal but hash
+differently (a pre-existing `__eq__`/`__hash__` contract gap the new docstring
+misdescribes).
+
+Decisions:
+
+- `Identifier`, `Namespace` and `Literal` gain `__getstate__`/`__setstate__`. State is
+  a dict of the slot values **without** `_hash` (and without `Namespace._cache`);
+  `__setstate__` restores the fields and recomputes `_hash` (`Identifier` and
+  subclasses) or rebuilds an empty `_cache` (`Namespace`). `__setstate__` also accepts
+  the dict a 3.1.1 pickle carries (the same field names, plus `_cache` for
+  `Namespace`), so old pickles load.
+- `"__weakref__"` is added to `Identifier.__slots__`, `Namespace.__slots__` and
+  `Literal.__slots__` (not to `QualifiedName`, which inherits it).
+- `Identifier._compute_hash` hashes the URI alone, like `QualifiedName`, so equal
+  identifiers hash equal. `test_identifier_hash_unchanged` is rewritten to pin the
+  contract (`hash(Identifier(u)) == hash(ns[local])` when URIs match). The
+  `_compute_hash` docstrings state the rule.
+
+### 2.2 Namespace manager (`namespaces.py`)
+
+Findings: `add_namespace`'s URI-already-registered branch writes
+`_prefix_renamed_map` and returns before `_resolve_cache.clear()`, so resolution
+becomes order-dependent (3.2.0 regression); URI compaction against the default
+namespace mints a `QualifiedName` with an empty local part, which the PROV-N writer
+emits as an empty string (`entity(, ...)`).
+
+Decisions:
+
+- `_resolve_cache.clear()` runs on every path that changes `_rename_map`,
+  `_prefix_renamed_map`, `_namespaces` or `_default`; concretely, the early-return
+  branch clears the cache before returning.
+- `_resolve_prefixed_string`'s URI-compaction loop skips a match whose remainder is
+  empty when the matching namespace has no prefix. `prefix:` with an empty local part
+  stays legal (PROV-N production [52] allows it; the Recommendation's own `bbc:`).
+- `QualifiedName.provn_bare_representation()` raises `ProvException` for an empty
+  local part in a prefix-less namespace, naming the namespace URI and saying a prefix
+  is needed, instead of writing nothing.
+
+### 2.3 PROV-N parser (`provn_lexer.py`, `provn_parser.py`, `provn.py`)
+
+Decisions, one per finding:
+
+- **Duplicate prefix in one declaration set** (§3.7.4 MUST NOT): `_declarations`
+  raises `ProvNSyntaxError("prefix 'ex' is declared twice in this scope")` at the
+  second declaration, in every profile. Declarations are not statements, so
+  `lenient` has nothing to skip.
+- **Escaped colon in a bare qualified-name literal with no default namespace**:
+  `_literal` raises `ProvNSyntaxError("cannot resolve 'a\\:b': no default namespace
+  declared")`, the same message the identifier position gives, instead of falling
+  through to a prefix split.
+- **Lenient resync and structural keywords**: a structural keyword (`document`,
+  `bundle`, `endBundle`, `endDocument`) is a boundary whatever the bracket depth,
+  unless the token before it is `=` (then it is an attribute value). The parser
+  records the kind of the last consumed token for this test; the depth gate goes.
+- **Duplicate bundle identifier**: `_bundle` wraps `document.bundle()` and
+  `document.add_bundle()` so a `ProvException` becomes a `ProvNSyntaxError` at the
+  identifier token. Under `lenient` the whole bundle body is skipped up to and
+  including its `endBundle`, with one warning; its statements are not attached to the
+  document.
+- **All-digit local names** as attribute names and as `%%` datatypes go through
+  `_digit_run_as_name()` like identifiers do.
+- **Byte order mark**: a leading U+FEFF is skipped before tokenising.
+- **Carriage return** ends a short string and a qualified-name literal like LF does
+  (`[^"\\\n\r]`); a CR inside such a literal is an "unterminated" error at the
+  opening quote, as LF is today.
+- **`bytearray` streams** are decoded like `bytes` in `ProvNSerializer.deserialize`.
+
+### 2.4 PROV-N writer (`identifier.py`, `bundle.py`, `records.py`)
+
+- **Bundle header**: when a bundle's identifier is in a prefix-less (default)
+  namespace and the bundle declares a default namespace of its own that differs, the
+  header cannot be a bare name (the reader resolves it against the bundle's default,
+  §3.4.1). The writer synthesises a prefix for the identifier's namespace, `dn`
+  (or `dn_1`, `dn_2`, ... if taken among the bundle's registered prefixes), writes
+  `bundle dn:b1` and adds `prefix dn <uri>` to the bundle's declaration lines. The
+  re-read document compares equal (record and bundle equality ignore registered
+  namespaces). The tutorial's example output is updated.
+- **Percent-encoding**: a character PN_LOCAL cannot express is still percent-encoded,
+  and the writer now emits a `ProvWarning` naming the identifier and saying its IRI
+  changes in PROV-N (once per `provn_bare_representation()` call that encodes). A
+  literal `%` followed by two hex digits stays verbatim (PROV-N, like SPARQL, does not
+  decode PERCENT), so `ex:a%20b` written from `a b` and from `a%20b` can still alias;
+  the warning makes the lossy case visible, and `docs/reference/conformance.md`
+  documents the aliasing next to the existing exclusion. A lone surrogate is encoded
+  with `errors="surrogatepass"` instead of raising `UnicodeEncodeError`.
+- **Leading PN_CHARS that are not PN_CHARS_U** (U+00B7, U+0300 to U+036F, U+203F to
+  U+2040) are percent-encoded when first, since PN_LOCAL forbids them there and they
+  have no backslash escape.
+- **Namespace URIs** in `prefix`/`default` declarations are checked against the
+  lexer's IRI_REF character set (`<>"{}|^\`` and U+0000 to U+0020 excluded);
+  `get_provn()` raises `ProvException` naming the prefix and the offending URI.
+- **Sub-minute UTC offsets** (reachable through historical zoneinfo LMT offsets):
+  `xsd:dateTime` forbids seconds in an offset, so a datetime whose `utcoffset()` is
+  not a whole number of minutes is converted to UTC before `isoformat()`, in both
+  `encoding_provn_value` and the formal-attribute writer.
+
+### 2.5 `prov.read()` options (`__init__.py`, `serializers/__init__.py`)
+
+Findings: auto-detection forwards `**kwargs` only to the `provn` candidate, so the
+RDF reader's `rdf_format`, `relation_mapper` and `predicate_mapper` are dropped; the
+explicit-format path forwards unknown kwargs unvalidated, surfacing json/rdflib
+`TypeError`s and a misleading "if you meant a file path" warning.
+
+Decisions:
+
+- `Serializer` gains a class attribute `deserialize_options: ClassVar[frozenset[str]]
+  = frozenset()`. `ProvNSerializer.deserialize_options = frozenset({"profile"})`;
+  `ProvRDFSerializer.deserialize_options = frozenset({"rdf_format",
+  "relation_mapper", "predicate_mapper"})`.
+- `_detect_and_parse` gives each candidate the subset of `kwargs` its class declares.
+- `read()` with an explicit format rejects an undeclared kwarg with
+  `TypeError("the 'json' deserializer accepts no option 'profile'; it accepts none")`
+  (or "it accepts: rdf_format, ...") before deserialising, and the raw-content warning
+  is not emitted for that error. `read()`'s docstring is corrected.
+
+### 2.6 PROV-O predicate resolution (`provrdf.py`)
+
+Finding: `_resolve_predicate_key` falls back to `_resolve_iri`, which mints `ns1:`
+for a predicate under a namespace declared neither in the document nor in the graph;
+3.1.1 raised `ProvExceptionInvalidQualifiedName`. #341's documented scope is
+graph-declared namespaces.
+
+Decision: `_resolve_iri` is split so the graph-namespace step is callable on its own;
+`_resolve_predicate_key` uses only that step and raises
+`ProvExceptionInvalidQualifiedName` (with the IRI) when no graph namespace matches.
+Value-side IRIs (`decode_rdf_representation`, subjects) keep the full minting
+fallback, which predates 3.2.0 and is pinned by
+`test_unregistered_namespace_iri_decodes_via_compute_qname`.
+
+### 2.7 PROV-JSONLD identified Membership; CLI stdin (`provjsonld.py`, `scripts/__init__.py`)
+
+- A `Membership` with an `@id` and two or more `entity` members fans out to records
+  that share the `@id`, which `unified()` then rejects. Decision: the `@id` is kept
+  only when the array has exactly one member; otherwise the records are unidentified
+  and a `ProvWarning` names the dropped `@id` and the member count.
+- `_open_binary` returns `getattr(stream, "buffer", stream)` for `-`, so a text-only
+  `sys.stdin` (an `io.StringIO` under a test harness or a redirected process) works;
+  every deserializer accepts a text stream.
+
+### 2.8 Documentation
+
+- `docs/explanation/architecture.md`: "every message reads 'expected X, found Y'"
+  becomes "every message names what was expected and what was found".
+- `HISTORY.md` 3.2.0: the binary-mode `deserialize()` bullet drops its `#341` link.
+- `docs/reference/conformance.md`: the PN_PREFIX parenthetical states the full rule
+  (start with a letter, continue with name characters or `.`, not end with `.`), and
+  the PROV-N caveats gain the percent-encoding aliasing note from §2.4.
+- `docs/tutorial/getting-started.md`: the bundle example's PROV-N output shows the
+  `dn:` header from §2.4.
+- `HISTORY.md` 3.2.1 gains one bullet per behaviour change above.
+
+## 3. Verification
+
+Every item has a test in the plan that fails before and passes after. The full suite,
+mypy, ruff, Codacy and the six-interpreter matrix run before the stamp is refreshed.
+The eye-check notebook is re-run against a wheel built from the final commit; its
+expectations for the bundle header (`dn:`) and for the new warnings are updated where
+they appear.
+
+## 4. Deliberately left alone
+
+- `Literal(value, None, "")`: the empty language tag stays `""` in the model and is
+  special-cased only by the PROV-N writer, per commit 4c213f8. Byte-identical to 3.1.1
+  in every other codec.
+- `Identifier` versus `QualifiedName` class-distinguished hashing is *changed* (§2.1);
+  the alternative, leaving the contract gap and only fixing the docstring, was
+  rejected because the gap is exactly what §2.1's pickle fix would otherwise preserve.
+- ProvToolbox's own defects (silent second-document drop, `mentionOf` unsupported,
+  nested `hadMember` shape, doubled underscores, rounded dateTimes).
+- The refuted candidates: `prov-convert` never auto-detected input; rejecting a
+  hash-less `xsd` binding follows §3.7.4.


### PR DESCRIPTION
Design spec and implementation plan for fixing every confirmed defect from the whole-diff code review of 3.1.1..main before 3.2.1 is tagged: identifier pickling and hashing, the namespace resolve cache and empty local parts, eight PROV-N parser gaps, five PROV-N writer gaps, prov.read() option handling, PROV-O predicate resolution, the identified Membership fan-out, CLI text stdin, and documentation corrections.

Planning documents only; no code changes.