### PR TITLE
fix(read): forward declared deserializer options; reject unknown ones clearly

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -76,6 +76,10 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   percent-encodes a leading character PN_LOCAL forbids first, raises `ProvException` for a
   namespace URI that is not an IRI, and writes a datetime whose UTC offset is not a whole
   number of minutes in UTC
+- `prov.read()` forwards each deserializer the options it declares (`profile` for PROV-N;
+  `rdf_format`, `relation_mapper` and `predicate_mapper` for PROV-O), so auto-detection can
+  read non-TriG RDF with `rdf_format`, and an option a format does not accept raises a
+  `TypeError` naming the format and its options instead of a JSON or rdflib error
 
 ## 3.2.0 (2026-09-12)
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -126,6 +126,8 @@ The PROV-N reader and writer set the pattern for any serializer added after 3.2.
 - Section comments and method order follow the grammar, so a reader can jump to a
   production. Tests are one case per token class or production and one per boundary, named
   for the scenario they pin.
+- A serializer declares the keyword arguments its `deserialize()` accepts in
+  `deserialize_options`; `prov.read()` forwards only those.
 
 ## Extras
 

--- a/src/prov/__init__.py
+++ b/src/prov/__init__.py
@@ -3,11 +3,11 @@ from __future__ import annotations  # defer eval: TYPE_CHECKING names in signatu
 import logging
 import os
 import warnings
-from collections.abc import Iterable
 from typing import IO, TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from prov.model import ProvDocument, StreamOrPath
+    from prov.serializers import Serializer
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
@@ -66,7 +66,7 @@ def _prepare_stream(
 def _detect_and_parse(
     src: StreamOrPath | None,
     content: str | bytes | None,
-    serializers: Iterable[str],
+    serializers: dict[str, type[Serializer]],
     **kwargs: Any,
 ) -> ProvDocument:
     """Try each registered format in turn, returning the first non-empty parse.
@@ -107,10 +107,14 @@ def _detect_and_parse(
                     start_pos = None
             try:
                 # kwargs are format-specific (e.g. profile= for provn); a
-                # candidate that doesn't understand them would otherwise
+                # candidate that doesn't understand an option would otherwise
                 # raise TypeError, indistinguishable here from "not this
-                # format", so only the candidate they're meant for gets them.
-                candidate_kwargs = kwargs if format == "provn" else {}
+                # format", so each candidate only gets the options it declares.
+                candidate_kwargs = {
+                    key: value
+                    for key, value in kwargs.items()
+                    if key in serializers[format].deserialize_options
+                }
                 document = ProvDocument.deserialize(
                     source=src, content=content, format=format, **candidate_kwargs
                 )
@@ -176,19 +180,20 @@ def read(
             ``"rdf"``, ``"provn"``). If ``None``, every registered format is
             tried in turn.
         **kwargs: Passed to the deserializer, for example ``profile`` for
-            PROV-N. With ``format`` given explicitly, the named deserializer
-            receives them as given. With auto-detection, only the ``provn``
-            candidate receives them, since ``json``/``rdf``/``xml``/``jsonld``
-            do not accept format-specific keyword arguments and would
-            otherwise raise a ``TypeError`` indistinguishable from "not this
-            format".
+            PROV-N or ``rdf_format`` for PROV-O. Each serializer declares
+            the options it accepts (``deserialize_options``); with
+            ``format`` given, an undeclared option raises ``TypeError``;
+            with auto-detection, every candidate receives only the options
+            it declares.
 
     Returns:
         The deserialized :class:`~prov.model.ProvDocument`.
 
     Raises:
-        TypeError: If ``format`` is ``None`` and no registered serializer
-            produced a non-empty document from ``source``.
+        TypeError: If ``format`` is given and names an option the
+            corresponding deserializer does not declare, or if ``format``
+            is ``None`` and no registered serializer produced a non-empty
+            document from ``source``.
     """
     # Lazy imports to not globber the namespace.
     from prov.model import ProvDocument
@@ -198,11 +203,20 @@ def read(
         Registry.load_serializers()
     if Registry.serializers is None:  # pragma: no cover -- populated above
         raise AssertionError("Registry.serializers is not populated")
-    serializers = Registry.serializers.keys()
+    serializers = Registry.serializers
 
     src, content = _resolve_source(source)
 
     if format:
+        cls = serializers.get(format.lower())
+        if cls is not None:
+            unknown = sorted(set(kwargs) - cls.deserialize_options)
+            if unknown:
+                accepted = ", ".join(sorted(cls.deserialize_options)) or "none"
+                raise TypeError(
+                    f"the {format.lower()!r} deserializer accepts no option "
+                    f"{unknown[0]!r}; it accepts: {accepted}"
+                )
         try:
             return ProvDocument.deserialize(
                 source=src, content=content, format=format.lower(), **kwargs

--- a/src/prov/serializers/__init__.py
+++ b/src/prov/serializers/__init__.py
@@ -35,6 +35,10 @@ class Serializer(ABC):
     document = None
     """PROV document to serialise."""
 
+    deserialize_options: ClassVar[frozenset[str]] = frozenset()
+    """Keyword arguments :meth:`deserialize` accepts beyond ``stream``;
+    :func:`prov.read` forwards only these."""
+
     def __init__(self, document: ProvDocument | None = None):
         """Create a serializer bound to a document.
 

--- a/src/prov/serializers/provn.py
+++ b/src/prov/serializers/provn.py
@@ -17,6 +17,8 @@ __all__ = ["PROFILES", "ProvNSerializer", "ProvNSyntaxError"]
 class ProvNSerializer(Serializer):
     """PROV-N serializer and deserializer for ProvDocument."""
 
+    deserialize_options = frozenset({"profile"})
+
     def serialize(self, stream: io.IOBase, strict: bool = False, **args: Any) -> None:
         """Serialize ``self.document`` to `PROV-N <http://www.w3.org/TR/prov-n/>`_.
 

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -391,6 +391,10 @@ def attr2rdf(attr: QualifiedName) -> URIRef:
 class ProvRDFSerializer(Serializer):
     """PROV-O serializer for :class:`~prov.model.ProvDocument`."""
 
+    deserialize_options = frozenset(
+        {"rdf_format", "relation_mapper", "predicate_mapper"}
+    )
+
     def serialize(
         self,
         stream: io.IOBase,

--- a/src/prov/tests/test_read.py
+++ b/src/prov/tests/test_read.py
@@ -318,6 +318,31 @@ def test_read_auto_detect_provn_with_kwargs_still_warns_and_skips():
     assert [str(r.identifier) for r in document.get_records()] == ["ex:e2"]
 
 
+def test_auto_detection_forwards_rdf_options(document):
+    text = document.serialize(format="rdf", rdf_format="xml")
+    assert prov.read(io.BytesIO(text.encode("utf-8")), rdf_format="xml") == document
+
+
+def test_unknown_option_for_an_explicit_format_is_a_clear_type_error(document):
+    text = document.serialize(format="json")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(
+            TypeError, match="'json' deserializer accepts no option 'profile'"
+        ):
+            prov.read(text, format="json", profile="strict")
+
+
+def test_declared_options_per_serializer():
+    from prov.serializers import Registry
+
+    Registry.load_serializers()
+    assert Registry.serializers["provn"].deserialize_options == frozenset({"profile"})
+    assert Registry.serializers["json"].deserialize_options == frozenset()
+    if "rdf" in Registry.serializers:
+        assert "rdf_format" in Registry.serializers["rdf"].deserialize_options
+
+
 def test_deserialize_path_reads_utf8_regardless_of_locale(tmp_path):
     # serialize(path) always writes UTF-8; deserialize(path) must read it
     # back the same way, not through the C locale's encoding. The 'C'


### PR DESCRIPTION
## Summary
The 3.2.1 review found that `prov.read()`'s auto-detection forwarded every kwarg only to the `provn` candidate, so an rdf-specific option such as `rdf_format` never reached the PROV-O deserializer during format detection, and an explicit `format=` call passed an unknown option straight through to the deserializer, surfacing a JSON `TypeError` or an rdflib error instead of one naming the format and its accepted options.

Each `Serializer` subclass now declares the keyword arguments its `deserialize()` accepts in a `deserialize_options` class attribute (`profile` for PROV-N; `rdf_format`, `relation_mapper` and `predicate_mapper` for PROV-O; none for JSON, XML or PROV-JSONLD). `_detect_and_parse()` forwards each candidate only the options it declares, so `rdf_format` now reaches the rdf candidate during auto-detection. `read()` checks an explicit `format`'s declared options before attempting deserialization and raises `TypeError` naming the format, the unknown option, and the options it does accept, without emitting the raw-content `UserWarning`. Suite: 2537 passed, 26 skipped, 191 xfailed (2534 plus the 3 new cases from the brief).

## Test plan
- [x] `uv run pytest -q` (2537 passed, 26 skipped, 191 xfailed)
- [x] `uv run mypy src`
- [x] `uv run ruff check src/ benchmarks/`
- [x] `uv run ruff format --check src/ benchmarks/`
- [x] `codacy-analysis analyze` on every changed file (0 new findings; 15 pre-existing findings in `provrdf.py` and `prov/__init__.py` predate this diff)