### PR TITLE
fix(rdf): warn instead of silently minting a prefix for an undeclared predicate namespace

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -80,6 +80,9 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
   `rdf_format`, `relation_mapper` and `predicate_mapper` for PROV-O), so auto-detection can
   read non-TriG RDF with `rdf_format`, and an option a format does not accept raises a
   `TypeError` naming the format and its options instead of a JSON or rdflib error
+- The PROV-O deserializer warns with `ProvWarning` when it mints a prefix for an attribute
+  predicate under a namespace declared neither in the document nor in the graph; 3.2.0
+  minted it silently where 3.1.1 raised
 
 ## 3.2.0 (2026-09-12)
 

--- a/planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md
+++ b/planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md
@@ -145,14 +145,27 @@ Decisions:
 
 Finding: `_resolve_predicate_key` falls back to `_resolve_iri`, which mints `ns1:`
 for a predicate under a namespace declared neither in the document nor in the graph;
-3.1.1 raised `ProvExceptionInvalidQualifiedName`. #341's documented scope is
-graph-declared namespaces.
+3.1.1 raised `ProvExceptionInvalidQualifiedName`.
 
-Decision: `_resolve_iri` is split so the graph-namespace step is callable on its own;
-`_resolve_predicate_key` uses only that step and raises
-`ProvExceptionInvalidQualifiedName` (with the IRI) when no graph namespace matches.
-Value-side IRIs (`decode_rdf_representation`, subjects) keep the full minting
-fallback, which predates 3.2.0 and is pinned by
+This section originally called for restoring the 3.1.1 raise, on the assumption that
+#341's fix only needed the graph-declared-namespace step. That assumption was wrong.
+rdflib's Turtle/TriG writer omits a namespace's `@prefix` line whenever nothing in the
+document can be written under it in compact `prefix:local` form, which is exactly what
+happens to a namespace used only for attribute keys whose local part ends in a PROV-N
+metacharacter (`= ' , : ; [ ]`) -- #341's motivating case. Such a namespace is bound on
+the encoding document but never declared in the decoded graph, so restricting
+`_resolve_predicate_key` to the graph-declared-namespace step alone reopens #341 for
+that shape (caught by the existing `test_metachar_attribute_keys_round_trip_through_provo`
+regression tests, which is what surfaced this during implementation).
+
+Decision (revised): keep `_resolve_predicate_key`'s full three-step fallback --
+document namespaces, then the graph's declared namespaces (via `_resolve_iri_via_graph`,
+extracted from `_resolve_iri` so the step is callable on its own), then `_resolve_iri`'s
+minting fallback. Reaching the minting step for a predicate now emits a `ProvWarning`
+naming the predicate's IRI and the prefix minted for it, restoring visibility of an
+unexpected namespace (3.1.1 raised, 3.2.0 minted silently) without reintroducing the
+raise and undoing #341. Value-side IRIs (`decode_rdf_representation`, subjects) are
+unaffected: they keep minting without a warning, as before 3.2.0, pinned by
 `test_unregistered_namespace_iri_decodes_via_compute_qname`.
 
 ### 2.7 PROV-JSONLD identified Membership; CLI stdin (`provjsonld.py`, `scripts/__init__.py`)

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -17,6 +17,7 @@ from rdflib.term import BNode, Literal as RDFLiteral, Node, URIRef
 
 import prov.model as pm
 from prov import Error
+from prov._warnings import external_stacklevel
 from prov.constants import (
     PROV,
     PROV_ALTERNATE,
@@ -552,13 +553,83 @@ class ProvRDFSerializer(Serializer):
     def _resolve_predicate_key(
         self, pred: URIRef | pm.QualifiedName, graph: Graph
     ) -> pm.QualifiedName:
-        """Resolve a PROV-O predicate to a QualifiedName key, falling back to
-        the graph's own namespace bindings when the document doesn't know
-        it (#341)."""
+        """Resolve a PROV-O predicate to a QualifiedName key.
+
+        Three steps, tried in order: the document's own namespaces, then
+        the graph's declared namespace bindings (``_resolve_iri_via_graph``),
+        then ``_resolve_iri``'s minting fallback for a namespace declared
+        in neither. The minting step stays, rather than raising there as
+        3.1.1 did, because a metacharacter-suffixed local part (``= ' , :
+        ; [ ]``) under a namespace used nowhere else in the document is
+        never written to a compact ``prefix:local`` form, so rdflib's
+        writer never emits an ``@prefix`` for it either; without minting,
+        such a key could never decode (#341).
+
+        Unlike a value-side IRI (see ``_resolve_iri``), reaching the
+        minting step for a predicate emits a `ProvWarning` naming the
+        predicate and the prefix minted for it: 3.2.0 reached this step
+        silently, where 3.1.1 raised; the warning restores visibility of
+        an unexpected namespace without undoing #341's fix.
+
+        Args:
+            pred: The predicate term to resolve.
+            graph: Graph the predicate came from, for its namespace bindings.
+
+        Returns:
+            The resolved :class:`~prov.identifier.QualifiedName`.
+
+        Warns:
+            ProvWarning: When ``pred``'s namespace is declared in neither
+                the document nor the graph, naming the prefix minted for it.
+        """
         pred_str = str(pred)
-        return self.document.valid_qualified_name(  # type: ignore[union-attr]
+        qname = self.document.valid_qualified_name(  # type: ignore[union-attr]
             pred_str
-        ) or self._resolve_iri(pred_str, graph)
+        ) or self._resolve_iri_via_graph(pred_str, graph)
+        if qname is None:
+            qname = self._resolve_iri(pred_str, graph)
+            warnings.warn(
+                f"The predicate {pred_str!r} is under a namespace declared "
+                f"neither in the document nor in the graph; prefix "
+                f"{qname.namespace.prefix!r} was minted for it.",
+                pm.ProvWarning,
+                stacklevel=external_stacklevel(),
+            )
+        return qname
+
+    def _resolve_iri_via_graph(self, iri: str, graph: Graph) -> pm.QualifiedName | None:
+        """Resolve ``iri`` against ``graph``'s own namespace bindings only.
+
+        Finds the longest namespace URI bound in ``graph`` that is a proper
+        prefix of ``iri`` and splits there, reusing that prefix. This
+        handles metacharacter local parts under a namespace the source
+        declared, which ``compute_qname`` refuses to split. Document
+        namespaces are not consulted here: callers only reach this method
+        after ``valid_identifier``/``valid_qualified_name`` returned
+        ``None``, which already scanned every document namespace for a
+        URI-prefix match, so any that applied would have resolved there.
+
+        Args:
+            iri: The IRI to resolve.
+            graph: Graph the IRI came from, for its namespace bindings.
+
+        Returns:
+            The resolved :class:`~prov.identifier.QualifiedName`, whose
+            namespace is now registered on ``self.document``, or ``None``
+            if no namespace bound in ``graph`` is a proper prefix of
+            ``iri``.
+        """
+        best_prefix, best_uri = None, ""
+        for prefix, uri_ref in graph.namespace_manager.namespaces():
+            uri = str(uri_ref)
+            if uri and len(uri) > len(best_uri) and iri.startswith(uri) and iri != uri:
+                best_prefix, best_uri = prefix, uri
+        if best_prefix is None:
+            return None
+        ns = self.document.add_namespace(  # type: ignore[union-attr]
+            best_prefix, best_uri
+        )
+        return pm.QualifiedName(ns, iri[len(ns.uri) :])
 
     def _resolve_iri(self, iri: str, graph: Graph) -> pm.QualifiedName:
         """Resolve an IRI to a QualifiedName, registering its namespace.
@@ -571,14 +642,9 @@ class ProvRDFSerializer(Serializer):
 
         Resolution, in order:
 
-        1. The longest namespace URI bound in ``graph`` that prefixes ``iri``
-           -- split there, reusing that prefix. This handles metacharacter
-           local parts under a namespace the source declared, which
-           ``compute_qname`` refuses to split. (Document namespaces are not
-           consulted here: both callers only reach this method after
-           ``valid_identifier`` returned ``None``, which already scanned every
-           document namespace for a URI-prefix match, so any that applied would
-           have resolved there.)
+        1. ``_resolve_iri_via_graph``: the longest namespace URI bound in
+           ``graph`` that prefixes ``iri`` -- split there, reusing that
+           prefix.
         2. Otherwise ``compute_qname``, preserving prefix-minting for ordinary
            IRIs under no registered namespace.
         3. If ``compute_qname`` itself raises (a trailing metacharacter under
@@ -602,14 +668,9 @@ class ProvRDFSerializer(Serializer):
         assert self.document is not None
         # 1. Longest namespace URI bound in the graph that is a proper prefix
         # of the IRI (see the docstring on why document namespaces are skipped).
-        best_prefix, best_uri = None, ""
-        for prefix, uri_ref in graph.namespace_manager.namespaces():
-            uri = str(uri_ref)
-            if uri and len(uri) > len(best_uri) and iri.startswith(uri) and iri != uri:
-                best_prefix, best_uri = prefix, uri
-        if best_prefix is not None:
-            ns = self.document.add_namespace(best_prefix, best_uri)
-            return pm.QualifiedName(ns, iri[len(ns.uri) :])
+        qname = self._resolve_iri_via_graph(iri, graph)
+        if qname is not None:
+            return qname
         # 2. compute_qname for ordinary IRIs (mints a fresh prefix).
         try:
             prefix, uri_ref, _local = graph.namespace_manager.compute_qname(iri)

--- a/src/prov/tests/test_rdf.py
+++ b/src/prov/tests/test_rdf.py
@@ -1077,6 +1077,53 @@ def test_unregistered_namespace_iri_decodes_via_compute_qname():
     assert "http://other.example/thing" in ids
 
 
+def test_predicate_under_undeclared_namespace_warns_and_mints():
+    # A predicate under a namespace declared in neither the document nor
+    # the graph still decodes (minting a fresh prefix, as it must for a
+    # metacharacter-suffixed key under a namespace rdflib's writer never
+    # declares compactly -- #341), but now warns about it: 3.1.1 raised
+    # here, 3.2.0 minted silently, and this is neither.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    ex:e1 a prov:Entity ; <http://other.org/p> "v" .
+    """
+    with pytest.warns(pm.ProvWarning, match="other.org/p") as record:
+        doc = ProvDocument.deserialize(
+            content=turtle, format="rdf", rdf_format="turtle"
+        )
+
+    prov_warnings = [w for w in record if issubclass(w.category, pm.ProvWarning)]
+    assert len(prov_warnings) == 1
+    (entity,) = doc.get_records()
+    ((_, value),) = [
+        (k, v) for k, v in entity.attributes if k.uri == "http://other.org/p"
+    ]
+    assert value == "v"
+
+
+def test_predicate_under_graph_declared_namespace_decodes():
+    # The same predicate resolves once its namespace is declared in the
+    # graph, even though the document itself never registered it, and
+    # without a warning: only the minting step (above) warns.
+    turtle = """
+    @prefix prov: <http://www.w3.org/ns/prov#> .
+    @prefix ex: <http://example.org/> .
+    @prefix o: <http://other.org/> .
+    ex:e1 a prov:Entity ; o:p "v" .
+    """
+    with warnings.catch_warnings():
+        # Scoped to ProvWarning, not a blanket "error": rdflib's own Dataset
+        # parsing emits unrelated DeprecationWarnings on this code path.
+        warnings.simplefilter("error", pm.ProvWarning)
+        doc = ProvDocument.deserialize(
+            content=turtle, format="rdf", rdf_format="turtle"
+        )
+    (entity,) = doc.get_records()
+    (value,) = entity.get_attribute(doc.valid_qualified_name("o:p"))
+    assert value == "v"
+
+
 def test_unsplittable_iri_raises_clear_error():
     # An IRI with no '#' or '/' separator genuinely cannot be split into a
     # namespace and local part; the decoder must raise a clear error naming


### PR DESCRIPTION
## Summary

3.2.0 changed PROV-O predicate resolution to fall through to compute_qname/split minting for a predicate under a namespace declared in neither the document nor the graph, where 3.1.1 raised ProvExceptionInvalidQualifiedName; the mint now happens silently, with no way to notice an unexpected namespace on decode.

_resolve_predicate_key keeps its full three-step fallback (document namespaces, then the graph's declared namespaces via the newly extracted _resolve_iri_via_graph, then _resolve_iri's minting), since restricting it to the first two steps alone would reopen #341 for an attribute key whose local part ends in a PROV-N metacharacter under a namespace used nowhere else in the document: rdflib's writer never declares such a namespace's prefix because nothing in the document can be written under it compactly, so the graph carries no declaration to fall back to. Reaching the minting step for a predicate now emits a ProvWarning naming the IRI and the prefix minted for it; value-side IRIs are unaffected. The design spec (planning/specs/2026-09-12-release-3.2.1-review-fixes-design.md §2.6) is amended to record this ruling in place of the original raise-based plan.

## Test plan

- [x] Full suite across all six supported interpreters: 2539 passed, 26 skipped, 191 xfailed (Task 5 count + 2)
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src/ benchmarks/` and `uv run ruff format --check src/ benchmarks/` clean
- [x] `codacy-analysis analyze` on changed files: 0 new findings vs `origin/main` baseline
- [x] `uv run coverage report`: 98%, above the 97% floor