### PR TITLE
fix(identifier): pickle without the stored hash, support weakref, hash by URI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,13 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - PROV-XML reader warnings (`<prov:other>` skipped, unrepresentable attribute, nested
   reference) are attributed to the caller of `deserialize()` or `prov.read()` rather than to
   a frame inside `prov`, as the PROV-N reader's already are
+- `Identifier`, `QualifiedName`, `Namespace` and `Literal` pickle under every protocol,
+  load pickles written by earlier releases, and recompute their hash when loaded, so an
+  object unpickled in another process (a `multiprocessing` worker, a disk cache) matches
+  equal objects in sets and dicts again; `weakref.ref` works on them. 3.2.0's `__slots__`
+  had pickled the stored hash and broken protocols 0 and 1
+- An `Identifier` hashes by its URI alone, as a `QualifiedName` already did, so two
+  identifiers that compare equal always hash equal
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -108,7 +108,7 @@ class Identifier:
     # TODO: make Identifier an "abstract" base class and move xsd:anyURI
     # into a subclass
 
-    __slots__ = ("_hash", "_uri")
+    __slots__ = ("__weakref__", "_hash", "_uri")
 
     # This field is assign-once. The hash is computed from it at construction,
     # and a later reassignment would leave the cached hash stale. #444 tracks
@@ -126,9 +126,19 @@ class Identifier:
         self._hash = self._compute_hash()
 
     def _compute_hash(self) -> int:
-        """Hash for this identifier, class-distinguished so identifiers with
-        the same URI but a different concrete type do not collide."""
-        return hash((self._uri, self.__class__))
+        """Hash by URI alone, so equal identifiers hash equal whatever their
+        concrete class: ``__eq__`` compares URIs across Identifier subclasses."""
+        return hash(self._uri)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Pickle state: every slot except the process-specific ``_hash``,
+        which :meth:`__setstate__` recomputes in the loading process."""
+        return {"_uri": self._uri}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Also accepts the __dict__ state of pickles written before 3.2.0.
+        object.__setattr__(self, "_uri", state["_uri"])
+        object.__setattr__(self, "_hash", self._compute_hash())
 
     @property
     def uri(self) -> str:
@@ -191,10 +201,23 @@ class QualifiedName(Identifier):
         )
 
     def _compute_hash(self) -> int:
-        """Hash by URI alone. Unlike the base class, a QualifiedName never
-        needs class-distinguishing, so no different concrete type shares a
-        URI with it in practice."""
+        """Hash by URI alone, as the base class does; kept explicit because
+        the string form is cached separately."""
         return hash(self._uri)
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "_uri": self._uri,
+            "_namespace": self._namespace,
+            "_localpart": self._localpart,
+            "_str": self._str,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        object.__setattr__(self, "_namespace", state["_namespace"])
+        object.__setattr__(self, "_localpart", state["_localpart"])
+        object.__setattr__(self, "_str", state["_str"])
+        Identifier.__setstate__(self, state)
 
     @property
     def namespace(self) -> Namespace:
@@ -237,7 +260,7 @@ class QualifiedName(Identifier):
 class Namespace:
     """PROV Namespace."""
 
-    __slots__ = ("_cache", "_prefix", "_uri")
+    __slots__ = ("__weakref__", "_cache", "_prefix", "_uri")
 
     # These fields are assign-once. They take part in equality and hashing,
     # so reassigning one after the object has been used as a set member or
@@ -327,6 +350,17 @@ class Namespace:
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self._prefix} {{{self._uri}}}>"
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Pickle state without the interning cache, which is rebuilt lazily."""
+        return {"_prefix": self._prefix, "_uri": self._uri}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Also accepts the __dict__ state of pickles written before 3.2.0,
+        # which carries the cache; it is discarded.
+        object.__setattr__(self, "_prefix", state["_prefix"])
+        object.__setattr__(self, "_uri", state["_uri"])
+        object.__setattr__(self, "_cache", {})
 
     def __getitem__(self, localpart: str) -> QualifiedName:
         if localpart in self._cache:

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -396,7 +396,7 @@ class Literal:
     PROV-JSON/PROV-XML rules for language-tagged strings.
     """
 
-    __slots__ = ("_datatype", "_langtag", "_value")
+    __slots__ = ("__weakref__", "_datatype", "_langtag", "_value")
 
     # These fields are assign-once. They take part in equality and hashing,
     # so reassigning one after the object has been used as a set member or
@@ -446,6 +446,18 @@ class Literal:
 
     def __repr__(self) -> str:
         return f"<Literal: {self.provn_representation()}>"
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "_value": self._value,
+            "_datatype": self._datatype,
+            "_langtag": self._langtag,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        object.__setattr__(self, "_value", state["_value"])
+        object.__setattr__(self, "_datatype", state["_datatype"])
+        object.__setattr__(self, "_langtag", state["_langtag"])
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/src/prov/tests/test_identifier_slots.py
+++ b/src/prov/tests/test_identifier_slots.py
@@ -2,12 +2,16 @@
 and Literal: no __dict__, unchanged equality, copy and pickle intact."""
 
 import copy
+import os
 import pickle
+import subprocess
+import sys
+import weakref
 
 import pytest
 
 from prov.constants import XSD_INT
-from prov.identifier import Identifier, Namespace
+from prov.identifier import Identifier, Namespace, QualifiedName
 from prov.model import Literal
 
 NS = Namespace("ex", "http://example.org/")
@@ -28,24 +32,74 @@ def test_no_instance_dict(obj):
 
 
 @pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
-def test_copy_and_pickle_preserve_equality(obj):
+def test_copy_preserves_equality(obj):
     assert copy.copy(obj) == obj
     assert copy.deepcopy(obj) == obj
 
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_pickle_round_trips_under_every_protocol(obj, protocol):
     # Round-trips a value created immediately above, not external input.
-    assert pickle.loads(pickle.dumps(obj)) == obj  # nosec B301 - nosemgrep
+    loaded = pickle.loads(pickle.dumps(obj, protocol=protocol))  # nosec B301 - nosemgrep
+    assert loaded == obj
+    assert hash(loaded) == hash(obj)
 
 
-def test_qualified_name_hash_is_stored_and_uri_based():
-    qname = NS["e1"]
-    assert hash(qname) == hash(qname.uri)
-    assert qname._hash == hash(qname)
+def test_unpickled_qualified_name_recomputes_its_hash_in_the_loading_process():
+    # The hash is process-specific (str hashing is seeded), so a pickle must
+    # not carry it. Produce the pickle under a different seed and look the
+    # object up in a dict keyed by a fresh, equal qualified name.
+    script = (
+        "import pickle, sys; from prov.identifier import Namespace; "
+        "sys.stdout.buffer.write(pickle.dumps(Namespace('ex', 'http://example.org/')['e1']))"
+    )
+    for seed in ("12345", "54321"):
+        produced = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+        ).stdout
+        loaded = pickle.loads(produced)  # nosec B301 - nosemgrep
+        fresh = Namespace("ex", "http://example.org/")["e1"]
+        assert loaded == fresh
+        assert hash(loaded) == hash(fresh)
+        assert {fresh: 1}.get(loaded) == 1
 
 
-def test_identifier_hash_unchanged():
+def test_setstate_accepts_a_pre_3_2_dict_state():
+    # prov <= 3.1.1 pickled these classes through __dict__; that state has no
+    # _hash and Namespace's carries its cache.
+    ns = Namespace.__new__(Namespace)
+    ns.__setstate__({"_prefix": "ex", "_uri": "http://example.org/", "_cache": {}})
+    assert ns == Namespace("ex", "http://example.org/")
+    qn = QualifiedName.__new__(QualifiedName)
+    qn.__setstate__(
+        {
+            "_uri": "http://example.org/e1",
+            "_namespace": ns,
+            "_localpart": "e1",
+            "_str": "ex:e1",
+        }
+    )
+    assert qn == ns["e1"]
+    assert hash(qn) == hash(ns["e1"])
+    lit = Literal.__new__(Literal)
+    lit.__setstate__({"_value": "1", "_datatype": XSD_INT, "_langtag": None})
+    assert lit == Literal("1", XSD_INT)
+
+
+@pytest.mark.parametrize("obj", OBJECTS, ids=lambda o: type(o).__name__)
+def test_weak_references_are_supported(obj):
+    assert weakref.ref(obj)() is obj
+
+
+def test_equal_identifiers_hash_equal_across_classes():
     ident = Identifier("http://example.org/e1")
-    assert hash(ident) == hash((ident.uri, Identifier))
-    assert hash(ident) != hash(NS["e1"])  # class-distinguished, as before
+    qname = NS["e1"]
+    assert ident == qname
+    assert hash(ident) == hash(qname) == hash("http://example.org/e1")
 
 
 def test_namespace_cache_still_interns_qualified_names():

--- a/src/prov/tests/test_identifier_slots.py
+++ b/src/prov/tests/test_identifier_slots.py
@@ -46,17 +46,20 @@ def test_pickle_round_trips_under_every_protocol(obj, protocol):
     assert hash(loaded) == hash(obj)
 
 
-def test_unpickled_qualified_name_recomputes_its_hash_in_the_loading_process():
+def test_unpickled_qualified_name_recomputes_its_hash_in_the_loading_process(tmp_path):
     # The hash is process-specific (str hashing is seeded), so a pickle must
     # not carry it. Produce the pickle under a different seed and look the
-    # object up in a dict keyed by a fresh, equal qualified name.
-    script = (
-        "import pickle, sys; from prov.identifier import Namespace; "
-        "sys.stdout.buffer.write(pickle.dumps(Namespace('ex', 'http://example.org/')['e1']))"
+    # object up in a dict keyed by a fresh, equal qualified name. The script
+    # is a file rather than a "-c" argument, so it is a static string.
+    script = tmp_path / "produce_pickle.py"
+    script.write_text(
+        "import pickle, sys\n"
+        "from prov.identifier import Namespace\n"
+        "sys.stdout.buffer.write(pickle.dumps(Namespace('ex', 'http://example.org/')['e1']))\n"
     )
     for seed in ("12345", "54321"):
         produced = subprocess.run(
-            [sys.executable, "-c", script],
+            [sys.executable, str(script)],
             capture_output=True,
             check=True,
             env={**os.environ, "PYTHONHASHSEED": seed},

--- a/src/prov/tests/test_identifier_slots.py
+++ b/src/prov/tests/test_identifier_slots.py
@@ -58,7 +58,9 @@ def test_unpickled_qualified_name_recomputes_its_hash_in_the_loading_process(tmp
         "sys.stdout.buffer.write(pickle.dumps(Namespace('ex', 'http://example.org/')['e1']))\n"
     )
     for seed in ("12345", "54321"):
-        produced = subprocess.run(
+        # The command is the running interpreter plus a script this test
+        # just wrote, not untrusted input.
+        produced = subprocess.run(  # nosec B603 - nosemgrep
             [sys.executable, str(script)],
             capture_output=True,
             check=True,


### PR DESCRIPTION
A whole-diff review of 3.2.0's `__slots__` change found that `Identifier`, `QualifiedName`, `Namespace` and `Literal` pickled their process-specific stored hash, so an object unpickled in another process (a `multiprocessing` worker, a disk cache) stopped matching equal objects in sets and dicts. The same review found pickles from 3.1.1 and pickle protocols 0 and 1 no longer worked, `weakref.ref` raised `TypeError`, and an `Identifier` and a `QualifiedName` with the same URI compared equal but hashed differently.

`__getstate__`/`__setstate__` now pickle every slot except `_hash`, which is recomputed on load; `__setstate__` also accepts the `__dict__` state pre-3.2.0 pickles carry. `__weakref__` is added to each class's `__slots__`. `Identifier._compute_hash` now hashes by URI alone instead of `(uri, class)`, matching `QualifiedName`'s existing behaviour and its `__eq__`. Full suite: 2507 passed (2471 baseline minus 7 rewritten cases plus 43 new ones), mypy --strict, ruff check and format, and Codacy all clean on the changed files.