### PR TITLE
fix(model): clear the resolve cache on every rename path; no bare empty local parts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -52,6 +52,12 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   had pickled the stored hash and broken protocols 0 and 1
 - An `Identifier` hashes by its URI alone, as a `QualifiedName` already did, so two
   identifiers that compare equal always hash equal
+- `add_namespace()` clears the qualified-name resolution cache when the URI was already
+  registered under another prefix, so resolving the same text before and after the
+  call gives the same result; 3.2.0's cache had made it order-dependent
+- A URI equal to the default namespace itself is no longer compacted to a qualified name
+  with an empty local part, and the PROV-N writer raises instead of writing an empty
+  identifier for one; `prefix:` with an empty local part is still written and read
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -3,6 +3,8 @@ from __future__ import annotations  # defer eval: Namespace used before it's def
 import re
 from typing import Any, Final
 
+from prov import Error
+
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
 
@@ -244,7 +246,17 @@ class QualifiedName(Identifier):
         [53]/[54]); characters PN_LOCAL cannot express at all are
         percent-encoded. The prefix is never escaped, as it cannot contain
         these characters.
+
+        Raises:
+            Error: If the local part is empty and the namespace has no prefix,
+                which has no PROV-N spelling.
         """
+        if not self._localpart and not self._namespace.prefix:
+            raise Error(
+                f"the qualified name for <{self._uri}> has an empty local part in a "
+                "namespace with no prefix, which PROV-N cannot write; give the "
+                "namespace a prefix"
+            )
         escaped_localpart = _provn_escape_local(self._localpart)
         return (
             ":".join([self._namespace.prefix, escaped_localpart])

--- a/src/prov/model/namespaces.py
+++ b/src/prov/model/namespaces.py
@@ -139,6 +139,9 @@ class NamespaceManager(dict[str, Namespace]):
             existing_ns = self._uri_map[uri]
             self._rename_map[namespace] = existing_ns
             self._prefix_renamed_map[prefix] = existing_ns
+            # _prefix_renamed_map feeds _resolve_prefixed_string, so cached
+            # resolutions are stale from here.
+            self._resolve_cache.clear()
             return existing_ns
 
         if prefix in self:
@@ -297,8 +300,13 @@ class NamespaceManager(dict[str, Namespace]):
             #  check if the URI can be compacted by any of the registered namespaces
             for namespace in self.values():
                 if str_value.startswith(namespace.uri):
-                    #  create a QName with the namespace
-                    return namespace[str_value.replace(namespace.uri, "")]
+                    local = str_value[len(namespace.uri) :]
+                    if not local and not namespace.prefix:
+                        # The URI is the default namespace itself; a bare
+                        # empty local name has no PROV-N spelling, so it is
+                        # not a qualified name here.
+                        continue
+                    return namespace[local]
         return None
 
     def get_anonymous_identifier(self, local_prefix: str = "id") -> Identifier:

--- a/src/prov/tests/test_model.py
+++ b/src/prov/tests/test_model.py
@@ -606,6 +606,16 @@ def test_valid_qualified_name_rejects_blank_node_and_bad_types():
     assert nm.valid_qualified_name(12345) is None
 
 
+def test_default_namespace_uri_alone_is_not_an_empty_local_name():
+    doc = ProvDocument()
+    doc.set_default_namespace("http://d/")
+    assert doc.valid_qualified_name("http://d/") is None
+    assert doc.valid_qualified_name("http://d/e1").localpart == "e1"
+    ex = doc.add_namespace("ex", "http://e/")
+    # [52] allows a prefixed empty local part.
+    assert doc.valid_qualified_name("ex:") == ex[""]
+
+
 def test_get_anonymous_identifier_increments_and_uses_prefix():
     nm = NamespaceManager()
     first_id = nm.get_anonymous_identifier()

--- a/src/prov/tests/test_namespace_cache.py
+++ b/src/prov/tests/test_namespace_cache.py
@@ -90,3 +90,23 @@ def test_parent_answered_resolution_is_not_cached_in_the_child():
     assert bundle._namespaces._resolve_cache == {}
     document.set_default_namespace("http://two.org/")
     assert bundle.valid_qualified_name("e1").uri == "http://two.org/e1"
+
+
+def test_add_namespace_with_known_uri_clears_the_resolve_cache():
+    ordered = ProvDocument()
+    for prefix, uri in (("x", "a:"), ("y", "a:b"), ("a", "a:b")):
+        ordered.add_namespace(prefix, uri)
+    expected = ordered.valid_qualified_name("a:bc")
+
+    doc = ProvDocument()
+    doc.add_namespace("x", "a:")
+    doc.add_namespace("y", "a:b")
+    first = doc.valid_qualified_name("a:bc")
+    # "a" is not yet registered here, so x's namespace is the only one whose
+    # URI prefixes "a:bc"; x:bc is the correct resolution at this point.
+    assert first.uri == "a:bc"
+    # Same URI as y: registers a rename, must drop the cache.
+    doc.add_namespace("a", "a:b")
+    second = doc.valid_qualified_name("a:bc")
+    assert second == expected
+    assert second.uri == "a:bbc"

--- a/src/prov/tests/test_qnames.py
+++ b/src/prov/tests/test_qnames.py
@@ -6,6 +6,10 @@ once per target in ``SHARED_TARGETS``. The legacy mixin remains for the
 not-yet-migrated xml/rdf/dot modules.
 """
 
+import pytest
+
+from prov import Error
+from prov.identifier import Namespace, QualifiedName
 from prov.model import ProvDocument
 
 
@@ -63,3 +67,10 @@ def test_flattening_2_bundle_with_default_namespaces(roundtrip):
     prov_doc = document_with_n_bundles_having_default_namespace(2)
     prov_doc.set_default_namespace("http://www.example.org/default/0")
     roundtrip(prov_doc.flattened())
+
+
+def test_provn_cannot_write_an_empty_local_part_without_a_prefix():
+    qname = QualifiedName(Namespace("", "http://d/"), "")
+    with pytest.raises(Error, match="prefix"):
+        qname.provn_bare_representation()
+    assert Namespace("ex", "http://e/")[""].provn_bare_representation() == "ex:"


### PR DESCRIPTION
The 3.2.0 review found that add_namespace's URI-already-registered branch wrote _prefix_renamed_map and returned before clearing _resolve_cache, so resolving the same string before and after registering a namespace under that URI could give two different, inconsistent qualified names depending on call order. The review also found that compacting a URI equal to the default namespace itself minted a QualifiedName with an empty local part, which the PROV-N writer then serialized as a bare, unreadable identifier.

add_namespace's early-return branch now clears _resolve_cache before returning, matching the other two mutation paths that already did. _resolve_prefixed_string's URI-compaction loop skips a match whose remainder is empty when the matching namespace has no prefix, so the default namespace's own URI no longer compacts to an empty local part; a prefixed empty local part (prefix:) is still legal per PROV-N production [52] and unaffected. QualifiedName.provn_bare_representation() raises prov.Error for the remaining case where an empty local part reaches the writer with no prefix to disambiguate it. Full interpreter matrix (3.10-3.14, pypy3.11): 2510 passed, 26 skipped, 191 xfailed on each. mypy --strict, ruff check/format, and codacy-analysis all clean on the changed files.