### PR TITLE
fix(jsonld,cli,serializers): unidentified fan-out for identified memberships; text stdin; UTC for sub-minute offsets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -83,6 +83,12 @@ and the PROV-N spelling of booleans. No API, dependency or Python-floor changes.
 - The PROV-O deserializer warns with `ProvWarning` when it mints a prefix for an attribute
   predicate under a namespace declared neither in the document nor in the graph; 3.2.0
   minted it silently where 3.1.1 raised
+- A PROV-JSONLD `Membership` with an `@id` and several members decodes to unidentified
+  `hadMember` records with a `ProvWarning`, since records sharing one identifier cannot be
+  unified; with one member the `@id` is kept
+- `prov-convert` and `prov-compare` accept a text-only standard stream for `-`
+- Every serializer writes a datetime whose UTC offset is not a whole number of minutes in
+  UTC, since `xsd:dateTime` allows no seconds in an offset
 
 ## 3.2.0 (2026-09-12)
 

--- a/src/prov/dot.py
+++ b/src/prov/dot.py
@@ -63,6 +63,7 @@ from prov.model import (
     ProvWarning,
     sorted_attributes,
 )
+from prov.model.records import _xsd_datetime_text
 
 __author__ = "Trung Dong Huynh"
 __email__ = "trungdong@donggiang.com"
@@ -294,7 +295,7 @@ def _attach_attribute_annotation(
             escape(
                 str(value)
                 if not isinstance(value, datetime)
-                else str(value.isoformat())
+                else _xsd_datetime_text(value)
             ),
         )
         for attr, value in attributes

--- a/src/prov/scripts/__init__.py
+++ b/src/prov/scripts/__init__.py
@@ -10,14 +10,17 @@ def _open_binary(
 
     ``standard_name`` is ``"stdin"`` or ``"stdout"``; its ``.buffer`` is
     resolved only when ``path`` is ``"-"``, so the other standard stream is
-    never touched. The second element says whether the caller owns the
-    returned stream and must close it; the standard streams belong to the
-    process. An unopenable path is reported through
-    :meth:`argparse.ArgumentParser.error`, which exits with status 2 like
-    argparse's own file handling did.
+    never touched. A standard stream with no ``.buffer`` (a text-only stream,
+    e.g. an ``io.StringIO`` substituted under a test harness) is returned as
+    it is, since every deserializer accepts a text stream. The second
+    element says whether the caller owns the returned stream and must close
+    it; the standard streams belong to the process. An unopenable path is
+    reported through :meth:`argparse.ArgumentParser.error`, which exits with
+    status 2 like argparse's own file handling did.
     """
     if path == "-":
-        return cast(BinaryIO, getattr(sys, standard_name).buffer), False
+        standard = getattr(sys, standard_name)
+        return cast(BinaryIO, getattr(standard, "buffer", standard)), False
     try:
         return cast(BinaryIO, open(path, mode)), True
     except OSError as exc:

--- a/src/prov/serializers/provjson.py
+++ b/src/prov/serializers/provjson.py
@@ -21,6 +21,7 @@ from prov.model import (
     first,
     parse_xsd_datetime,
 )
+from prov.model.records import _xsd_datetime_text
 from prov.serializers import Serializer, _is_text_stream
 
 logger = logging.getLogger(__name__)
@@ -235,7 +236,9 @@ def encode_json_container(bundle: ProvBundle) -> ProvJSONDict:
                     # TODO: QName export
                     record_json[attr_name] = str(first(values))
                 elif attr in PROV_ATTRIBUTE_LITERALS:
-                    record_json[attr_name] = first(values).isoformat()  # type: ignore[union-attr]
+                    record_json[attr_name] = _xsd_datetime_text(
+                        first(values)  # type: ignore[arg-type]
+                    )
                 else:
                     if len(values) == 1:
                         # single value
@@ -579,7 +582,7 @@ def encode_json_representation(value: Any) -> Any:
     if isinstance(value, Literal):
         return literal_json_representation(value)
     elif isinstance(value, datetime.datetime):
-        return {"$": value.isoformat(), "type": "xsd:dateTime"}
+        return {"$": _xsd_datetime_text(value), "type": "xsd:dateTime"}
     elif isinstance(value, QualifiedName):
         # TODO Manage prefix in the whole structure consistently
         # #168: the PROV-JSON submission (§3.1.2) types QualifiedName values

--- a/src/prov/serializers/provjsonld.py
+++ b/src/prov/serializers/provjsonld.py
@@ -8,11 +8,13 @@ compacted shape only, one JSON object per PROV-DM statement in ``@graph``.
 import datetime
 import io
 import json
+import warnings
 from functools import lru_cache
 from importlib.resources import files
 from typing import Any
 
 from prov import Error
+from prov._warnings import ProvWarning, external_stacklevel
 from prov.constants import (
     PROV_ATTR_ENTITY,
     PROV_ATTRIBUTE_LITERALS,
@@ -44,6 +46,7 @@ from prov.model import (
     first,
     parse_xsd_datetime,
 )
+from prov.model.records import _xsd_datetime_text
 from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Trung Dong Huynh"
@@ -185,7 +188,7 @@ def encode_jsonld_value(value: Any, term: str) -> Any:
             return {"@value": value.value, "@language": value.langtag}
         return {"@value": value.value, "@type": str(value.datatype)}
     if isinstance(value, datetime.datetime):
-        return {"@value": value.isoformat(), "@type": "xsd:dateTime"}
+        return {"@value": _xsd_datetime_text(value), "@type": "xsd:dateTime"}
     if isinstance(value, Identifier):
         return {"@value": value.uri, "@type": "xsd:anyURI"}
     if isinstance(value, bool):
@@ -261,7 +264,7 @@ def encode_jsonld_statement(record: ProvRecord) -> dict[str, Any]:
         if values:
             value = first(values)
             obj[attr.localpart] = (
-                value.isoformat()  # type: ignore[union-attr]
+                _xsd_datetime_text(value)  # type: ignore[arg-type]
                 if attr in PROV_ATTRIBUTE_LITERALS
                 else str(value)
             )
@@ -619,6 +622,13 @@ def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
             :func:`encode_jsonld_statement`.
         bundle: Bundle to add the decoded record to.
 
+    An identified Membership's array of members yields one record per
+    member; PROV-DM's ``hadMember`` is binary, so records sharing one
+    identifier cannot be unified. The ``"@id"`` is kept only when the array
+    has exactly one member; with more than one, every decoded record is
+    unidentified and a :class:`~prov.model.ProvWarning` names the dropped
+    ``"@id"`` and the member count.
+
     Raises:
         ProvJSONLDException: If ``item``'s ``"@type"`` is missing, is not a
             recognised PROV-JSONLD statement type (including ``"Mention"``,
@@ -648,11 +658,20 @@ def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
         raise ProvJSONLDException(
             f'The "entity" array of {type_term} is empty; found {item!r}'
         )
+    member_id = rec_id
+    if rec_id is not None and len(members) > 1:
+        warnings.warn(
+            f"Membership {rec_id!r} lists {len(members)} members; PROV-DM membership "
+            "is binary, so the members are decoded as unidentified hadMember records",
+            ProvWarning,
+            stacklevel=external_stacklevel(),
+        )
+        member_id = None
     for member in members:
         entity = _decode_formal_qname(bundle, member, type_term, "entity")
         bundle.new_record(
             rec_type,
-            rec_id,
+            member_id,
             {**attributes, PROV_ATTR_ENTITY: entity},
             list(other_attributes),
         )

--- a/src/prov/serializers/provjsonld.py
+++ b/src/prov/serializers/provjsonld.py
@@ -622,7 +622,7 @@ def decode_jsonld_statement(item: dict[str, Any], bundle: ProvBundle) -> None:
             :func:`encode_jsonld_statement`.
         bundle: Bundle to add the decoded record to.
 
-    An identified Membership's array of members yields one record per
+    Note: an identified Membership's array of members yields one record per
     member; PROV-DM's ``hadMember`` is binary, so records sharing one
     identifier cannot be unified. The ``"@id"`` is kept only when the array
     has exactly one member; with more than one, every decoded record is

--- a/src/prov/serializers/provrdf.py
+++ b/src/prov/serializers/provrdf.py
@@ -51,6 +51,7 @@ from prov.constants import (
     XSD_QNAME,
 )
 from prov.identifier import QualifiedName
+from prov.model.records import _xsd_datetime_text
 from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Satrajit S. Ghosh"
@@ -527,7 +528,7 @@ class ProvRDFSerializer(Serializer):
         elif isinstance(value, pm.Literal):
             return literal_rdf_representation(value)
         elif isinstance(value, datetime.datetime):
-            return RDFLiteral(value.isoformat(), datatype=XSD["dateTime"])
+            return RDFLiteral(_xsd_datetime_text(value), datatype=XSD["dateTime"])
         elif isinstance(value, pm.QualifiedName):
             return URIRef(value.uri)
         elif isinstance(value, pm.Identifier):

--- a/src/prov/serializers/provxml.py
+++ b/src/prov/serializers/provxml.py
@@ -20,6 +20,7 @@ from prov.model import (
     canonical_xsd_datatype,
     sorted_attributes,
 )
+from prov.model.records import _xsd_datetime_text
 from prov.serializers import Serializer, _is_text_stream
 
 __author__ = "Lion Krischer"
@@ -456,7 +457,7 @@ def _encode_attribute_value(
             subelem.attrib[_ns_xsi("type")] = "xsd:QName"
         return str(value)
     elif isinstance(value, datetime.datetime):
-        return value.isoformat()
+        return _xsd_datetime_text(value)
     else:
         return str(value)
 

--- a/src/prov/tests/test_attributes.py
+++ b/src/prov/tests/test_attributes.py
@@ -18,10 +18,13 @@ hit a distinct RDF multi-datatype fidelity loss (``xsd:double`` precision),
 now round-trips through RDF too.
 """
 
+import datetime
+
 import pytest
 
 from prov.model import ProvDocument
 from prov.tests.attribute_values import ATTRIBUTE_VALUES, EX_NS
+from prov.tests.conftest import ROUNDTRIP_FORMATS, roundtrip_document
 
 
 @pytest.mark.parametrize(
@@ -52,3 +55,29 @@ def test_entity_with_multiple_value_attribute(roundtrip):
     attributes = [("prov:value", value) for value in ATTRIBUTE_VALUES]
     document.entity(EX_NS["emv"], attributes)
     roundtrip(document)
+
+
+@pytest.mark.parametrize("fmt", ROUNDTRIP_FORMATS)
+def test_sub_minute_utc_offset_round_trips_as_utc(fmt):
+    # xsd:dateTime allows no seconds in a timezone offset (#341 scope
+    # extension): a historical LMT-style +00:00:30 offset must serialize as
+    # its UTC equivalent, not as an xsd:dateTime-illegal string. A round trip
+    # through this library's own tolerant parser reconstructs the same
+    # instant either way (aware datetimes compare by instant, not by offset),
+    # so the serialized text itself is checked too, for the illegal offset
+    # an external, strict xsd:dateTime consumer would reject.
+    odd_offset = datetime.timezone(datetime.timedelta(seconds=30))
+    document = ProvDocument()
+    document.activity(
+        EX_NS["a"],
+        startTime=datetime.datetime(2026, 9, 12, 10, 0, 30, tzinfo=odd_offset),
+    )
+    expected = ProvDocument()
+    expected.activity(
+        EX_NS["a"],
+        startTime=datetime.datetime(
+            2026, 9, 12, 10, 0, 0, tzinfo=datetime.timezone.utc
+        ),
+    )
+    assert "+00:00:30" not in document.serialize(format=fmt)
+    assert roundtrip_document(document, fmt) == expected

--- a/src/prov/tests/test_dot.py
+++ b/src/prov/tests/test_dot.py
@@ -228,6 +228,24 @@ def test_quoted_label_escapes_double_quote():
     assert len(dot.create(format="svg")) > 0
 
 
+def test_sub_minute_utc_offset_attribute_is_rendered_as_utc():
+    # xsd:dateTime allows no seconds in a timezone offset (#341 scope
+    # extension): the attribute-annotation label must show the UTC
+    # equivalent of a sub-minute offset, not the illegal offset text.
+    odd_offset = datetime.timezone(datetime.timedelta(seconds=30))
+    doc = ProvDocument()
+    doc.add_namespace("ex", "http://example.org/")
+    doc.activity(
+        "ex:a", startTime=datetime.datetime(2026, 9, 12, 10, 0, 30, tzinfo=odd_offset)
+    )
+
+    dot = prov_to_dot(doc)
+    dot_text = dot.to_string()
+
+    assert "2026-09-12T10:00:00+00:00" in dot_text
+    assert "+00:00:30" not in dot_text
+
+
 def test_unset_endpoint_is_drawn_to_a_blank_node_with_a_warning():
     from prov.model import ProvWarning
 

--- a/src/prov/tests/test_jsonld.py
+++ b/src/prov/tests/test_jsonld.py
@@ -8,7 +8,7 @@ import pytest
 
 import prov
 from prov.constants import PROV
-from prov.model import Literal, ProvDocument, ProvMembership
+from prov.model import Literal, ProvDocument, ProvMembership, ProvWarning
 from prov.serializers.provjsonld import (
     JSONLD_CONTEXT_URL,
     ProvJSONLDException,
@@ -357,8 +357,8 @@ def test_deserialize_membership_empty_entity_array_raises():
         ProvDocument.deserialize(content=_membership_payload([]), format="jsonld")
 
 
-def test_deserialize_membership_array_shares_id_and_attributes():
-    payload = json.dumps(
+def _identified_membership_payload(entities) -> str:
+    return json.dumps(
         {
             "@context": [{"ex": EX_URI}, JSONLD_CONTEXT_URL],
             "@graph": [
@@ -367,17 +367,30 @@ def test_deserialize_membership_array_shares_id_and_attributes():
                     "@type": "Membership",
                     "@id": "ex:m",
                     "collection": "ex:c",
-                    "entity": ["ex:e1", "ex:e2"],
+                    "entity": entities,
                     "label": [{"@value": "members"}],
                 },
             ],
         }
     )
-    doc = ProvDocument.deserialize(content=payload, format="jsonld")
+
+
+def test_deserialize_identified_membership_array_drops_the_id_with_a_warning():
+    payload = _identified_membership_payload(["ex:e1", "ex:e2"])
+    with pytest.warns(ProvWarning, match="ex:m"):
+        doc = ProvDocument.deserialize(content=payload, format="jsonld")
     memberships = sorted(doc.get_records(ProvMembership), key=lambda r: str(r.args[1]))
-    assert [str(r.identifier) for r in memberships] == ["ex:m", "ex:m"]
+    assert [r.identifier for r in memberships] == [None, None]
     assert [str(r.args[1]) for r in memberships] == ["ex:e1", "ex:e2"]
     assert all(list(r.get_attribute(PROV["label"])) == ["members"] for r in memberships)
+    doc.unified()
+
+
+def test_deserialize_identified_membership_with_one_member_keeps_the_id():
+    payload = _identified_membership_payload(["ex:e1"])
+    doc = ProvDocument.deserialize(content=payload, format="jsonld")
+    (membership,) = doc.get_records(ProvMembership)
+    assert str(membership.identifier) == "ex:m"
 
 
 def _expected_primer_document() -> ProvDocument:

--- a/src/prov/tests/test_scripts.py
+++ b/src/prov/tests/test_scripts.py
@@ -435,6 +435,15 @@ def test_compare_reads_one_file_from_stdin_for_dash(compare_files, monkeypatch):
     assert not stdin.buffer.closed
 
 
+def test_compare_reads_a_text_only_stdin_for_dash(compare_files, monkeypatch):
+    json_file, xml_file = compare_files
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json_file.read_text()))
+    monkeypatch.setattr(
+        sys, "argv", ["prov-compare", "-f", "json", "-F", "xml", "-", str(xml_file)]
+    )
+    assert compare_main() == 0
+
+
 def test_compare_two_dashes_exits_2(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["prov-compare", "-", "-"])
     monkeypatch.setattr(sys, "stderr", io.StringIO())


### PR DESCRIPTION
## Summary
A PROV-JSONLD Membership with an @id and several members fanned out to records sharing that @id, which unified() then rejects; the decoder now keeps the @id only when the array has exactly one member, and drops it with a ProvWarning naming the identifier and member count otherwise. prov-compare and prov-convert now accept a text-only standard stream for "-" (an io.StringIO substituted under a test harness), not only a binary one. Every serializer (PROV-JSON, PROV-XML, PROV-O, PROV-JSONLD, and the DOT export) now routes a datetime through the shared _xsd_datetime_text helper Task 4 added to the PROV-N writer, normalising a sub-minute UTC offset to UTC instead of writing an xsd:dateTime-illegal string; naive and whole-minute datetimes stay byte-identical.

## Test plan
- [x] Full suite: 2546 passed, 26 skipped, 191 xfailed (Task 6's 2539 plus 2 from the JSONLD/CLI acceptance criteria plus 5 from the new datetime round-trip test parametrized over ROUNDTRIP_FORMATS)
- [x] `uv run mypy src`
- [x] `uv run ruff check src/ benchmarks/`
- [x] `uv run ruff format --check src/ benchmarks/`
- [x] `codacy-analysis analyze` on every changed file: 15 pre-existing findings on unrelated lines, 0 new
- [x] `uv run pytest src/prov/tests/test_public_api.py -q`
- [x] Verified the new datetime test fails on 4/5 formats without the fix (provn already fixed by Task 4) and passes on all 5 after it