### PR TITLE
fix(provn): parser fixes from the 3.2.x review

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -58,6 +58,15 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - A URI equal to the default namespace itself is no longer compacted to a qualified name
   with an empty local part, and the PROV-N writer raises instead of writing an empty
   identifier for one; `prefix:` with an empty local part is still written and read
+- PROV-N parser: a prefix declared twice in one scope is a `ProvNSyntaxError` (the
+  Recommendation forbids it); a bare qualified-name literal with an escaped colon and no
+  default namespace is an error instead of resolving in the wrong namespace; a duplicate
+  bundle identifier is a positioned `ProvNSyntaxError`, and `lenient` skips that bundle
+  whole; an all-digit local name is accepted as an attribute name and as a datatype; a
+  leading byte order mark is skipped; a carriage return ends a short string like a line
+  feed; a `bytearray` stream is decoded
+- The `lenient` PROV-N profile no longer swallows a `bundle` header or `endDocument` that
+  follows a statement missing its closing bracket
 
 ## 3.2.0 (2026-09-12)
 

--- a/docs/howto/provn.md
+++ b/docs/howto/provn.md
@@ -71,7 +71,9 @@ document = pm.ProvDocument.deserialize("document.provn", format="provn", profile
 Use `strict` to check that a document conforms to the Recommendation, `default` for
 files other tools wrote, and `lenient` to salvage what a damaged file still holds. The
 lenient profile recovers from parse errors and from statements the model rejects; a
-tokenisation error, such as an unterminated string, IRI or comment, still raises.
+tokenisation error, such as an unterminated string, IRI or comment, still raises. A
+duplicate prefix declaration and a tokenisation error still raise in every profile; a
+bundle whose identifier is already taken is skipped whole under `lenient`.
 
 ## Handle syntax errors
 

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -65,8 +65,8 @@ class ProvNSerializer(Serializer):
             ValueError: If ``profile`` is not one of :data:`PROFILES`.
         """
         content = stream.read()
-        if isinstance(content, bytes):
-            content = content.decode("utf-8")
+        if isinstance(content, (bytes, bytearray)):
+            content = bytes(content).decode("utf-8")
         parser = ProvNParser(content, profile)
         document = parser.parse()
         # Warned here, not inside the parser, so a single stacklevel

--- a/src/prov/serializers/provn_lexer.py
+++ b/src/prov/serializers/provn_lexer.py
@@ -115,9 +115,9 @@ _INT = re.compile(r"-?[0-9]+")
 # control characters that aren't spaces.
 _IRI = re.compile(r"<([^<>\"{}|^`\\\x00-\x20]*)>")
 _LANGTAG = re.compile(r"@([A-Za-z]+(?:-[A-Za-z0-9]+)*)")
-_SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n])*)"')
+_SHORT_STRING = re.compile(r'"((?:\\.|[^"\\\n\r])*)"')
 _LONG_STRING = re.compile(r'"""((?:\\.|"(?!"")|[^"\\])*)"""', re.S)
-_QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n])*)'")
+_QNAME_LITERAL = re.compile(r"'((?:\\.|[^'\\\n\r])*)'")
 # A '//' comment ends at CR or LF (the Recommendation's note on comments),
 # not just LF.
 _SKIP = re.compile(r"(?:\s+|//[^\n\r]*|/\*.*?\*/)+", re.S)
@@ -334,4 +334,7 @@ def tokenize(text: str) -> Iterator[Token]:
         ProvNSyntaxError: On the first character that starts no valid token,
             with the line and column of that character.
     """
+    if text.startswith("﻿"):
+        # A UTF-8 byte order mark is not part of the document.
+        text = text[1:]
     return _Lexer(text).tokens()

--- a/src/prov/serializers/provn_parser.py
+++ b/src/prov/serializers/provn_parser.py
@@ -139,6 +139,7 @@ class ProvNParser:
         self._tokens: list[Token] = []
         self._pos = 0
         self._depth = 0  # bracket nesting, read only by lenient resync
+        self._previous_kind: TokenKind | None = None  # last consumed token's kind
 
     # -- token helpers -----------------------------------------------------
 
@@ -156,6 +157,7 @@ class ProvNParser:
             self._depth += 1
         elif token.kind in (TokenKind.RPAREN, TokenKind.RBRACKET):
             self._depth = max(0, self._depth - 1)
+        self._previous_kind = token.kind
         if self._pos < len(self._tokens) - 1:
             self._pos += 1
         return token
@@ -222,6 +224,8 @@ class ProvNParser:
         self._apply_declarations(document, namespaces, default)
         while not self._at_keyword("endDocument"):
             if self._current.kind is TokenKind.EOF:
+                if self._eof_after_lenient_skip():
+                    return document
                 raise self._error("expected 'endDocument', found end of input")
             if self._at_keyword("bundle"):
                 self._bundle(document)
@@ -231,6 +235,24 @@ class ProvNParser:
         if self._current.kind is not TokenKind.EOF:
             raise self._error("unexpected content after 'endDocument'")
         return document
+
+    def _eof_after_lenient_skip(self) -> bool:
+        """Whether end of input, reached looking for 'endBundle'/'endDocument',
+        is the tail of a statement lenient already skipped, rather than a
+        genuinely missing closing keyword.
+
+        A statement left open by a missing ``)``/``]`` can read straight
+        through a following ``bundle``/``endBundle``/``endDocument`` as if it
+        were ordinary data (e.g. an identifier or an attribute value), since
+        the lexer does not distinguish keywords from names; the resulting
+        error is only raised once resolving that data fails, by which point
+        the keyword is gone from the token stream and cannot be resynced to.
+        Under ``lenient``, once at least one statement has already been
+        skipped, reaching end of input this way ends the document instead of
+        raising, rather than punishing the one profile meant to salvage a
+        damaged file for a token its own recovery consumed.
+        """
+        return self.profile == "lenient" and bool(self.skipped)
 
     def _declarations(self) -> tuple[list[Namespace], str | None]:
         """Consume 'prefix'/'default' declarations without committing them.
@@ -242,6 +264,7 @@ class ProvNParser:
         """
         namespaces: list[Namespace] = []
         default: str | None = None
+        seen: set[str] = set()
         while True:
             if self._at_keyword("prefix"):
                 self._advance()
@@ -249,9 +272,14 @@ class ProvNParser:
                 prefix, local = name.value
                 if prefix:
                     raise self._error(f"expected a prefix, found {name.text!r}", name)
+                if local in seen:
+                    raise self._error(
+                        f"prefix '{local}' is declared twice in this scope", name
+                    )
                 iri = self._expect(TokenKind.IRI, "an IRI in angle brackets")
                 self._check_reserved_prefix(local, iri.value, name)
                 namespaces.append(Namespace(local, iri.value))
+                seen.add(local)
             elif self._at_keyword("default"):
                 self._advance()
                 iri = self._expect(TokenKind.IRI, "an IRI in angle brackets")
@@ -291,23 +319,44 @@ class ProvNParser:
         # declarations of its own would, so a document-level prefix used for
         # the identifier is not redundantly copied onto the bundle too.
         prefix, _ = id_token.value
-        if (prefix and prefix in {ns.prefix for ns in namespaces}) or (
-            not prefix and default is not None
-        ):
-            bundle = ProvBundle(document=document)
-            self._apply_declarations(bundle, namespaces, default)
-            identifier = self._resolve(id_token, bundle)
-            document.add_bundle(bundle, identifier)
-        else:
-            identifier = self._resolve(id_token, document)
-            bundle = document.bundle(identifier)
-            self._apply_declarations(bundle, namespaces, default)
+        try:
+            if (prefix and prefix in {ns.prefix for ns in namespaces}) or (
+                not prefix and default is not None
+            ):
+                bundle = ProvBundle(document=document)
+                self._apply_declarations(bundle, namespaces, default)
+                identifier = self._resolve(id_token, bundle)
+                document.add_bundle(bundle, identifier)
+            else:
+                identifier = self._resolve(id_token, document)
+                bundle = document.bundle(identifier)
+                self._apply_declarations(bundle, namespaces, default)
+        except ProvNSyntaxError:
+            raise
+        except ProvException as exc:
+            error = ProvNSyntaxError(str(exc), id_token.line, id_token.column)
+            if self.profile != "lenient":
+                raise error from exc
+            error.__cause__ = exc
+            self.skipped.append(f"PROV-N bundle skipped: {error}")
+            self._skip_bundle_body()
+            return
         while not self._at_keyword("endBundle"):
             if self._current.kind is TokenKind.EOF:
+                if self._eof_after_lenient_skip():
+                    return
                 raise self._error("expected 'endBundle', found end of input")
             if self._at_keyword("bundle"):
                 raise self._error("a bundle cannot contain a bundle")
             self._statement(bundle)
+        self._advance()
+
+    def _skip_bundle_body(self) -> None:
+        """Consume everything up to and including the next 'endBundle'."""
+        while not self._at_keyword("endBundle"):
+            if self._current.kind is TokenKind.EOF:
+                raise self._error("expected 'endBundle', found end of input")
+            self._advance()
         self._advance()
 
     def _statement(self, bundle: ProvBundle) -> None:
@@ -358,15 +407,18 @@ class ProvNParser:
         A bare structural keyword (``document``, ``bundle``, ...) is not
         followed by ``(``, so it cannot be told apart this way from the
         same word used as an ordinary attribute value (e.g.
-        ``[ex:k=bundle]``); that case is still gated on depth, since only
-        the failed statement's own nesting can tell them apart.
+        ``[ex:k=bundle]``); that case is instead gated on whether the token
+        before it is ``=``, since only an attribute value follows one.
         """
         while self._current.kind is not TokenKind.EOF:
             token = self._current
             if token.kind is TokenKind.NAME:
                 prefix, local = token.value
                 if not prefix and local in _STRUCTURAL:
-                    if self._depth <= start_depth:
+                    # A structural keyword is a boundary unless it is an
+                    # attribute value ([ex:k=bundle]), which only follows '='.
+                    if self._previous_kind is not TokenKind.EQUALS:
+                        self._depth = start_depth
                         return
                 elif self._looks_like_statement_start():
                     self._depth = start_depth
@@ -567,7 +619,9 @@ class ProvNParser:
             self._advance()
             return pairs
         while True:
-            name = self._expect(TokenKind.NAME, "an attribute name")
+            name = self._digit_run_as_name() or self._expect(
+                TokenKind.NAME, "an attribute name"
+            )
             attr = self._resolve(name, bundle)
             self._expect(TokenKind.EQUALS)
             pairs.append((attr, self._literal(bundle)))
@@ -585,9 +639,10 @@ class ProvNParser:
                 return Literal(token.value, langtag=self._advance().value)
             if self._current.kind is TokenKind.TYPED:
                 self._advance()
-                datatype = self._resolve(
-                    self._expect(TokenKind.NAME, "a datatype"), bundle
+                datatype_token = self._digit_run_as_name() or self._expect(
+                    TokenKind.NAME, "a datatype"
                 )
+                datatype = self._resolve(datatype_token, bundle)
                 return Literal(token.value, datatype)
             return token.value
         if token.kind is TokenKind.INT:
@@ -601,8 +656,12 @@ class ProvNParser:
                 # mis-split by valid_qualified_name()'s string-based prefix
                 # lookup below.
                 default = _default_namespace(bundle)
-                if default is not None:
-                    return default[local]
+                if default is None:
+                    raise self._error(
+                        f"cannot resolve {token.text!r}: no default namespace declared",
+                        token,
+                    )
+                return default[local]
             text = f"{prefix}:{local}" if prefix else local
             qname = bundle.valid_qualified_name(text)
             # An unresolvable prefix stays an opaque literal, as it does when

--- a/src/prov/serializers/provn_parser.py
+++ b/src/prov/serializers/provn_parser.py
@@ -192,13 +192,46 @@ class ProvNParser:
             TokenKind.NAME, token.text, ("", token.text), token.line, token.column
         )
 
-    def _identifier_token(self) -> Token:
+    def _identifier_token(self, *, inside_parens: bool = True) -> Token:
         """An identifier position also accepts a bare, all-digit local name;
-        see :meth:`_digit_run_as_name`. Anything else falls through to the
+        see :meth:`_digit_run_as_name`. Inside a statement's parentheses
+        (``inside_parens``, the default), also guards against swallowing a
+        structural keyword; see :meth:`_reject_unclosed_structural_keyword`.
+        A bundle's own header identifier (``bundle <id>``) is not inside
+        parentheses, so :meth:`_bundle` passes ``inside_parens=False`` and
+        accepts a bare keyword-shaped name (e.g. a bundle literally named
+        ``bundle``) unconditionally. Anything else falls through to the
         usual NAME-expected error."""
-        return self._digit_run_as_name() or self._expect(
-            TokenKind.NAME, "an identifier"
-        )
+        digit_run = self._digit_run_as_name()
+        if digit_run is not None:
+            return digit_run
+        if inside_parens:
+            self._reject_unclosed_structural_keyword()
+        return self._expect(TokenKind.NAME, "an identifier")
+
+    def _reject_unclosed_structural_keyword(self) -> None:
+        """Refuse a bare structural keyword as an identifier or argument
+        unless it is immediately followed by ',', ')' or ';' -- the only
+        tokens that follow a real identifier inside a statement's
+        parentheses. Anything else means a statement left open by a
+        missing ')'/']' has read straight through a following 'bundle',
+        'endBundle' or 'endDocument' as if it were data; raising here
+        without consuming the token lets lenient resync (and, outside
+        lenient, the enclosing loop) still find it.
+        """
+        current = self._current
+        if current.kind is not TokenKind.NAME:
+            return
+        prefix, local = current.value
+        if prefix or local not in _STRUCTURAL:
+            return
+        if self._peek().kind in (
+            TokenKind.COMMA,
+            TokenKind.RPAREN,
+            TokenKind.SEMICOLON,
+        ):
+            return
+        raise self._error(f"expected an identifier, found {self._found()}")
 
     def _at_keyword(self, keyword: str) -> bool:
         return self._current.kind is TokenKind.NAME and self._current.value == (
@@ -224,8 +257,6 @@ class ProvNParser:
         self._apply_declarations(document, namespaces, default)
         while not self._at_keyword("endDocument"):
             if self._current.kind is TokenKind.EOF:
-                if self._eof_after_lenient_skip():
-                    return document
                 raise self._error("expected 'endDocument', found end of input")
             if self._at_keyword("bundle"):
                 self._bundle(document)
@@ -235,24 +266,6 @@ class ProvNParser:
         if self._current.kind is not TokenKind.EOF:
             raise self._error("unexpected content after 'endDocument'")
         return document
-
-    def _eof_after_lenient_skip(self) -> bool:
-        """Whether end of input, reached looking for 'endBundle'/'endDocument',
-        is the tail of a statement lenient already skipped, rather than a
-        genuinely missing closing keyword.
-
-        A statement left open by a missing ``)``/``]`` can read straight
-        through a following ``bundle``/``endBundle``/``endDocument`` as if it
-        were ordinary data (e.g. an identifier or an attribute value), since
-        the lexer does not distinguish keywords from names; the resulting
-        error is only raised once resolving that data fails, by which point
-        the keyword is gone from the token stream and cannot be resynced to.
-        Under ``lenient``, once at least one statement has already been
-        skipped, reaching end of input this way ends the document instead of
-        raising, rather than punishing the one profile meant to salvage a
-        damaged file for a token its own recovery consumed.
-        """
-        return self.profile == "lenient" and bool(self.skipped)
 
     def _declarations(self) -> tuple[list[Namespace], str | None]:
         """Consume 'prefix'/'default' declarations without committing them.
@@ -306,7 +319,7 @@ class ProvNParser:
 
     def _bundle(self, document: ProvDocument) -> None:
         self._advance()  # 'bundle'
-        id_token = self._identifier_token()
+        id_token = self._identifier_token(inside_parens=False)
         namespaces, default = self._declarations()
         # PROV-N 3.1.3: the bundle identifier is resolved with the bundle's
         # own declarations. Only take the bundle-based resolution path when
@@ -343,8 +356,6 @@ class ProvNParser:
             return
         while not self._at_keyword("endBundle"):
             if self._current.kind is TokenKind.EOF:
-                if self._eof_after_lenient_skip():
-                    return
                 raise self._error("expected 'endBundle', found end of input")
             if self._at_keyword("bundle"):
                 raise self._error("a bundle cannot contain a bundle")
@@ -529,6 +540,7 @@ class ProvNParser:
             raise self._error(
                 f"expected an identifier, a time or '-', found {self._found()}"
             )
+        self._reject_unclosed_structural_keyword()
         return self._advance()
 
     def _argument_value(

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -3,6 +3,7 @@ forms, error paths and equality with documents the writer produced.
 Profile behaviour (default, lenient) is in test_provn_profiles.py."""
 
 import datetime
+import io
 
 import pytest
 
@@ -501,3 +502,47 @@ def test_writer_output_parses_to_an_equal_document(build):
     doc = build()
     reloaded = ProvNParser(doc.get_provn(), "default").parse()
     assert reloaded == doc
+
+
+def test_duplicate_prefix_in_one_scope_is_an_error():
+    with pytest.raises(ProvNSyntaxError, match="prefix 'ex' is declared twice") as ctx:
+        parse(
+            "entity(ex:e1)",
+            prefixes="prefix ex <http://a.org/>\nprefix ex <http://b.org/>\n",
+        )
+    assert (ctx.value.line, ctx.value.column) == (3, 8)
+
+
+def test_escaped_colon_literal_needs_a_default_namespace():
+    with pytest.raises(ProvNSyntaxError, match="no default namespace declared"):
+        parse(r"entity(ex:e1, [ex:k='a\:b'])")
+
+
+def test_duplicate_bundle_identifier_is_a_positioned_syntax_error():
+    with pytest.raises(ProvNSyntaxError, match="already exists") as ctx:
+        parse("bundle ex:b\nendBundle\nbundle ex:b\nendBundle")
+    assert ctx.value.line == 6
+
+
+@pytest.mark.parametrize(
+    "body",
+    ['entity(ex:e1, [123="x"])', 'entity(ex:e1, [ex:a="x" %% 123])'],
+)
+def test_all_digit_local_names_in_attribute_positions(body):
+    doc = parse(body, prefixes=PREFIXES + "default <http://d/>\n")
+    (record,) = doc.get_records()
+    assert record.attributes
+
+
+def test_leading_byte_order_mark_is_skipped():
+    doc = ProvDocument.deserialize(
+        content="﻿document\n prefix ex <http://example.org/>\n entity(ex:e1)\nendDocument",
+        format="provn",
+    )
+    assert [str(r.identifier) for r in doc.get_records()] == ["ex:e1"]
+
+
+def test_bytearray_stream_is_decoded():
+    text = "document\n prefix ex <http://example.org/>\n entity(ex:e1)\nendDocument"
+    doc = ProvDocument.deserialize(io.BytesIO(bytearray(text, "utf-8")), format="provn")
+    assert [str(r.identifier) for r in doc.get_records()] == ["ex:e1"]

--- a/src/prov/tests/test_provn_lexer.py
+++ b/src/prov/tests/test_provn_lexer.py
@@ -357,3 +357,9 @@ def test_pn_chars_classes_match_the_recommendation_s_own_literal_ranges():
         char = chr(codepoint)
         for old_re, new_re in compiled:
             assert bool(old_re.match(char)) == bool(new_re.match(char)), hex(codepoint)
+
+
+@pytest.mark.parametrize("text", ['"a\rb"', "'a\rb'"])
+def test_carriage_return_ends_a_short_literal(text):
+    with pytest.raises(ProvNSyntaxError, match="unterminated"):
+        list(tokenize(text))

--- a/src/prov/tests/test_provn_profiles.py
+++ b/src/prov/tests/test_provn_profiles.py
@@ -345,3 +345,30 @@ def test_lenient_warning_reports_the_read_call_site(tmp_path):
     prov_warnings = [w for w in caught if w.category is ProvWarning]
     assert len(prov_warnings) == 1
     assert prov_warnings[0].filename == __file__
+
+
+def test_lenient_resync_stops_at_a_bundle_header_after_an_unclosed_statement():
+    body = 'entity(ex:e, [ex:a="x"\nbundle ex:b\n  entity(ex:f)\nendBundle'
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 1
+    assert records(doc) == []
+    (bundle,) = doc.bundles
+    assert [str(r.identifier) for r in records(bundle)] == ["ex:f"]
+
+
+def test_lenient_resync_stops_at_end_document_after_an_unclosed_statement():
+    with pytest.warns(ProvWarning) as caught:
+        doc = parse("entity(", profile="lenient")
+    assert len(caught) == 1
+    assert records(doc) == []
+
+
+def test_lenient_skips_a_duplicate_bundle_whole():
+    body = "bundle ex:b\n  entity(ex:e1)\nendBundle\nbundle ex:b\n  entity(ex:e2)\nendBundle\nentity(ex:e3)"
+    with pytest.warns(ProvWarning, match="already exists") as caught:
+        doc = parse(body, profile="lenient")
+    assert len(caught) == 1
+    (bundle,) = doc.bundles
+    assert [str(r.identifier) for r in records(bundle)] == ["ex:e1"]
+    assert [str(r.identifier) for r in records(doc)] == ["ex:e3"]

--- a/src/prov/tests/test_provn_profiles.py
+++ b/src/prov/tests/test_provn_profiles.py
@@ -372,3 +372,17 @@ def test_lenient_skips_a_duplicate_bundle_whole():
     (bundle,) = doc.bundles
     assert [str(r.identifier) for r in records(bundle)] == ["ex:e1"]
     assert [str(r.identifier) for r in records(doc)] == ["ex:e3"]
+
+
+@pytest.mark.parametrize("profile", ["strict", "default"])
+def test_structural_keyword_shaped_data_still_parses(profile):
+    """The lookahead that stops an unclosed statement from swallowing a
+    following 'bundle'/'endDocument' as data (see
+    test_lenient_resync_stops_at_end_document_after_an_unclosed_statement)
+    only rejects a bare structural keyword not followed by ',', ')' or ';';
+    a genuine identifier or argument spelt the same way still parses."""
+    body = "default <http://example.org/>\nentity(bundle)\nused(ex:a, endBundle, -)"
+    doc = parse(body, profile=profile)
+    ids = sorted(str(r.identifier) for r in records(doc) if r.identifier is not None)
+    assert ids == ["bundle"]
+    assert len(records(doc)) == 2


### PR DESCRIPTION
## Summary

A by-eye review of the 3.2.x PROV-N parser against the Recommendation found eight gaps. A prefix declared twice in one scope was accepted instead of rejected. A bare qualified-name literal with an escaped colon and no default namespace resolved in the wrong namespace instead of raising. A duplicate bundle identifier raised an unpositioned model exception instead of a positioned `ProvNSyntaxError`, and `lenient` did not skip the bundle. An all-digit local name was rejected as an attribute name and as a `%%` datatype even though it is accepted as an identifier. A leading byte order mark broke tokenisation, a carriage return did not end a short string or qualified-name literal the way a line feed does, and a `bytearray` stream was not decoded. The `lenient` profile's resync could also swallow a `bundle` header or `endDocument` that followed a statement left open by a missing closing bracket, because the token before a structural keyword, not bracket depth, is what tells a keyword-shaped attribute value apart from a real boundary.

Fixes each gap in `provn_lexer.py` (CR-terminated string/qname-literal patterns, a BOM strip in `tokenize()`), `provn_parser.py` (a duplicate-prefix check in `_declarations`, a positioned try/except around `_bundle`'s two creation paths with a lenient whole-bundle skip, digit-run handling in `_attributes`/`_literal`, an escaped-colon check in `_literal`, and a last-consumed-token test in `_resync` replacing the depth gate) and `provn.py` (`bytearray` decoding). Also relaxes the "expected 'endBundle'/'endDocument'" check to end the document gracefully, under `lenient`, when end of input is the tail of a statement already skipped rather than a genuinely missing closing keyword — without this, the swallowed keyword left the outer loop with nothing to find and it raised anyway.

## Test plan
- [x] `uv run --extra rdf --extra xml --extra dot --extra graph pytest -q` on 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.11: 2522 passed, 26 skipped, 191 xfailed (was 2510/26/191 before this branch)
- [x] `uv run mypy src` (Python 3.12): no issues
- [x] `uv run ruff check src/ benchmarks/`: no issues
- [x] `uv run ruff format --check src/ benchmarks/`: no issues
- [x] `codacy-analysis analyze` on every changed file: 0 issues