### PR TITLE
fix(provn): writer fixes from the 3.2.x review

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -67,6 +67,15 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   feed; a `bytearray` stream is decoded
 - The `lenient` PROV-N profile no longer swallows a `bundle` header or `endDocument` that
   follows a statement missing its closing bracket
+- PROV-N output names a bundle with a prefixed identifier when the bundle declares a default
+  namespace different from the one its identifier lives in, adding the prefix declaration
+  inside the bundle, so the identifier's IRI survives re-reading; a bare name was resolved
+  against the bundle's own default
+- The PROV-N writer warns with `ProvWarning` when it percent-encodes a character a local
+  part cannot express, encodes a lone surrogate instead of raising `UnicodeEncodeError`,
+  percent-encodes a leading character PN_LOCAL forbids first, raises `ProvException` for a
+  namespace URI that is not an IRI, and writes a datetime whose UTC offset is not a whole
+  number of minutes in UTC
 
 ## 3.2.0 (2026-09-12)
 

--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -31,7 +31,9 @@ background for PROV-DM's six components. This page is the detailed reference und
   PROV-N that ProvToolbox writes for the shared test corpus; the differences it found are
   listed under "PROV-N corpus" below. A namespace prefix must be a valid PROV-N `PN_PREFIX`
   (start with a letter, not end with `.`) for the PROV-N output to be readable; `prov` does
-  not validate or rename a prefix that isn't.
+  not validate or rename a prefix that isn't. A local part containing a character PN_LOCAL
+  cannot express is percent-encoded with a `ProvWarning`; a PROV-N reader recovers the
+  percent-encoded IRI, so `a b` and `a%20b` read back as the same identifier.
 
 ## Caveats that span several rows
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -137,13 +137,18 @@ document
   prefix ex2 <http://example.org/2/>
 
   entity(e001)
-  bundle e001
+  bundle dn:e001
     default <http://example.org/2/>
+    prefix dn <http://example.org/0/>
 
     entity(e001)
   endBundle
 endDocument
 ```
+
+The bundle's identifier lives in the document's default namespace while the bundle declares
+its own default, so the writer gives that namespace the prefix `dn` inside the bundle; a bare
+`bundle e001` would be read as `http://example.org/2/e001`.
 
 ## Where next
 

--- a/src/prov/_warnings.py
+++ b/src/prov/_warnings.py
@@ -1,4 +1,8 @@
-"""Shared ``warnings.warn()`` stacklevel helper.
+"""``ProvWarning`` and the shared ``warnings.warn()`` stacklevel helper.
+
+Both live here, not in :mod:`prov.model.records`, so that :mod:`prov.identifier`
+can raise ``ProvWarning`` without importing :mod:`prov.model` and creating a
+cycle; :mod:`prov.model` re-exports both under their historic names.
 
 Attributing a warning to its caller with a fixed ``stacklevel`` only works
 when every call path between the ``warn()`` site and the external caller
@@ -10,6 +14,10 @@ found by walking the real call stack instead.
 
 import sys
 from types import FrameType
+
+
+class ProvWarning(Warning):
+    """Base class for PROV model warnings."""
 
 
 def external_stacklevel(skip: int = 1) -> int:

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -1,9 +1,11 @@
 from __future__ import annotations  # defer eval: Namespace used before it's defined
 
 import re
+import warnings
 from typing import Any, Final
 
 from prov import Error
+from prov._warnings import ProvWarning, external_stacklevel
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
@@ -54,6 +56,19 @@ _PROVN_LOCAL_LEADING_ESCAPE = "-."
 # PN_LOCAL's own character class ([53]), the shared NCName table minus '.'
 # (see the comment on _NCNAME_CHARS above).
 _PN_CHARS = _NCNAME_CHARS.replace(".", "")
+# The characters in _PN_CHARS that are legal anywhere in PN_LOCAL but, being
+# combining marks rather than letters, cannot start it ([53]'s PN_CHARS_BASE
+# vs. PN_CHARS): the NameChar-only part of _NCNAME_CHARS, minus '-'/'.'
+# (handled positionally above) and the digits (PN_LOCAL allows a leading
+# digit). Spelled the same way as _NCNAME_CHARS so a look-alike codepoint
+# stays visible on inspection.
+_PN_LOCAL_BAD_START = re.compile(
+    "["
+    "\xb7"  # NameChar: #xB7 (middle dot)
+    "\u0300-\u036f"  # NameChar: [#x0300-#x036F]
+    "\u203f-\u2040"  # NameChar: [#x203F-#x2040]
+    "]"
+)
 # The remaining characters PN_LOCAL allows unescaped ([54]'s PLX minus '%').
 _PN_CHARS_OTHER = "/@~&+*?#$!"
 _PROVN_HEX_PAIR = re.compile(r"[0-9A-Fa-f]{2}")
@@ -79,29 +94,55 @@ _PROVN_LOCAL_NEEDS_ESCAPE = re.compile(
 )
 
 
-def _provn_escape_local(localpart: str) -> str:
-    """Return ``localpart`` escaped for use in a PROV-N ``PN_LOCAL`` position."""
-    if not _PROVN_LOCAL_NEEDS_ESCAPE.search(localpart):
-        return localpart
+def _escape_local_char(
+    localpart: str, i: int, last_index: int, char: str
+) -> tuple[str, bool]:
+    """Return one character's PROV-N spelling and whether it was percent-encoded."""
+    if i == 0 and _PN_LOCAL_BAD_START.match(char):
+        # PN_LOCAL_BAD_START chars are legal PN_CHARS but cannot start a
+        # PN_LOCAL, and there is no backslash escape for "start here";
+        # percent-encoding is the only way to write one first.
+        return "".join(f"%{byte:02X}" for byte in char.encode("utf-8")), True
+    if char == "%":
+        # An existing valid escape (e.g. "%20") is kept verbatim; a bare
+        # '%' not followed by two hex digits is not, so it is escaped
+        # itself to keep the sequence unambiguous.
+        return (char if _PROVN_HEX_PAIR.match(localpart, i + 1) else "%25"), False
+    if (
+        (i == 0 and char in _PROVN_LOCAL_LEADING_ESCAPE)
+        or (i == last_index and char == ".")
+        or char in _PROVN_LOCAL_METACHARS
+    ):
+        return f"\\{char}", False
+    if _PROVN_LOCAL_NEEDS_PERCENT_ENCODING.match(char):
+        # "surrogatepass" lets a lone surrogate (unpaired, e.g. from WTF-8 or
+        # a Windows filename) be percent-encoded from its raw UTF-16 code
+        # unit rather than raising UnicodeEncodeError.
+        encoded = char.encode("utf-8", "surrogatepass")
+        return "".join(f"%{byte:02X}" for byte in encoded), True
+    return char, False
+
+
+def _provn_escape_local(localpart: str) -> tuple[str, bool]:
+    """Return ``localpart`` escaped for use in a PROV-N ``PN_LOCAL`` position.
+
+    Returns the escaped text and whether it was percent-encoded anywhere: a
+    backslash escape (a metacharacter, or a leading/trailing ``-``/``.``) is
+    reversible and a PROV-N reader recovers the original text, but a
+    percent-encoded character is not, so the caller warns when it happens.
+    """
+    if not _PROVN_LOCAL_NEEDS_ESCAPE.search(localpart) and not (
+        localpart and _PN_LOCAL_BAD_START.match(localpart[0])
+    ):
+        return localpart, False
     last_index = len(localpart) - 1
     parts = []
+    encoded = False
     for i, char in enumerate(localpart):
-        if char == "%":
-            # An existing valid escape (e.g. "%20") is kept verbatim; a bare
-            # '%' not followed by two hex digits is not, so it is escaped
-            # itself to keep the sequence unambiguous.
-            parts.append(char if _PROVN_HEX_PAIR.match(localpart, i + 1) else "%25")
-        elif (
-            (i == 0 and char in _PROVN_LOCAL_LEADING_ESCAPE)
-            or (i == last_index and char == ".")
-            or char in _PROVN_LOCAL_METACHARS
-        ):
-            parts.append(f"\\{char}")
-        elif _PROVN_LOCAL_NEEDS_PERCENT_ENCODING.match(char):
-            parts.extend(f"%{byte:02X}" for byte in char.encode("utf-8"))
-        else:
-            parts.append(char)
-    return "".join(parts)
+        text, char_was_encoded = _escape_local_char(localpart, i, last_index, char)
+        parts.append(text)
+        encoded = encoded or char_was_encoded
+    return "".join(parts), encoded
 
 
 class Identifier:
@@ -243,9 +284,10 @@ class QualifiedName(Identifier):
         The local part's PROV-N metacharacters (``= ' ( ) , : ; [ ]``) are
         backslash-escaped per grammar production [55] ``PN_CHARS_ESC`` (#223),
         as are a leading ``-``/``.`` and a trailing ``.`` (forbidden bare by
-        [53]/[54]); characters PN_LOCAL cannot express at all are
-        percent-encoded. The prefix is never escaped, as it cannot contain
-        these characters.
+        [53]/[54]); a character PN_LOCAL cannot express at all, or cannot
+        start it, is percent-encoded instead, which changes the IRI a PROV-N
+        reader recovers, so that emits a :class:`~prov.model.ProvWarning`.
+        The prefix is never escaped, as it cannot contain these characters.
 
         Raises:
             Error: If the local part is empty and the namespace has no prefix,
@@ -257,7 +299,15 @@ class QualifiedName(Identifier):
                 "namespace with no prefix, which PROV-N cannot write; give the "
                 "namespace a prefix"
             )
-        escaped_localpart = _provn_escape_local(self._localpart)
+        escaped_localpart, encoded = _provn_escape_local(self._localpart)
+        if encoded:
+            warnings.warn(
+                f"the local part {self._localpart!r} of <{self._uri}> contains a "
+                "character PROV-N cannot write; it is percent-encoded, which changes "
+                "the IRI a PROV-N reader recovers",
+                ProvWarning,
+                stacklevel=external_stacklevel(),
+            )
         return (
             ":".join([self._namespace.prefix, escaped_localpart])
             if self._namespace.prefix

--- a/src/prov/identifier.py
+++ b/src/prov/identifier.py
@@ -145,6 +145,29 @@ def _provn_escape_local(localpart: str) -> tuple[str, bool]:
     return "".join(parts), encoded
 
 
+def _provn_escape_local_and_warn(localpart: str, uri: str) -> str:
+    """Escape ``localpart`` for a PROV-N ``PN_LOCAL`` position, warning if that
+    changes the IRI a PROV-N reader recovers.
+
+    ``uri`` is the identifier's full URI, named in the warning so the caller
+    can find which identifier is affected. Shared by
+    :meth:`QualifiedName.provn_bare_representation` and the bundle-header
+    prefix path in :mod:`prov.model.bundle`, so both raise the same
+    :class:`~prov.model.ProvWarning` for the same reason rather than one of
+    them silently changing the IRI.
+    """
+    escaped, encoded = _provn_escape_local(localpart)
+    if encoded:
+        warnings.warn(
+            f"the local part {localpart!r} of <{uri}> contains a character PROV-N "
+            "cannot write; it is percent-encoded, which changes the IRI a PROV-N "
+            "reader recovers",
+            ProvWarning,
+            stacklevel=external_stacklevel(),
+        )
+    return escaped
+
+
 class Identifier:
     """Base class for all identifiers and also represents xsd:anyURI."""
 
@@ -299,15 +322,7 @@ class QualifiedName(Identifier):
                 "namespace with no prefix, which PROV-N cannot write; give the "
                 "namespace a prefix"
             )
-        escaped_localpart, encoded = _provn_escape_local(self._localpart)
-        if encoded:
-            warnings.warn(
-                f"the local part {self._localpart!r} of <{self._uri}> contains a "
-                "character PROV-N cannot write; it is percent-encoded, which changes "
-                "the IRI a PROV-N reader recovers",
-                ProvWarning,
-                stacklevel=external_stacklevel(),
-            )
+        escaped_localpart = _provn_escape_local_and_warn(self._localpart, self._uri)
         return (
             ":".join([self._namespace.prefix, escaped_localpart])
             if self._namespace.prefix

--- a/src/prov/model/__init__.py
+++ b/src/prov/model/__init__.py
@@ -22,6 +22,7 @@ from typing import Any as Any, Union as Union
 from urllib.parse import urlparse as urlparse
 
 from prov import Error as Error, serializers as serializers
+from prov._warnings import ProvWarning as ProvWarning
 from prov.constants import *
 from prov.identifier import (
     Identifier as Identifier,
@@ -78,7 +79,6 @@ from prov.model.records import (
     ProvStart as ProvStart,
     ProvUnificationError as ProvUnificationError,
     ProvUsage as ProvUsage,
-    ProvWarning as ProvWarning,
     QualifiedNameCandidate as QualifiedNameCandidate,
     RecordAttributesArg as RecordAttributesArg,
     StreamOrPath as StreamOrPath,

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -68,7 +68,7 @@ from prov.constants import (
     PROV_USAGE,
     PROV_VALUE,
 )
-from prov.identifier import Namespace, QualifiedName, _provn_escape_local
+from prov.identifier import Namespace, QualifiedName, _provn_escape_local_and_warn
 from prov.model.namespaces import NamespaceManager
 from prov.model.records import (
     PROV_REC_CLS,
@@ -554,7 +554,9 @@ class ProvBundle:
             prefix = f"dn_{count}"
             count += 1
         extra_prefix = Namespace(prefix, id_namespace.uri)
-        localpart = _provn_escape_local(self._identifier.localpart)[0]
+        localpart = _provn_escape_local_and_warn(
+            self._identifier.localpart, self._identifier.uri
+        )
         return f"{prefix}:{localpart}", extra_prefix
 
     def _provn_namespace_lines(

--- a/src/prov/model/bundle.py
+++ b/src/prov/model/bundle.py
@@ -6,6 +6,7 @@ import io
 import itertools
 import logging
 import os
+import re
 import shutil
 import tempfile
 from collections import defaultdict
@@ -67,7 +68,7 @@ from prov.constants import (
     PROV_USAGE,
     PROV_VALUE,
 )
-from prov.identifier import Namespace, QualifiedName
+from prov.identifier import Namespace, QualifiedName, _provn_escape_local
 from prov.model.namespaces import NamespaceManager
 from prov.model.records import (
     PROV_REC_CLS,
@@ -111,6 +112,22 @@ from prov.model.records import (
 )
 
 logger = logging.getLogger(__name__)
+
+_PROVN_IRI_FORBIDDEN = re.compile(r'[<>"{}|^`\\\x00-\x20]')
+
+
+def _check_provn_iri(namespace: Namespace) -> None:
+    """A namespace URI must be a PROV-N IRI_REF ([56]) to be declared."""
+    if _PROVN_IRI_FORBIDDEN.search(namespace.uri):
+        where = (
+            f"prefix '{namespace.prefix}'"
+            if namespace.prefix
+            else "the default namespace"
+        )
+        raise ProvException(
+            f"{where} has URI <{namespace.uri}>, which PROV-N cannot write as an IRI: "
+            'it contains a space, a control character or one of <>"{}|^`\\'
+        )
 
 
 # PROV-CONSTRAINTS (https://www.w3.org/TR/prov-constraints/) type compatibility
@@ -507,6 +524,70 @@ class ProvBundle:
         """
         raise ProvException("A PROV bundle does not contain sub-bundles")
 
+    def _provn_header_id(
+        self,
+        default_namespace: Namespace | None,
+        registered_namespaces: list[Namespace],
+    ) -> tuple[str, Namespace | None]:
+        """Return the bundle header's identifier text and, if needed, an
+        extra prefix declaration for its namespace.
+
+        A bare identifier in a namespace with no prefix would, on re-read,
+        resolve against the bundle's own default namespace (PROV-N 3.4.1)
+        rather than the namespace it was minted in. When those differ, this
+        mints a prefix for the identifier's namespace instead of writing the
+        identifier bare.
+        """
+        if self._identifier is None:
+            return "", None
+        id_namespace = self._identifier.namespace
+        if (
+            id_namespace.prefix
+            or default_namespace is None
+            or default_namespace.uri == id_namespace.uri
+        ):
+            return self._identifier.provn_bare_representation(), None
+        prefix = "dn"
+        taken = {ns.prefix for ns in registered_namespaces}
+        count = 1
+        while prefix in taken:
+            prefix = f"dn_{count}"
+            count += 1
+        extra_prefix = Namespace(prefix, id_namespace.uri)
+        localpart = _provn_escape_local(self._identifier.localpart)[0]
+        return f"{prefix}:{localpart}", extra_prefix
+
+    def _provn_namespace_lines(
+        self,
+        default_namespace: Namespace | None,
+        registered_namespaces: list[Namespace],
+        extra_prefix: Namespace | None,
+    ) -> list[str]:
+        """Return the header's ``default``/``prefix`` declaration lines.
+
+        Checks every namespace being declared is a legal PROV-N IRI first,
+        then a trailing blank line separates the declarations from the
+        assertions that follow, present only when there is at least one.
+        """
+        for namespace in (
+            ([default_namespace] if default_namespace else [])
+            + registered_namespaces
+            + ([extra_prefix] if extra_prefix else [])
+        ):
+            _check_provn_iri(namespace)
+
+        lines = [f"default <{default_namespace.uri}>"] if default_namespace else []
+        lines.extend(
+            f"prefix {namespace.prefix} <{namespace.uri}>"
+            for namespace in registered_namespaces
+        )
+        if extra_prefix is not None:
+            lines.append(f"prefix {extra_prefix.prefix} <{extra_prefix.uri}>")
+        if lines:
+            #  a blank line between the prefixes and the assertions
+            lines.append("")
+        return lines
+
     def get_provn(self, _indent_level: int = 0, strict: bool = False) -> str:
         """Return the PROV-N representation of the bundle.
 
@@ -521,27 +602,17 @@ class ProvBundle:
 
         #  if this is the document, start the document;
         # otherwise, start the bundle
-        bundle_id = (
-            self._identifier.provn_bare_representation() if self._identifier else ""
+        default_namespace = self._namespaces.get_default_namespace()
+        registered_namespaces = list(self._namespaces.get_registered_namespaces())
+        bundle_id, extra_prefix = self._provn_header_id(
+            default_namespace, registered_namespaces
         )
         lines = ["document"] if self.is_document() else [f"bundle {bundle_id}"]
-
-        default_namespace = self._namespaces.get_default_namespace()
-        if default_namespace:
-            lines.append(f"default <{default_namespace.uri}>")
-
-        registered_namespaces = self._namespaces.get_registered_namespaces()
-        if registered_namespaces:
-            lines.extend(
-                [
-                    f"prefix {namespace.prefix} <{namespace.uri}>"
-                    for namespace in registered_namespaces
-                ]
+        lines.extend(
+            self._provn_namespace_lines(
+                default_namespace, registered_namespaces, extra_prefix
             )
-
-        if default_namespace or registered_namespaces:
-            #  a blank line between the prefixes and the assertions
-            lines.append("")
+        )
 
         #  adding all the records
         lines.extend([record.get_provn(strict=strict) for record in self._records])

--- a/src/prov/model/records.py
+++ b/src/prov/model/records.py
@@ -353,6 +353,15 @@ def _ensure_multiline_string_triple_quoted(value: str) -> str:
         return f'"{s}"'
 
 
+def _xsd_datetime_text(value: datetime.datetime) -> str:
+    """ISO 8601 text with an xsd:dateTime-legal zone: an offset that is not a
+    whole number of minutes (historical LMT offsets) is normalised to UTC."""
+    offset = value.utcoffset()
+    if offset is not None and (offset.total_seconds() % 60 or offset.microseconds):
+        value = value.astimezone(datetime.timezone.utc)
+    return value.isoformat()
+
+
 def encoding_provn_value(
     value: str | datetime.datetime | float | bool | int | QualifiedName,
 ) -> str:
@@ -369,7 +378,7 @@ def encoding_provn_value(
     if isinstance(value, str):
         return _ensure_multiline_string_triple_quoted(value)
     elif isinstance(value, datetime.datetime):
-        return f'"{value.isoformat()}" %% xsd:dateTime'
+        return f'"{_xsd_datetime_text(value)}" %% xsd:dateTime'
     elif isinstance(value, float):
         return f'"{value!r}" %% xsd:double'
     elif isinstance(value, bool):
@@ -558,10 +567,6 @@ CoercedAttributeValue: typing.TypeAlias = (
 # Exceptions and warnings
 class ProvException(Error):
     """Base class for PROV model exceptions."""
-
-
-class ProvWarning(Warning):
-    """Base class for PROV model warnings."""
 
 
 class ProvExceptionInvalidQualifiedName(ProvException):
@@ -1007,7 +1012,7 @@ class ProvRecord:
                 # Formal attributes always have single values
                 value = first(values)
                 if isinstance(value, datetime.datetime):
-                    items.append(value.isoformat())
+                    items.append(_xsd_datetime_text(value))
                 elif isinstance(value, QualifiedName):
                     items.append(value.provn_bare_representation())
                 else:

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -7,7 +7,7 @@ import io
 
 import pytest
 
-from prov.model import PROV_REC_CLS, Literal, ProvDocument, ProvMention
+from prov.model import PROV_REC_CLS, Literal, ProvDocument, ProvException, ProvMention
 from prov.serializers.provn_lexer import ProvNSyntaxError
 from prov.serializers.provn_parser import (
     _ELEMENTS,
@@ -546,3 +546,34 @@ def test_bytearray_stream_is_decoded():
     text = "document\n prefix ex <http://example.org/>\n entity(ex:e1)\nendDocument"
     doc = ProvDocument.deserialize(io.BytesIO(bytearray(text, "utf-8")), format="provn")
     assert [str(r.identifier) for r in doc.get_records()] == ["ex:e1"]
+
+
+def test_bundle_in_document_default_with_its_own_default_round_trips():
+    d = ProvDocument()
+    d.set_default_namespace("http://doc.org/")
+    b = d.bundle("b1")
+    b.set_default_namespace("http://bundle.org/")
+    b.entity("e1")
+    text = d.get_provn()
+    assert "bundle dn:b1" in text and "prefix dn <http://doc.org/>" in text
+    again = ProvDocument.deserialize(content=text, format="provn")
+    assert again == d
+    (bundle,) = again.bundles
+    assert bundle.identifier.uri == "http://doc.org/b1"
+
+
+def test_namespace_uri_that_is_not_an_iri_cannot_be_written():
+    d = ProvDocument()
+    d.add_namespace("bad", "http://example.org/a b/")
+    with pytest.raises(ProvException, match="bad"):
+        d.get_provn()
+
+
+def test_sub_minute_utc_offset_is_written_in_utc():
+    tz = datetime.timezone(datetime.timedelta(seconds=30))
+    d = ProvDocument()
+    d.add_namespace("ex", "http://example.org/")
+    d.activity("ex:a1", datetime.datetime(2026, 9, 12, 10, 0, 30, tzinfo=tz))
+    text = d.get_provn()
+    assert "2026-09-12T10:00:00+00:00" in text
+    assert ProvDocument.deserialize(content=text, format="provn") == d

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -562,6 +562,22 @@ def test_bundle_in_document_default_with_its_own_default_round_trips():
     assert bundle.identifier.uri == "http://doc.org/b1"
 
 
+def test_bundle_header_prefix_avoids_a_taken_dn_prefix():
+    # When the bundle already declares its own "dn" prefix for something
+    # else, the header's minted prefix falls back to "dn_1" instead of
+    # colliding with it.
+    d = ProvDocument()
+    d.set_default_namespace("http://doc.org/")
+    b = d.bundle("b1")
+    b.set_default_namespace("http://bundle.org/")
+    b.add_namespace("dn", "http://other.org/")
+    b.entity("e1")
+    text = d.get_provn()
+    assert "bundle dn_1:b1" in text
+    assert "prefix dn_1 <http://doc.org/>" in text
+    assert ProvDocument.deserialize(content=text, format="provn") == d
+
+
 def test_namespace_uri_that_is_not_an_iri_cannot_be_written():
     d = ProvDocument()
     d.add_namespace("bad", "http://example.org/a b/")

--- a/src/prov/tests/test_provn.py
+++ b/src/prov/tests/test_provn.py
@@ -7,7 +7,14 @@ import io
 
 import pytest
 
-from prov.model import PROV_REC_CLS, Literal, ProvDocument, ProvException, ProvMention
+from prov.model import (
+    PROV_REC_CLS,
+    Literal,
+    ProvDocument,
+    ProvException,
+    ProvMention,
+    ProvWarning,
+)
 from prov.serializers.provn_lexer import ProvNSyntaxError
 from prov.serializers.provn_parser import (
     _ELEMENTS,
@@ -576,6 +583,23 @@ def test_bundle_header_prefix_avoids_a_taken_dn_prefix():
     assert "bundle dn_1:b1" in text
     assert "prefix dn_1 <http://doc.org/>" in text
     assert ProvDocument.deserialize(content=text, format="provn") == d
+
+
+def test_bundle_header_prefix_percent_encoding_warns_once():
+    # The synthesised "dn:" prefix and the percent-encoding of an
+    # unrepresentable character in the bundle's own identifier are two
+    # separate writer decisions on the same identifier; only one warning
+    # should reach the caller, via the same code path
+    # provn_bare_representation() uses.
+    d = ProvDocument()
+    d.set_default_namespace("http://doc.org/")
+    b = d.bundle("b 1")
+    b.set_default_namespace("http://bundle.org/")
+    b.entity("e1")
+    with pytest.warns(ProvWarning) as record:
+        text = d.get_provn()
+    assert "bundle dn:b%201" in text
+    assert len(record) == 1
 
 
 def test_namespace_uri_that_is_not_an_iri_cannot_be_written():

--- a/src/prov/tests/test_provn_escaping.py
+++ b/src/prov/tests/test_provn_escaping.py
@@ -3,9 +3,12 @@
 
 import pytest
 
-from prov.model import Literal, ProvDocument
+from prov.identifier import Namespace
+from prov.model import Literal, ProvDocument, ProvWarning
 
 METACHARS = "='(),:;[]"
+
+NS = Namespace("ex", "http://example.org/")
 
 
 def _doc():
@@ -111,6 +114,28 @@ def test_unrepresentable_chars_are_percent_encoded(local, escaped):
     reloaded = ProvDocument.deserialize(content=provn, format="provn")
     (reloaded_entity,) = reloaded.get_records()
     assert reloaded_entity.identifier.localpart == escaped
+
+
+def test_percent_encoding_warns_that_the_iri_changes():
+    with pytest.warns(ProvWarning, match="percent"):
+        assert NS["a b"].provn_bare_representation() == "ex:a%20b"
+
+
+def test_lone_surrogate_is_percent_encoded():
+    with pytest.warns(ProvWarning):
+        assert NS["e\udc80"].provn_bare_representation() == "ex:e%ED%B2%80"
+
+
+@pytest.mark.parametrize("first", ["·", "́", "‿"])
+def test_leading_name_char_that_cannot_start_a_local_part_is_encoded(first):
+    with pytest.warns(ProvWarning):
+        written = NS[first + "a"].provn_bare_representation()
+    assert written.startswith("ex:%")
+    doc = ProvDocument.deserialize(
+        content=f"document\n prefix ex <{NS.uri}>\n entity({written})\nendDocument",
+        format="provn",
+    )
+    assert len(list(doc.get_records())) == 1
 
 
 def test_empty_langtag_literal_written_as_plain_string():


### PR DESCRIPTION
## Summary
A by-eye review of the PROV-N writer against the Recommendation grammar found five gaps: a bundle whose identifier lives in the document's default namespace but which declares its own different default wrote a bare name that re-read against the wrong namespace; the writer raised UnicodeEncodeError on a lone surrogate and silently percent-encoded other unrepresentable characters with no warning; a local part starting with a PN_CHARS-only combining mark was written as if it were a legal PN_LOCAL; a namespace URI containing a space or other IRI-illegal character was written unchecked; and a datetime whose UTC offset was not a whole number of minutes produced text that is not legal xsd:dateTime lexical form.

The bundle header now gives the identifier's namespace a fresh prefix (declared inside the bundle) whenever it differs from the bundle's own default, so the identifier's IRI survives re-reading. `_provn_escape_local` returns whether it percent-encoded anything, and `provn_bare_representation()` warns with `ProvWarning` when it did; a lone surrogate is encoded via `surrogatepass` instead of raising, and a leading PN_CHARS-only character is percent-encoded rather than written bare. `get_provn()` validates every declared namespace against PROV-N's IRI_REF grammar and raises `ProvException` naming the offending prefix. A shared `_xsd_datetime_text()` helper normalises a sub-minute UTC offset to UTC before formatting. `ProvWarning` moves to a new `prov._warnings` module, re-exported from `prov.model` under its historic name, so `prov.identifier` can raise it without a circular import with `prov.model`. The tutorial and conformance page are updated to match.

## Test plan
- [x] Full suite: 2532 passed, 26 skipped, 191 xfailed (Task 3's 2524 plus 8 new cases; no skip/xfail regressions)
- [x] `uv run mypy src` clean
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `codacy-analysis analyze` on every changed file: 0 new findings (2 pre-existing, unrelated `redefined-builtin` findings on untouched lines of `bundle.py`)
- [x] `test_public_api.py` (dir(prov.model) unchanged), `test_provn_corpus.py`, `test_statements.py` all pass